### PR TITLE
Remove AddDefaultValueSerializer when loading resources from the DB

### DIFF
--- a/src/Moryx.AbstractionLayer.Resources.Endpoints/Moryx.AbstractionLayer.Resources.Endpoints.csproj
+++ b/src/Moryx.AbstractionLayer.Resources.Endpoints/Moryx.AbstractionLayer.Resources.Endpoints.csproj
@@ -15,6 +15,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Moryx.AbstractionLayer\Moryx.AbstractionLayer.csproj" />
 	<ProjectReference Include="..\Moryx.Asp.Extensions\Moryx.Asp.Extensions.csproj" />
+	<ProjectReference Include="..\Moryx.Resources.Management\Moryx.Resources.Management.csproj" />
 	<ProjectReference Include="..\Moryx.Runtime\Moryx.Runtime.csproj" />
   </ItemGroup>
 

--- a/src/Moryx.AbstractionLayer.Resources.Endpoints/ResourceManagementController.cs
+++ b/src/Moryx.AbstractionLayer.Resources.Endpoints/ResourceManagementController.cs
@@ -16,6 +16,8 @@ using Moryx.Tools;
 using Moryx.AbstractionLayer.Properties;
 using Moryx.Runtime.Modules;
 using Moryx.Runtime.Container;
+using Moryx.Configuration;
+using Moryx.Resources.Management;
 
 namespace Moryx.AbstractionLayer.Resources.Endpoints
 {
@@ -149,6 +151,10 @@ namespace Moryx.AbstractionLayer.Resources.Endpoints
             var resource = (Resource)Activator.CreateInstance(_resourceTypeTree[type].ResourceType);
             if (resource is null)
                 return NotFound(new MoryxExceptionResponse { Title = Strings.RESOURCE_NOT_FOUND });
+
+            ValueProviderExecutor.Execute(resource, new ValueProviderExecutorSettings()
+                .AddFilter(new DataMemberAttributeValueProviderFilter(false))
+                .AddDefaultValueProvider());
 
             if (method != null)
                 EntryConvert.InvokeMethod(resource, method, _serialization);

--- a/src/Moryx.Resources.Management/Resources/ResourceEntityAccessor.cs
+++ b/src/Moryx.Resources.Management/Resources/ResourceEntityAccessor.cs
@@ -76,11 +76,6 @@ namespace Moryx.Resources.Management
             if (ExtensionData != null)
                 JsonConvert.PopulateObject(ExtensionData, Instance, JsonSettings.Minimal);
 
-            // Read everything else from defaults
-            ValueProviderExecutor.Execute(Instance, new ValueProviderExecutorSettings()
-                .AddFilter(new DataMemberAttributeValueProviderFilter(false))
-                .AddDefaultValueProvider());
-
             return Instance;
         }
 


### PR DESCRIPTION
The DefaultValueAttributeProvider.Handle function replaces system default values with the costum default values set using the DefaultValueAttribute. The consequence was that setting the system default value wasn't possible anymore, since it gets overwritten when loading the resource  from the database. NewtonsoftJson is able to set the costum default value directly when populating an object since Version 12.0.1.

