### PR TITLE
Fixed minimal version of npgsql cause of version missmatch

### DIFF
--- a/src/Moryx.Model.PostgreSQL/Moryx.Model.PostgreSQL.csproj
+++ b/src/Moryx.Model.PostgreSQL/Moryx.Model.PostgreSQL.csproj
@@ -19,7 +19,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)'=='net45'">
-    <PackageReference Include="Npgsql" Version="4.0.11" />
+    <PackageReference Include="Npgsql" Version="4.0.10" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)'=='net461'">


### PR DESCRIPTION
This fixes #88 in moryx-core 3.x - there is a missmatch in npgsql and the database provider which cannot be fixed in application. Therefore I reduced the patch version of npgsql. This works.