### PR TITLE
Added reusable workflow and dependant packages with coverage feature

### DIFF
--- a/.build/BuildToolkit.ps1
+++ b/.build/BuildToolkit.ps1
@@ -186,9 +186,7 @@ function Install-Tool([string]$PackageName, [string]$Version, [string]$TargetExe
 }
 
 function Invoke-Build([string]$ProjectFile, [string]$Options = "") {
-    Write-Step "Building $ProjectFile";
-
-    $env:NODE_OPTIONS = "--openssl-legacy-provider";
+    Write-Step "Building $ProjectFile"
 
     # TODO: maybe we find a better way: currently all packages of all solutions are restored.
     ForEach ($solution in (Get-ChildItem $RootPath -Filter "*.sln")) {

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -12,154 +12,94 @@ on:
     branches: 
       - dev
       - future
-
+      
 env:
   MORYX_OPTIMIZE_CODE: "false"
   MORYX_BUILD_CONFIG: "Release"
   MORYX_BUILDNUMBER: ${{github.run_number}}
   dotnet_sdk_version: '7.x'
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+  REPOSITORY_NAME: ${{ github.event.repository.name }}
 
 jobs:
   Build:
-    runs-on: windows-2019
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Setup .NET SDK
-        uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: ${{ env.dotnet_sdk_version }}
-
-      - name: Build
-        shell: pwsh
-        run: ./Build.ps1 -Build -Pack
-
-      - name: Upload package artifacts
-        uses: actions/upload-artifact@v2
-        with:
-          name: packages
-          path: artifacts/Packages/
-          retention-days: 1
+    uses: PHOENIXCONTACT/tools/.github/workflows/build-tool.yml@main
+    with:
+      MORYX_OPTIMIZE_CODE: "false"
+      MORYX_BUILD_CONFIG: "Release"
+      MORYX_BUILDNUMBER: ${{github.run_number}}
+      dotnet_sdk_version: '7.x'
+      DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+      REPOSITORY_NAME: ${{ github.event.repository.name }}
 
   UnitTests:
     needs: [Build]
-    runs-on: windows-2019
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Setup .NET SDK
-        uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: ${{ env.dotnet_sdk_version }}
-
-      - name: Execute Unit Tests
-        shell: pwsh
-        run: ./Build.ps1 -UnitTests
-
-      - name: Upload test results
-        uses: actions/upload-artifact@v2
-        with:
-          name: test-results
-          path: artifacts/Tests/
-          retention-days: 1
+    uses: PHOENIXCONTACT/tools/.github/workflows/unittest-tool.yml@main
+    with:
+      MORYX_OPTIMIZE_CODE: "false"
+      MORYX_BUILD_CONFIG: "Release"
+      MORYX_BUILDNUMBER: ${{github.run_number}}
+      dotnet_sdk_version: '7.x'
+      DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+      REPOSITORY_NAME: ${{ github.event.repository.name }}
 
   IntegrationTests:
     needs: [Build]
-    if: ${{ github.ref == 'refs/heads/dev' }} # dev branche is published to myget moryx
-    runs-on: windows-2019
-    steps:
-      - uses: actions/checkout@v2
+    uses: PHOENIXCONTACT/tools/.github/workflows/integrationtest-tool.yml@main
+    with:
+      MORYX_OPTIMIZE_CODE: "false"
+      MORYX_BUILD_CONFIG: "Release"
+      MORYX_BUILDNUMBER: ${{github.run_number}}
+      dotnet_sdk_version: '7.x'
+      DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+      REPOSITORY_NAME: ${{ github.event.repository.name }}
 
-      - name: Setup .NET SDK
-        uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: ${{ env.dotnet_sdk_version }}
-
-      - name: Execute Integration Tests
-        shell: pwsh
-        run: ./Build.ps1 -IntegrationTests
-
-      - name: Upload test results
-        uses: actions/upload-artifact@v2
-        with:
-          name: test-results
-          path: artifacts/Tests/
-          retention-days: 1
-
-  Codecov:
+  ReportGenerator:
     needs: [UnitTests, IntegrationTests]
-    runs-on: windows-2019
-    steps:
-      - name: Download test results
-        uses: actions/download-artifact@v2
-        with:
-          name: test-results
-          path: artifacts/Tests/
-
-      - name: Codecov
-        uses: codecov/codecov-action@v1
-        with:
-          files: '*.OpenCover.xml'
+    uses: PHOENIXCONTACT/tools/.github/workflows/reportgenerator-tool.yml@main
+    with:
+      MORYX_OPTIMIZE_CODE: "false"
+      MORYX_BUILD_CONFIG: "Release"
+      MORYX_BUILDNUMBER: ${{github.run_number}}
+      dotnet_sdk_version: '7.x'
+      DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+      REPOSITORY_NAME: ${{ github.event.repository.name }}
+               
+  Publish-Test-Coverage:
+    needs: [ReportGenerator]
+    uses: PHOENIXCONTACT/tools/.github/workflows/publish-test-coverage-tool.yml@main
+    with:
+      MORYX_OPTIMIZE_CODE: "false"
+      MORYX_BUILD_CONFIG: "Release"
+      MORYX_BUILDNUMBER: ${{github.run_number}}
+      dotnet_sdk_version: '7.x'
+      DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+      REPOSITORY_NAME: ${{ github.event.repository.name }}
+    secrets:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
   Documentation:
-    needs: [Build]
-    runs-on: windows-2019
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Generate docFx
-        shell: pwsh
-        run: ./Build.ps1 -GenerateDocs
-
-      - name: Upload documentation results
-        uses: actions/upload-artifact@v2
-        with:
-          name: documentation
-          path: artifacts/Documentation/
-          retention-days: 1
+    needs: [UnitTests]
+    uses: PHOENIXCONTACT/tools/.github/workflows/documentation-tool.yml@main
+    with:
+      MORYX_OPTIMIZE_CODE: "false"
+      MORYX_BUILD_CONFIG: "Release"
+      MORYX_BUILDNUMBER: ${{github.run_number}}
+      dotnet_sdk_version: '7.x'
+      DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+      REPOSITORY_NAME: ${{ github.event.repository.name }}
 
   Publish:
-    needs: [Build, UnitTests]
-    if: ${{ github.event_name == 'push' }}
-    runs-on: windows-2019
-    steps:
-      - uses: actions/checkout@v2
-      
-      - name: Setup .NET SDK
-        uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: ${{ env.dotnet_sdk_version }}
-  
-      - name: Download package artifacts
-        uses: actions/download-artifact@v2
-        with:
-          name: packages
-          path: artifacts/Packages/
-
-      - name: Publish on MyGet-CI
-        if: ${{ github.ref == 'refs/heads/dev' }} # dev branche is published to myget moryx
-        shell: pwsh
-        env:
-          MORYX_NUGET_APIKEY: ${{secrets.MYGET_TOKEN}}
-          MORYX_PACKAGE_TARGET: "https://www.myget.org/F/moryx/api/v2/package"
-          MORYX_PACKAGE_TARGET_V3: "https://www.myget.org/F/moryx/api/v3/index.json"
-        run: ./Build.ps1 -Publish
-
-      - name: Publish on MyGet-Future
-        if: ${{ github.ref == 'refs/heads/future' }} # Future branch is published to myget moryx-future
-        shell: pwsh
-        env:
-          MORYX_NUGET_APIKEY: ${{secrets.MYGET_TOKEN}}
-          MORYX_PACKAGE_TARGET: "https://www.myget.org/F/moryx-future/api/v2/package"
-          MORYX_PACKAGE_TARGET_V3: "https://www.myget.org/F/moryx-future/api/v3/index.json"
-        run: ./Build.ps1 -Publish
-
-      - name: Publish on NuGet
-        if: ${{ startsWith(github.ref, 'refs/tags/v') }} # Version Tags are published to nuget
-        shell: pwsh
-        env:
-          MORYX_NUGET_APIKEY: ${{secrets.NUGET_TOKEN}}
-          MORYX_PACKAGE_TARGET: "https://api.nuget.org/v3/index.json"
-          MORYX_PACKAGE_TARGET_V3: "https://api.nuget.org/v3/index.json"
-        run: ./Build.ps1 -Publish
+    needs: [UnitTests]
+    uses: PHOENIXCONTACT/tools/.github/workflows/publish-tool.yml@main
+    with:
+      MORYX_OPTIMIZE_CODE: "false"
+      MORYX_BUILD_CONFIG: "Release"
+      MORYX_BUILDNUMBER: ${{github.run_number}}
+      dotnet_sdk_version: '7.x'
+      DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+      REPOSITORY_NAME: ${{ github.event.repository.name }}
+    secrets: 
+      MYGET_TOKEN: ${{secrets.MYGET_TOKEN}}
+      NUGET_TOKEN: ${{secrets.NUGET_TOKEN}}

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -21,6 +21,10 @@
 		<PackageReference Update="Moq" Version="4.17.2" />
 		<PackageReference Update="NUnit" Version="3.13.3" />
 		<PackageReference Update="NUnit3TestAdapter" Version="4.2.1" />
+		<PackageReference Update="coverlet.collector" Version="3.2.0" >
+      		<PrivateAssets>all</PrivateAssets>
+      		<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+  		</PackageReference>
 
 		<PackageReference Update="Newtonsoft.Json" Version="12.0.3" />
 		<PackageReference Update="CommandLineParser" Version="2.8.0" />

--- a/src/Tests/Moryx.AbstractionLayer.Tests/Moryx.AbstractionLayer.Tests.csproj
+++ b/src/Tests/Moryx.AbstractionLayer.Tests/Moryx.AbstractionLayer.Tests.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+	<PackageReference Include="coverlet.collector" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="NUnit" />
     <PackageReference Include="NUnit3TestAdapter" />

--- a/src/Tests/Moryx.Container.Tests/Moryx.Container.Tests.csproj
+++ b/src/Tests/Moryx.Container.Tests/Moryx.Container.Tests.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+	<PackageReference Include="coverlet.collector" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="NUnit" />
     <PackageReference Include="NUnit3TestAdapter" />

--- a/src/Tests/Moryx.Model.Tests/Moryx.Model.Tests.csproj
+++ b/src/Tests/Moryx.Model.Tests/Moryx.Model.Tests.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+	<PackageReference Include="coverlet.collector" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Moq" />
     <PackageReference Include="NUnit" />

--- a/src/Tests/Moryx.Notifications.Tests/Moryx.Notifications.Tests.csproj
+++ b/src/Tests/Moryx.Notifications.Tests/Moryx.Notifications.Tests.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+	<PackageReference Include="coverlet.collector" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="NUnit" />
     <PackageReference Include="NUnit3TestAdapter" />

--- a/src/Tests/Moryx.Products.Management.Tests/Moryx.AbstractionLayer.Products.Endpoints.Tests.csproj
+++ b/src/Tests/Moryx.Products.Management.Tests/Moryx.AbstractionLayer.Products.Endpoints.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <TargetFramework>net6.0</TargetFramework>
@@ -7,6 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+		<PackageReference Include="coverlet.collector" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" />
         <PackageReference Include="NUnit" />
         <PackageReference Include="NUnit3TestAdapter" />

--- a/src/Tests/Moryx.Resources.Management.Tests/Moryx.Resources.Management.Tests.csproj
+++ b/src/Tests/Moryx.Resources.Management.Tests/Moryx.Resources.Management.Tests.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+	<PackageReference Include="coverlet.collector" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="NUnit" />
     <PackageReference Include="NUnit3TestAdapter" />

--- a/src/Tests/Moryx.Runtime.Endpoints.Tests/Moryx.Runtime.Endpoints.Tests.csproj
+++ b/src/Tests/Moryx.Runtime.Endpoints.Tests/Moryx.Runtime.Endpoints.Tests.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+	<PackageReference Include="coverlet.collector" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Moq" />
     <PackageReference Include="NUnit" />

--- a/src/Tests/Moryx.Runtime.Kernel.Tests/Moryx.Runtime.Kernel.Tests.csproj
+++ b/src/Tests/Moryx.Runtime.Kernel.Tests/Moryx.Runtime.Kernel.Tests.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+	<PackageReference Include="coverlet.collector" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Moq" />
     <PackageReference Include="NUnit" />

--- a/src/Tests/Moryx.Runtime.Tests/Moryx.Runtime.Tests.csproj
+++ b/src/Tests/Moryx.Runtime.Tests/Moryx.Runtime.Tests.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+	<PackageReference Include="coverlet.collector" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Moq" />
     <PackageReference Include="NUnit" />

--- a/src/Tests/Moryx.Tests/Moryx.Tests.csproj
+++ b/src/Tests/Moryx.Tests/Moryx.Tests.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+	<PackageReference Include="coverlet.collector" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="NUnit" />
     <PackageReference Include="NUnit3TestAdapter" />


### PR DESCRIPTION
Added new workflow using reusable workflows stored in https://github.com/PHOENIXCONTACT/tools and the coverlet.collector-NugetPackage in the Test-Projects, which are needed for the dotnet test command to collect all coverage information. 
Workflow includes:

- new Unit-Testing
- generating a Code Coverage Report via ReportGenerator
- Syncing the html-files generated by the ReportGenerator with an AWS S3-Bucket, where it gets hosted via CloudFront

Attention: for it to work properly, you need to add the AWS Secrets: AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY

(Already including bug fix for openSSL bug occuring today)