### PR TITLE
Fix saving resources with internal properties, which are EntrySerialize, using the UI

### DIFF
--- a/src/Moryx.AbstractionLayer.Resources.Endpoints/ResourceSerialization.cs
+++ b/src/Moryx.AbstractionLayer.Resources.Endpoints/ResourceSerialization.cs
@@ -37,5 +37,11 @@ namespace Moryx.AbstractionLayer.Resources.Endpoints
         {
             return _memberFilter.GetMethods(sourceType);
         }
+
+        public override IEnumerable<MappedProperty> WriteFilter(Type sourceType, IEnumerable<Entry> encoded)
+        {
+            return _memberFilter.WriteFilter(sourceType, encoded);
+            
+        }
     }
 }

--- a/src/Moryx/Serialization/EntrySerializeSerialization.cs
+++ b/src/Moryx/Serialization/EntrySerializeSerialization.cs
@@ -74,7 +74,15 @@ namespace Moryx.Serialization
         public override IEnumerable<MappedProperty> WriteFilter(Type sourceType, IEnumerable<Entry> encoded)
         {
             // Ignore properties which are not mapped
-            return base.WriteFilter(sourceType, encoded).Where(mapped => mapped.Entry != null);
+            var properties = GetProperties(sourceType);
+            var result = from entry in encoded
+                         let property = properties.FirstOrDefault(x => x.Name.Equals(entry.Identifier))
+                         select new MappedProperty
+                         {
+                             Entry = entry,
+                             Property = property
+                         };
+            return result.Where(mapped => mapped.Entry != null);
         }
 
         /// <summary>


### PR DESCRIPTION
The basic WriteFilter method in the DefaultSerialization doesn't get internal properties. Since they are shown on the UI when using the ResourceSerialization, there will be an exception, if you try to save such a resource

