### PR TITLE
Changing Plugins with different Configs throws exceptions

### DIFF
--- a/src/Moryx.CommandCenter.Web/src/modules/models/Entry.ts
+++ b/src/Moryx.CommandCenter.Web/src/modules/models/Entry.ts
@@ -66,7 +66,6 @@ export default class Entry {
 
         Config.patchParent(entryPrototype, parent);
 
-        entryPrototype.Identifier = "CREATED";
         Entry.generateUniqueIdentifiers(entryPrototype);
         return entryPrototype;
     }


### PR DESCRIPTION
Problem : 

- Right now Changing one of those Plugins throws an exception.

Solution : 

- Removed setting entryProtoType Identifer default value to CREATED in entryFromPrototype method.
