### PR TITLE
ControlCabinetType is not creatable using the DemoImporter

### DIFF
--- a/src/Moryx.Products.Management/Implementation/Storage/ProductStorage.cs
+++ b/src/Moryx.Products.Management/Implementation/Storage/ProductStorage.cs
@@ -662,6 +662,9 @@ namespace Moryx.Products.Management
 
                     // Save those currently active
                     var currentEntities = FindLinks(linkStrategy.PropertyName, typeEntity).ToArray();
+
+                    if (links is null) return typeEntity;
+
                     foreach (var link in links)
                     {
                         PartLinkEntity linkEntity;


### PR DESCRIPTION
New ProductType that has List<ProductPartLink> can't be created using the DefaultImporter in the Demo.
