### PR TITLE
Adjust default SQLite connection string to prevent db files being cre…

### DIFF
--- a/src/Moryx.Model.Sqlite/SqliteDatabaseConfig.cs
+++ b/src/Moryx.Model.Sqlite/SqliteDatabaseConfig.cs
@@ -47,7 +47,7 @@ namespace Moryx.Model.Sqlite
         }
 
         /// <inheritdoc />
-        [DataMember, Required, DefaultValue("Data Source=.\\db\\<DatabaseName>.db")]
+        [DataMember, Required, DefaultValue("Data Source=.\\db\\<DatabaseName>.db;Mode=ReadWrite;")]
         public override string ConnectionString { get; set; }
 
         /// <inheritdoc />

--- a/src/Moryx.Model.Sqlite/SqliteModelConfigurator.cs
+++ b/src/Moryx.Model.Sqlite/SqliteModelConfigurator.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Data.Common;
 using System.IO;
-using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
@@ -62,6 +61,7 @@ namespace Moryx.Model.Sqlite
         {
             var builder = new DbContextOptionsBuilder();
             builder.UseSqlite(BuildConnectionString(config));
+            
 
             return builder.Options;
         }
@@ -94,6 +94,20 @@ namespace Moryx.Model.Sqlite
         {
             var builder = new SqliteConnectionStringBuilder(config.ConnectionSettings.ConnectionString);
             return builder.DataSource;
+        }
+
+        /// <inheritdoc />
+        public override Task<bool> CreateDatabase(IDatabaseConfig config)
+        {
+            // Overwrite the connection mode to ensure that the database
+            // file can be created
+            var connectionStringBuilder = new SqliteConnectionStringBuilder(config.ConnectionSettings.ConnectionString)
+            {
+                Mode = SqliteOpenMode.ReadWriteCreate
+            };
+            config.ConnectionSettings.ConnectionString = connectionStringBuilder.ConnectionString;
+
+            return base.CreateDatabase(config);
         }
     }
 }


### PR DESCRIPTION
…ated by default

`Mode=ReadWrite` is added to the default SQLite ConnectionString to prevent the database being created on a read or write operation, when it doesn't exist.

Databases should be created using the API, to ensure, that they are created properly. To make sure this happens correctly, the ConnectionString has to be adjusted for that action.

