### PR TITLE
Added obsolete for old signin way

### DIFF
--- a/src/Moryx/Modules/ModuleMenuCategory.cs
+++ b/src/Moryx/Modules/ModuleMenuCategory.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) 2023, Phoenix Contact GmbH & Co. KG
 // Licensed under the Apache License, Version 2.0
 
+using System;
+
 namespace Moryx.Asp.Integration
 {
     /// <summary>
@@ -31,6 +33,7 @@ namespace Moryx.Asp.Integration
         /// <summary>
         /// Module represents a sign-in screen
         /// </summary>
+        [Obsolete]
         SignIn = 40,
     }
 }


### PR DESCRIPTION
We will not be relying on the sign in module anymore. In the future branch, we will be redirecting to the url of the authentication providers instead