### PR TITLE
Harmonize ResourceSerialization

### DIFF
--- a/src/Moryx.AbstractionLayer.Resources.Endpoints/ResourceSerialization.cs
+++ b/src/Moryx.AbstractionLayer.Resources.Endpoints/ResourceSerialization.cs
@@ -13,23 +13,29 @@ namespace Moryx.AbstractionLayer.Resources.Endpoints
 {
     internal class ResourceSerialization : PossibleValuesSerialization
     {
+        /// <summary>
+        /// Instance for <see cref="EntrySerializeSerialization"/> we use to filter properties and methods
+        /// </summary>
+        private EntrySerializeSerialization _memberFilter = new();
+
         public ResourceSerialization(IContainer container) : base(container, new ValueProviderExecutor(new ValueProviderExecutorSettings()))
         {
         }
 
         /// <summary>
-        /// Only export properties flagged with <see cref="EntrySerializeAttribute"/>
+        /// Follow the rules for <see cref="EntrySerializeSerialization"/>
         /// </summary>
         public override IEnumerable<PropertyInfo> GetProperties(Type sourceType)
         {
-            return typeof(Resource).IsAssignableFrom(sourceType)
-                ? base.GetProperties(sourceType).Where(p => p.GetCustomAttribute<EntrySerializeAttribute>()?.Mode == EntrySerializeMode.Always)
-                : new EntrySerializeSerialization().GetProperties(sourceType);
+            return _memberFilter.GetProperties(sourceType);
         }
 
+        /// <summary>
+        /// Follow the rules for <see cref="EntrySerializeSerialization"/>
+        /// </summary>
         public override IEnumerable<MethodInfo> GetMethods(Type sourceType)
         {
-            return new EntrySerializeSerialization().GetMethods(sourceType);
+            return _memberFilter.GetMethods(sourceType);
         }
     }
 }

--- a/src/Moryx.AbstractionLayer/Resources/Resource.cs
+++ b/src/Moryx.AbstractionLayer/Resources/Resource.cs
@@ -13,7 +13,7 @@ namespace Moryx.AbstractionLayer.Resources
     /// <summary>
     /// Base class for all resources to reduce boilerplate code
     /// </summary>
-    [DataContract]
+    [DataContract, EntrySerialize(EntrySerializeMode.Never)]
     public abstract class Resource : ILoggingComponent, IResource, IInitializablePlugin, IDisposable, IPersistentObject
     {
         #region Dependencies


### PR DESCRIPTION
Filter members used a mixture of two different strategies and for resources applied its own implementation of "DecoratedOnly".

I harmonized it to only use EntrySerialize behavior.