### PR TITLE
Catch exception on missing license

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -11,5 +11,6 @@
   <packageSources>
     <clear />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+	<add key="3rdParty" value="https://packages-ctvc.europe.phoenixcontact.com/nuget/3rdParty/" />
   </packageSources>
 </configuration>

--- a/src/Moryx.Asp.Extensions/Exception/MoryxLicenseException.cs
+++ b/src/Moryx.Asp.Extensions/Exception/MoryxLicenseException.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using WupiEngine;
+
+namespace Moryx.Asp.Extensions
+{
+    /// <summary>
+    /// License missing exception class
+    /// </summary>
+    public class MoryxLicenseException : WupiException
+    {
+        public MoryxLicenseException(WupiException wxcpt) : base(wxcpt)
+        {
+        }
+
+    }
+}

--- a/src/Moryx.Asp.Extensions/License/MoryxLicenseExceptionPageBuilder.cs
+++ b/src/Moryx.Asp.Extensions/License/MoryxLicenseExceptionPageBuilder.cs
@@ -1,0 +1,228 @@
+﻿// Copyright (c) 2023, Phoenix Contact GmbH & Co. KG
+// Licensed under the Apache License, Version 2.0
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.ExceptionServices;
+using System.Text;
+using System.Threading.Tasks;
+using WupiEngine;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Hosting;
+using Moryx.Runtime.Modules;
+using Moryx.Asp.Extensions;
+
+namespace Moryx.Asp.Extensions
+{
+    /// <summary>
+    /// License exception page builder class
+    /// </summary>
+    public static  class MoryxLicenseExceptionPageBuilder
+    {
+        internal static readonly string LicensePageName = "index.html";
+        internal static readonly string LicensePageRootFolder = "LicenseExceptionFolder";
+        internal static bool MissingLicenseDetected { get; private set; }
+
+        /// <summary>
+        /// Listens to exception that happens in the app and collects License exception
+        /// </summary>
+        internal static void RegisterLicenseExceptionBuilder()
+        {
+            //catching all exception not handled in the app
+            AppDomain.CurrentDomain.FirstChanceException += HandleMissingLicenseException;
+        }
+
+
+        /// <summary>
+        /// (Extension method)
+        /// Boot system and start all modules
+        /// </summary>
+        /// <param name="serviceProvider"></param>
+        /// <returns></returns>
+        public static IModuleManager StartAllMoryxModules(this IServiceProvider serviceProvider)
+        {
+            //register the license exception handling
+            RegisterLicenseExceptionBuilder();
+
+            var moduleManager = serviceProvider.GetRequiredService<IModuleManager>();
+            moduleManager.StartModules();
+
+            //start moryx license page builder
+            if (MissingLicenseDetected)
+                StartLicensePageBuilder();
+
+            return moduleManager;
+        }
+
+        /// <summary>
+        /// Builds the license page to display to the user
+        /// Note: This generate a raw html file.
+        /// </summary>
+        /// <param name="pageTitle"></param>
+        /// <param name="description"></param>
+        /// <returns></returns>
+        private static LicensePageContent BuildLicensePage(string pageTitle, string description)
+        {
+            var exceptions = LicenseExceptions.GroupBy(x => x.Source).Select(d => new
+            {
+                Title = d.FirstOrDefault().Source,
+                d.FirstOrDefault().Message,
+            }).ToList();
+
+            StringBuilder contentBuilder = new StringBuilder();
+            contentBuilder.AppendLine("<!DOCTYPE html>");
+            contentBuilder.AppendLine("<html>");
+            contentBuilder.AppendLine("<body>");
+            contentBuilder.AppendLine(@"
+             <style>
+                #table {
+                  font-family: Arial, Helvetica, sans-serif;
+                  border-collapse: collapse;
+                  width: 100%;
+                 }
+
+                #table td, #table th {
+                  border: 1px solid #ddd;
+                  padding: 8px;
+                }
+
+                #table tr:nth-child(even){background-color: #f2f2f2;}
+
+                #table tr:hover {background-color: #ddd;}
+
+                #table th {
+                  padding-top: 12px;
+                  padding-bottom: 12px;
+                  text-align: left;
+                  background-color: red;
+                  color: white;
+                }
+            </style>");
+            contentBuilder.AppendLine($"<h1> MORYX License </h1>");
+            contentBuilder.AppendLine($"<h2>{pageTitle}</h2>");
+            contentBuilder.AppendLine($"<p>{description}</p>");
+            //content table
+
+            contentBuilder.AppendLine("<table id=\"table\">");
+            //header
+            contentBuilder.AppendLine("<tr>");
+            contentBuilder.AppendLine(" <th> Title</th>");
+            contentBuilder.AppendLine(" <th> Message</th>");
+            contentBuilder.AppendLine("</tr>");
+            //content
+
+            foreach (var exception in exceptions)
+            {
+                contentBuilder.AppendLine("<tr>");
+                contentBuilder.AppendLine($"    <td>{exception.Title}</td>");
+                contentBuilder.AppendLine($"    <td>License missing!</td>");
+                contentBuilder.AppendLine("</tr>");
+            }
+            contentBuilder.AppendLine("</table>");
+            //end of centent
+            contentBuilder.AppendLine("</body>");
+            contentBuilder.AppendLine("</html>");
+
+            return new LicensePageContent(contentBuilder.ToString(), LicenseExceptions.Count == 0);
+        }
+
+        /// <summary>
+        /// build the license exception page in the environment
+        /// </summary>
+        /// <param name="env"> Current environment</param>
+        internal static void BuildLicensePage(IWebHostEnvironment env)
+        {
+            if (LicenseExceptions.Count == 0) return;
+
+            var content = BuildLicensePage("Missing license dectected!", "Your app was not able to load because of missing licenses.");
+            if (content.IsEmpty) return;
+
+            GenerateFile(env, content);
+
+            //license exception already handled , empty the list to catch new incoming license exceptions
+            LicenseExceptions.Clear();
+            MissingLicenseDetected = false;
+        }
+
+        internal static void StartLicensePageBuilder()
+        {
+            //configure the host
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureWebHostDefaults(webBuilder =>
+                {
+                    webBuilder.UseStartup<CustomStartup>();
+                    webBuilder.UseIISIntegration();
+                })
+                .Build();
+            //start the host for the license page
+            host.Run();
+        }
+
+        //creates the html file on the webroot 
+        private static void GenerateFile(IWebHostEnvironment env, LicensePageContent content)
+        {
+            var path = Path.Combine(env.WebRootPath, LicensePageRootFolder);
+            var fileFullPath = Path.Combine(path, LicensePageName);
+            if (!Directory.Exists(path)) Directory.CreateDirectory(path);
+            File.WriteAllText(fileFullPath, content.Content.ToString());
+        }
+
+        private static List<MoryxLicenseException> LicenseExceptions { get; set; } = new List<MoryxLicenseException>();
+
+        private static void HandleMissingLicenseException(object sender, FirstChanceExceptionEventArgs e)
+        {
+            //skip all exceptions that are not WupiException
+            if (e.Exception is not WupiException licenseException) return;
+
+            //register all license exception to display to the user
+            LicenseExceptions.Add(new MoryxLicenseException(licenseException));
+            MissingLicenseDetected = true;
+        }
+
+    }
+
+    /// <summary>
+    /// License page content class use to generate the Html page content
+    /// </summary>
+    internal class LicensePageContent
+    {
+        public LicensePageContent(string content, bool isEmpty)
+        {
+            this.Content = content;
+            this.IsEmpty = isEmpty;
+        }
+        public string Content { get; }
+        public bool IsEmpty { get; }
+    }
+
+    /// <summary>
+    /// Custom startup class to configure the license exception page host
+    /// </summary>
+    internal class CustomStartup
+    {
+
+        public void ConfigureServices(IServiceCollection services)
+        {
+        }
+
+        public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
+        {
+            //generate the page
+            MoryxLicenseExceptionPageBuilder.BuildLicensePage(env);
+
+            //configure the web root folder (wwwroot/LicensePageRootFolder/)
+            env.WebRootFileProvider = new PhysicalFileProvider(
+                Path.Combine(env.WebRootPath, MoryxLicenseExceptionPageBuilder.LicensePageRootFolder));
+            env.WebRootPath = Path.Combine(env.WebRootPath, MoryxLicenseExceptionPageBuilder.LicensePageRootFolder);
+            app.UseDefaultFiles();
+            app.UseStaticFiles();
+        }
+    }
+
+}
+

--- a/src/Moryx.Asp.Extensions/Moryx.Asp.Extensions.csproj
+++ b/src/Moryx.Asp.Extensions/Moryx.Asp.Extensions.csproj
@@ -9,6 +9,16 @@
 
 	<ItemGroup>
 		<FrameworkReference Include="Microsoft.AspNetCore.App" />
+		<PackageReference Include="Wibu.Build" Version="7.21.0" />
 	</ItemGroup>
 
+	<ItemGroup>
+		<Compile Remove="$(NugetPackageRoot)\**\*.WibuCmRaU" />
+		<None Remove="$(NugetPackageRoot)\**\*.WibuCmRaU" />
+	</ItemGroup>
+
+	<ItemGroup>
+	  <ProjectReference Include="..\Moryx.Runtime\Moryx.Runtime.csproj" />
+	</ItemGroup>
+	
 </Project>

--- a/src/Moryx.Runtime.Kernel/KernelServiceCollectionExtensions.cs
+++ b/src/Moryx.Runtime.Kernel/KernelServiceCollectionExtensions.cs
@@ -87,6 +87,7 @@ namespace Moryx.Runtime.Kernel
             return configManager;
         }
 
+        [Obsolete("please use Moryx.Asp.Extensions.StartAllMoryxModules instead.")]
         /// <summary>
         /// Boot system and start all modules
         /// </summary>


### PR DESCRIPTION
Problem:

- When starting the application, the `endpoint.Mapcontrollers()` call raises a TargetInvocationException when there is a module without a license:

`System.Reflection.TargetInvocationException: 'Exception has been thrown by the target of an invocation.'
WupiException: Der CmContainer-Eintrag wurde nicht gefunden, Fehler 200.`
This should be catched or at least give a hint to the module in question.


Solution:
- Added a subscription to the AppDomain unhandled Exception event to collect all the license missing exception before the web host is built.
in case there is an exception we build and execute the license exception-page host instead of the default host configured by the user.
- Added a new Extension method 'StartAllMoryxModules' for the IServiceProvider.
