### PR TITLE
Fix saving configs with and without lists

### DIFF
--- a/src/Moryx.CommandCenter.Web/src/modules/components/ConfigEditor/CollectionEditor.tsx
+++ b/src/Moryx.CommandCenter.Web/src/modules/components/ConfigEditor/CollectionEditor.tsx
@@ -50,6 +50,7 @@ export default class CollectionEditor extends CollapsibleEntryEditorBase<Collect
     public addEntry(): void {
         const prototype = this.props.Entry.prototypes.find((proto: Entry) => proto.displayName === this.state.SelectedEntry);
         const entryPrototype = Entry.entryFromPrototype(prototype, this.props.Entry);
+        entryPrototype.identifier = "CREATED";
 
         let counter: number = 0;
         let entryName: string = entryPrototype.displayName;

--- a/src/Moryx.CommandCenter.Web/src/modules/models/Entry.ts
+++ b/src/Moryx.CommandCenter.Web/src/modules/models/Entry.ts
@@ -66,7 +66,6 @@ export default class Entry {
 
         Config.patchParent(entryPrototype, parent);
 
-        entryPrototype.identifier = "CREATED";
         Entry.generateUniqueIdentifiers(entryPrototype);
         return entryPrototype;
     }


### PR DESCRIPTION
Only for list items you have to set the identifier to "CREATED". If it's not a list item, the identifier needs to be the name of the class in order to find the PropertyInfo in the backend