### PR TITLE
Fix usage of strategies in resources

### DIFF
--- a/src/Moryx.AbstractionLayer.Resources.Endpoints/Moryx.AbstractionLayer.Resources.Endpoints.csproj
+++ b/src/Moryx.AbstractionLayer.Resources.Endpoints/Moryx.AbstractionLayer.Resources.Endpoints.csproj
@@ -15,6 +15,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Moryx.AbstractionLayer\Moryx.AbstractionLayer.csproj" />
 	<ProjectReference Include="..\Moryx.Asp.Extensions\Moryx.Asp.Extensions.csproj" />
+	<ProjectReference Include="..\Moryx.Runtime\Moryx.Runtime.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Moryx.AbstractionLayer.Resources.Endpoints/ResourceManagementController.cs
+++ b/src/Moryx.AbstractionLayer.Resources.Endpoints/ResourceManagementController.cs
@@ -14,6 +14,8 @@ using Moryx.Asp.Extensions;
 using Moryx.Serialization;
 using Moryx.Tools;
 using Moryx.AbstractionLayer.Properties;
+using Moryx.Runtime.Modules;
+using Moryx.Runtime.Container;
 
 namespace Moryx.AbstractionLayer.Resources.Endpoints
 {
@@ -29,11 +31,13 @@ namespace Moryx.AbstractionLayer.Resources.Endpoints
         private readonly IResourceTypeTree _resourceTypeTree;
         private readonly ResourceSerialization _serialization;
 
-        public ResourceModificationController(IResourceManagement resourceManagement, IResourceTypeTree resourceTypeTree)
+        public ResourceModificationController(IResourceManagement resourceManagement, IResourceTypeTree resourceTypeTree, IModuleManager moduleManager)
         {
             _resourceManagement = resourceManagement ?? throw new ArgumentNullException(nameof(resourceManagement));
             _resourceTypeTree = resourceTypeTree ?? throw new ArgumentNullException(nameof(resourceTypeTree));
-            _serialization = new ResourceSerialization();
+            var module = moduleManager.AllModules.FirstOrDefault(module => module is IFacadeContainer<IResourceManagement>);
+            var containerHost = (IContainerHost)module;
+            _serialization = new ResourceSerialization(containerHost.Container);
         }
 
         [HttpGet]

--- a/src/Moryx.AbstractionLayer.Resources.Endpoints/ResourceSerialization.cs
+++ b/src/Moryx.AbstractionLayer.Resources.Endpoints/ResourceSerialization.cs
@@ -13,7 +13,7 @@ namespace Moryx.AbstractionLayer.Resources.Endpoints
 {
     internal class ResourceSerialization : PossibleValuesSerialization
     {
-        public ResourceSerialization() : base(new ContainerMock(), new ValueProviderExecutor(new ValueProviderExecutorSettings()))
+        public ResourceSerialization(IContainer container) : base(container, new ValueProviderExecutor(new ValueProviderExecutorSettings()))
         {
         }
 
@@ -30,103 +30,6 @@ namespace Moryx.AbstractionLayer.Resources.Endpoints
         public override IEnumerable<MethodInfo> GetMethods(Type sourceType)
         {
             return new EntrySerializeSerialization().GetMethods(sourceType);
-        }
-
-        private class ContainerMock : IContainer
-        {
-            public void Destroy()
-            {
-                throw new NotImplementedException();
-            }
-
-            public IContainer ExecuteInstaller(IContainerInstaller installer)
-            {
-                throw new NotImplementedException();
-            }
-
-            public void Extend<TExtension>() where TExtension : new()
-            {
-                throw new NotImplementedException();
-            }
-
-            public IEnumerable<Type> GetRegisteredImplementations(Type componentInterface)
-            {
-                throw new NotImplementedException();
-            }
-
-            public void LoadComponents<T>() where T : class
-            {
-                throw new NotImplementedException();
-            }
-
-            public void LoadComponents<T>(Predicate<Type> condition) where T : class
-            {
-                throw new NotImplementedException();
-            }
-
-            public IContainer Register<TService, TComp>()
-                where TService : class
-                where TComp : TService
-            {
-                throw new NotImplementedException();
-            }
-
-            public IContainer Register<TService, TComp>(string name, LifeCycle lifeCycle)
-                where TService : class
-                where TComp : TService
-            {
-                throw new NotImplementedException();
-            }
-
-            public IContainer Register<TFactory>() where TFactory : class
-            {
-                throw new NotImplementedException();
-            }
-
-            public IContainer Register<TFactory>(string name) where TFactory : class
-            {
-                throw new NotImplementedException();
-            }
-
-            public T Resolve<T>()
-            {
-                throw new NotSupportedException();
-            }
-
-            public object Resolve(Type service)
-            {
-                throw new NotSupportedException();
-            }
-
-            public T Resolve<T>(string name)
-            {
-                throw new NotSupportedException();
-            }
-
-            public object Resolve(Type service, string name)
-            {
-                throw new NotSupportedException();
-            }
-
-            public T[] ResolveAll<T>()
-            {
-                throw new NotSupportedException();
-            }
-
-            public Array ResolveAll(Type service)
-            {
-                throw new NotSupportedException();
-            }
-
-            public IContainer SetInstance<T>(T instance) where T : class
-            {
-                throw new NotImplementedException();
-            }
-
-            public IContainer SetInstance<T>(T instance, string name) where T : class
-            {
-                throw new NotImplementedException();
-            }
         }
     }
 }

--- a/src/Moryx.Resources.Samples/StrategyUsingResource.cs
+++ b/src/Moryx.Resources.Samples/StrategyUsingResource.cs
@@ -1,0 +1,42 @@
+﻿using Moryx.AbstractionLayer.Drivers.Rfid;
+using Moryx.AbstractionLayer.Drivers;
+using Moryx.AbstractionLayer.Resources;
+using Moryx.Container;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Moryx.Serialization;
+using System.Runtime.Serialization;
+using System.Text.RegularExpressions;
+
+namespace Moryx.Resources.Demo
+{
+
+    [DependencyRegistration(typeof(IWhiteSpaceRemovingStrategy)), ResourceRegistration]
+    public class StrategyUsingResource: Resource
+    {
+        [PluginNameSelector(typeof(IWhiteSpaceRemovingStrategy))]
+        [DataMember, EntrySerialize]
+        public string Strategy { get; set; }
+    }
+
+    public interface IWhiteSpaceRemovingStrategy
+    {
+        string DropSpaces(string s);
+    }
+
+    [Plugin(LifeCycle.Singleton, typeof(IWhiteSpaceRemovingStrategy), Name = "Regex Remover")]
+    public class RegexWhiteSpaceRemovingStrategy : IWhiteSpaceRemovingStrategy
+    {
+        public string DropSpaces(string s) => Regex.Replace(s, @"\s+", "");
+    }
+
+    [Plugin(LifeCycle.Singleton, typeof(IWhiteSpaceRemovingStrategy), Name = "Linq Remover")]
+    public class LinqWhiteSpaceRemovingStrategy : IWhiteSpaceRemovingStrategy
+    {
+        public string DropSpaces(string s) => string.Concat(s.Where(c => !char.IsWhiteSpace(c)));
+    }
+}


### PR DESCRIPTION
Usage of strategies within resources lead to `NotImplementedException` when serialized. This is fixed by making the module container visible to `ResourceSerialization`.

Add `StrategyUsingResource` as a sample for this scenario.

