### PR TITLE
Added entryPrototype.identifier = "CREATED";

### DIFF
--- a/src/Moryx.CommandCenter.Web/src/modules/models/Entry.ts
+++ b/src/Moryx.CommandCenter.Web/src/modules/models/Entry.ts
@@ -66,6 +66,7 @@ export default class Entry {
 
         Config.patchParent(entryPrototype, parent);
 
+        entryPrototype.identifier = "CREATED";
         Entry.generateUniqueIdentifiers(entryPrototype);
         return entryPrototype;
     }


### PR DESCRIPTION
Initializing resources caused an exception. previously removed thing was reintroduced and typo got fixed.

**Problem** :
The current resolution in #260 caused an exception when calling the resource initialize method in the resource manager console. Stacktrace attached in the following comment.

**Solution** :
Added the old line `entryPrototype.Identifier = "CREATED";`  and updated to  `entryPrototype.identifier = "CREATED"`;