### PR TITLE
Set method parameter as required when the parameter has no default value.

### DIFF
--- a/src/Moryx/Serialization/EntryConvert/EntryConvert.cs
+++ b/src/Moryx/Serialization/EntryConvert/EntryConvert.cs
@@ -468,6 +468,9 @@ namespace Moryx.Serialization
                 Validation = serialization.CreateValidation(parameterType, parameter)
             };
 
+            // mark the parameter as required when there is no default value
+            parameterModel.Validation.IsRequired = defaultValue is null ? true : false;
+
             switch (parameterModel.Value.Type)
             {
                 case EntryValueType.Class:

--- a/src/Tests/Moryx.Tests/Serialization/EntryConvertSerializationTests.cs
+++ b/src/Tests/Moryx.Tests/Serialization/EntryConvertSerializationTests.cs
@@ -1,0 +1,65 @@
+﻿using Moryx.Serialization;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Moryx.Tests.Serialization
+{
+    [TestFixture]
+    public class EntryConvertSerializationTests
+    {
+       
+        [Test]
+        public void ParameterWithNoDefaultValueShouldHaveValidation_IsRequired()
+        {
+            // arrange 
+            var myClass = typeof(EntrySerialize_Methods);
+            var myMethodWithParameters = myClass.GetMethods().FirstOrDefault(x => x.GetParameters().Length > 0);
+            string parameter1Name = "intValue";
+            string parameter2Name = "stringValue1";
+            string parameter3Name = "stringValue2";
+
+            //act 
+            var entry = EntryConvert.EncodeMethod(myMethodWithParameters);
+            var parameter1Validation = entry.Parameters.SubEntries.FirstOrDefault(x => x.DisplayName == parameter1Name).Validation;
+            var parameter2Validation = entry.Parameters.SubEntries.FirstOrDefault(x => x.DisplayName == parameter2Name).Validation;
+            var parameter3Validation = entry.Parameters.SubEntries.FirstOrDefault(x => x.DisplayName == parameter3Name).Validation;
+
+            //assert
+
+            Assert.That(parameter1Validation.IsRequired, Is.True);
+            Assert.That(parameter2Validation.IsRequired, Is.True);
+            Assert.That(parameter3Validation.IsRequired, Is.False); // parameter with default value is not required
+        }
+
+        [Test]
+        public void ShouldEncodeClass_Properties()
+        {
+            //act
+            var entry = EntryConvert.EncodeClass(typeof(DummyClass));
+
+            //assert
+            Assert.That(entry.SubEntries.FirstOrDefault(x => x.DisplayName == nameof(DummyClass.Number)) != null, Is.True);
+        }
+
+        [Test]
+        public void ShouldEncodeObject_PropertyWithValue()
+        {
+            //arrange
+            var myObject = new DummyClass();
+            myObject.Number = 10;
+
+            //act
+            var entry = EntryConvert.EncodeObject(myObject);
+
+            //assert
+            Assert.That(entry.SubEntries
+                .FirstOrDefault(x => x.DisplayName == nameof(DummyClass.Number)).Value.Current, 
+                Is.EqualTo(myObject.Number.ToString()));
+        }
+    }
+}

--- a/src/Tests/Moryx.Tests/Serialization/EntrySerializeDummies.cs
+++ b/src/Tests/Moryx.Tests/Serialization/EntrySerializeDummies.cs
@@ -107,7 +107,10 @@ namespace Moryx.Tests
     {
         [EntrySerialize]
         public void InvocablePublic() { }
-        
+
+        [EntrySerialize]
+        public void InvocablePublic(int intValue,string stringValue1,string stringValue2 = "testing value") { }
+
         [EntrySerialize]
         internal void InvocableInternal() { }
 


### PR DESCRIPTION
Parameter that doesn't have a default value, will be set as **IsRequired**.

The current ConvertParameter doesn't set the Parameter as required unless there is a **Required** attribute on the parameter.