### PR TITLE
Fix time conversion

### DIFF
--- a/src/Moryx.Model/Annotations/DateTimeKindAnnotation.cs
+++ b/src/Moryx.Model/Annotations/DateTimeKindAnnotation.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Linq;
 using System.Reflection;
+using System.Threading;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
@@ -26,7 +27,7 @@ namespace Moryx.Model.Annotations
         private static readonly ValueConverter<DateTime, DateTime> UtcConverter =
             new ValueConverter<DateTime, DateTime>(v => ConvertToUtc(v), v => DateTime.SpecifyKind(v, DateTimeKind.Utc));
         private static readonly ValueConverter<DateTime, DateTime> LocalConverter =
-            new ValueConverter<DateTime, DateTime>(v => ConvertToUtc(v), v => DateTime.SpecifyKind(v, DateTimeKind.Local));
+            new ValueConverter<DateTime, DateTime>(v => ConvertToUtc(v), v => ConvertToLocal(v));
         private static readonly ValueConverter<DateTime, DateTime> UnspecifiedConverter =
            new ValueConverter<DateTime, DateTime>(v => ConvertToUtc(v), v => DateTime.SpecifyKind(v, DateTimeKind.Unspecified));
 
@@ -38,6 +39,12 @@ namespace Moryx.Model.Annotations
                 return TimeZoneInfo.ConvertTimeToUtc(dateTime, TimeZoneInfo.Local);
         }
        
+        private static DateTime ConvertToLocal(DateTime timeUtc)
+        {
+            var result = TimeZoneInfo.ConvertTimeFromUtc(timeUtc, TimeZoneInfo.Local);
+            result = DateTime.SpecifyKind(result, DateTimeKind.Local);
+            return result;
+        }
 
         /// <summary>
         /// Adds the date time kind converter to the model builder.
@@ -51,7 +58,6 @@ namespace Moryx.Model.Annotations
             foreach (var property in dateTimeProperties)
             {
                 var kind = FindDateTimeKind(property) ?? defaultKind;
-                property.SetValueConverter(UtcConverter);
                 switch (kind)
                 {
                     case DateTimeKind.Utc:

--- a/src/Moryx.Model/Annotations/DateTimeKindAnnotation.cs
+++ b/src/Moryx.Model/Annotations/DateTimeKindAnnotation.cs
@@ -9,6 +9,7 @@ using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Moryx.Model.Attributes;
+using Newtonsoft.Json.Linq;
 
 namespace Moryx.Model.Annotations
 {
@@ -23,13 +24,20 @@ namespace Moryx.Model.Annotations
         private const string AnnotationName = "DateTimeKind";
 
         private static readonly ValueConverter<DateTime, DateTime> UtcConverter =
-            new ValueConverter<DateTime, DateTime>(v => v, v => DateTime.SpecifyKind(v, DateTimeKind.Utc));
-
+            new ValueConverter<DateTime, DateTime>(v => ConvertToUtc(v), v => DateTime.SpecifyKind(v, DateTimeKind.Utc));
         private static readonly ValueConverter<DateTime, DateTime> LocalConverter =
-            new ValueConverter<DateTime, DateTime>(v => v, v => DateTime.SpecifyKind(v, DateTimeKind.Local));
-
+            new ValueConverter<DateTime, DateTime>(v => ConvertToUtc(v), v => DateTime.SpecifyKind(v, DateTimeKind.Local));
         private static readonly ValueConverter<DateTime, DateTime> UnspecifiedConverter =
-            new ValueConverter<DateTime, DateTime>(v => v, v => DateTime.SpecifyKind(v, DateTimeKind.Unspecified));
+           new ValueConverter<DateTime, DateTime>(v => ConvertToUtc(v), v => DateTime.SpecifyKind(v, DateTimeKind.Unspecified));
+
+        private static DateTime ConvertToUtc(DateTime dateTime)
+        {                
+            if (dateTime.Kind == DateTimeKind.Utc)
+                return dateTime;
+            else
+                return TimeZoneInfo.ConvertTimeToUtc(dateTime, TimeZoneInfo.Local);
+        }
+       
 
         /// <summary>
         /// Adds the date time kind converter to the model builder.
@@ -43,6 +51,7 @@ namespace Moryx.Model.Annotations
             foreach (var property in dateTimeProperties)
             {
                 var kind = FindDateTimeKind(property) ?? defaultKind;
+                property.SetValueConverter(UtcConverter);
                 switch (kind)
                 {
                     case DateTimeKind.Utc:

--- a/src/Moryx.TestTools.Test.Model/Entities/CarEntity.cs
+++ b/src/Moryx.TestTools.Test.Model/Entities/CarEntity.cs
@@ -1,8 +1,10 @@
 // Copyright (c) 2023, Phoenix Contact GmbH & Co. KG
 // Licensed under the Apache License, Version 2.0
 
+using System;
 using System.Collections.Generic;
 using Moryx.Model;
+using Moryx.Model.Attributes;
 
 namespace Moryx.TestTools.Test.Model
 {
@@ -13,6 +15,11 @@ namespace Moryx.TestTools.Test.Model
         public virtual int Price { get; set; }
 
         public virtual byte[] Image { get; set; }
+
+        [DateTimeKind(DateTimeKind.Local)]
+        public DateTime ReleaseDateLocal { get; set; }
+
+        public DateTime ReleaseDateUtc { get; set; }
 
         public virtual ICollection<WheelEntity> Wheels { get; set; }
     }

--- a/src/Moryx/Serialization/EntryConvert/EntryConvertGenerator.cs
+++ b/src/Moryx/Serialization/EntryConvert/EntryConvertGenerator.cs
@@ -15,55 +15,55 @@ namespace Moryx.Serialization
         /// <returns>Enum representation of the property type</returns>
         public static EntryValueType TransformType(Type propertyType)
         {
-			var valueType = EntryValueType.String;
-			if (propertyType == typeof(Byte))
-			{
-				valueType = EntryValueType.Byte;
-			}
-			else if (propertyType == typeof(Boolean))
-			{
-				valueType = EntryValueType.Boolean;
-			}
-			else if (propertyType == typeof(Int16))
-			{
-				valueType = EntryValueType.Int16;
-			}
-			else if (propertyType == typeof(UInt16))
-			{
-				valueType = EntryValueType.UInt16;
-			}
-			else if (propertyType == typeof(Int32))
-			{
-				valueType = EntryValueType.Int32;
-			}
-			else if (propertyType == typeof(UInt32))
-			{
-				valueType = EntryValueType.UInt32;
-			}
-			else if (propertyType == typeof(Int64))
-			{
-				valueType = EntryValueType.Int64;
-			}
-			else if (propertyType == typeof(UInt64))
-			{
-				valueType = EntryValueType.UInt64;
-			}
-			else if (propertyType == typeof(Single))
-			{
-				valueType = EntryValueType.Single;
-			}
-			else if (propertyType == typeof(Double))
-			{
-				valueType = EntryValueType.Double;
-			}
+            var valueType = EntryValueType.String;
+            if (propertyType == typeof(Byte))
+            {
+                valueType = EntryValueType.Byte;
+            }
+            else if (propertyType == typeof(Boolean))
+            {
+                valueType = EntryValueType.Boolean;
+            }
+            else if (propertyType == typeof(Int16))
+            {
+                valueType = EntryValueType.Int16;
+            }
+            else if (propertyType == typeof(UInt16))
+            {
+                valueType = EntryValueType.UInt16;
+            }
+            else if (propertyType == typeof(Int32))
+            {
+                valueType = EntryValueType.Int32;
+            }
+            else if (propertyType == typeof(UInt32))
+            {
+                valueType = EntryValueType.UInt32;
+            }
+            else if (propertyType == typeof(Int64))
+            {
+                valueType = EntryValueType.Int64;
+            }
+            else if (propertyType == typeof(UInt64))
+            {
+                valueType = EntryValueType.UInt64;
+            }
+            else if (propertyType == typeof(Single))
+            {
+                valueType = EntryValueType.Single;
+            }
+            else if (propertyType == typeof(Double))
+            {
+                valueType = EntryValueType.Double;
+            }
             else if (propertyType.IsEnum)
             {
                 valueType = EntryValueType.Enum;
             }
-			else if (typeof(Stream).IsAssignableFrom(propertyType))
-			{
-			    valueType = EntryValueType.Stream;
-			}
+            else if (typeof(Stream).IsAssignableFrom(propertyType))
+            {
+                valueType = EntryValueType.Stream;
+            }
             else if (typeof(IEnumerable).IsAssignableFrom(propertyType) && propertyType != typeof(string))
             {
                 valueType = EntryValueType.Collection;
@@ -86,104 +86,119 @@ namespace Moryx.Serialization
         {
             // Traditional re-transformation
             object result = null;
-			if (type == typeof(string))
-			{
-				result = value;
-			}
-			else if (type == typeof(Byte))
-			{
-				result = Byte.Parse(value, formatProvider);
-			}
-			else if (type == typeof(Boolean))
-			{
-				result = Boolean.Parse(value);
-			}
-			else if (type == typeof(Int16))
-			{
-				result = Int16.Parse(value, formatProvider);
-			}
-			else if (type == typeof(UInt16))
-			{
-				result = UInt16.Parse(value, formatProvider);
-			}
-			else if (type == typeof(Int32))
-			{
-				result = Int32.Parse(value, formatProvider);
-			}
-			else if (type == typeof(UInt32))
-			{
-				result = UInt32.Parse(value, formatProvider);
-			}
-			else if (type == typeof(Int64))
-			{
-				result = Int64.Parse(value, formatProvider);
-			}
-			else if (type == typeof(UInt64))
-			{
-				result = UInt64.Parse(value, formatProvider);
-			}
-			else if (type == typeof(Single))
-			{
-				result = Single.Parse(value, formatProvider);
-			}
-			else if (type == typeof(Double))
-			{
-				result = Double.Parse(value, formatProvider);
-			}
-			else if (type.IsEnum)
+            if (type == typeof(string))
+            {
+                result = value;
+            }
+            else if (type == typeof(Byte))
+            {
+                result = Byte.Parse(value, formatProvider);
+            }
+            else if (type == typeof(Boolean))
+            {
+                result = Boolean.Parse(value);
+            }
+            else if (type == typeof(Int16))
+            {
+                result = Int16.Parse(value, formatProvider);
+            }
+            else if (type == typeof(UInt16))
+            {
+                result = UInt16.Parse(value, formatProvider);
+            }
+            else if (type == typeof(Int32))
+            {
+                result = Int32.Parse(value, formatProvider);
+            }
+            else if (type == typeof(UInt32))
+            {
+                result = UInt32.Parse(value, formatProvider);
+            }
+            else if (type == typeof(Int64))
+            {
+                result = Int64.Parse(value, formatProvider);
+            }
+            else if (type == typeof(UInt64))
+            {
+                result = UInt64.Parse(value, formatProvider);
+            }
+            else if (type == typeof(Single))
+            {
+                result = Single.Parse(value, formatProvider);
+            }
+            else if (type == typeof(Double))
+            {
+                result = Double.Parse(value, formatProvider);
+            }
+            else if (type.IsEnum)
             {
                 result = Enum.Parse(type, value);
+            }
+            else if (type == typeof(DateTime))
+            {
+                result = ConvertToUtc(DateTime.Parse(value, formatProvider));
             }
 
             return result;
         }
 
-		/// <summary>
+        private static DateTime? ConvertToUtc(DateTime? dateTime)
+        {
+            if (dateTime == null) return null;
+
+            var nonNullDateTime = (DateTime)dateTime;
+            if (nonNullDateTime.Kind == DateTimeKind.Utc)
+                return nonNullDateTime;
+            else
+                return TimeZoneInfo.ConvertTimeToUtc(nonNullDateTime, TimeZoneInfo.Local);
+        }
+
+        /// <summary>
         /// Transform string to typed object based on the type enum value
         /// </summary>
         /// <param name="type">Entry value type</param>
         /// <param name="value">String value</param>
-		/// <param name="formatProvider"><see cref="IFormatProvider"/> used for parsing value</param>
+        /// <param name="formatProvider"><see cref="IFormatProvider"/> used for parsing value</param>
         /// <returns>Typed object with parsed value</returns>
         public static object ToObject(EntryValueType type, string value, IFormatProvider formatProvider)
         {
             // Traditional re-transformation
             object result = null;
-			switch (type)
-			{
-				case EntryValueType.String:
-					result = value;
-					break;
-				case EntryValueType.Byte:
-					result = Byte.Parse(value, formatProvider);
-					break;
-				case EntryValueType.Boolean:
-					result = Boolean.Parse(value);
-					break;
-				case EntryValueType.Int16:
-					result = Int16.Parse(value, formatProvider);
-					break;
-				case EntryValueType.UInt16:
-					result = UInt16.Parse(value, formatProvider);
-					break;
-				case EntryValueType.Int32:
-					result = Int32.Parse(value, formatProvider);
-					break;
-				case EntryValueType.UInt32:
-					result = UInt32.Parse(value, formatProvider);
-					break;
-				case EntryValueType.Int64:
-					result = Int64.Parse(value, formatProvider);
-					break;
-				case EntryValueType.UInt64:
-					result = UInt64.Parse(value, formatProvider);
-					break;
-				case EntryValueType.Single:
-					result = Single.Parse(value, formatProvider);
-					break;
-				case EntryValueType.Double:
-					result = Double.Parse(value, formatProvider);
-					break;
+            switch (type)
+            {
+                case EntryValueType.String:
+                    result = value;
+                    break;
+                case EntryValueType.Byte:
+                    result = Byte.Parse(value, formatProvider);
+                    break;
+                case EntryValueType.Boolean:
+                    result = Boolean.Parse(value);
+                    break;
+                case EntryValueType.Int16:
+                    result = Int16.Parse(value, formatProvider);
+                    break;
+                case EntryValueType.UInt16:
+                    result = UInt16.Parse(value, formatProvider);
+                    break;
+                case EntryValueType.Int32:
+                    result = Int32.Parse(value, formatProvider);
+                    break;
+                case EntryValueType.UInt32:
+                    result = UInt32.Parse(value, formatProvider);
+                    break;
+                case EntryValueType.Int64:
+                    result = Int64.Parse(value, formatProvider);
+                    break;
+                case EntryValueType.UInt64:
+                    result = UInt64.Parse(value, formatProvider);
+                    break;
+                case EntryValueType.Single:
+                    result = Single.Parse(value, formatProvider);
+                    break;
+                case EntryValueType.Double:
+                    result = Double.Parse(value, formatProvider);
+                    break;
             }
 
             return result;

--- a/src/Tests/Moryx.Model.Tests/InMemoryTests.cs
+++ b/src/Tests/Moryx.Model.Tests/InMemoryTests.cs
@@ -36,6 +36,30 @@ namespace Moryx.Model.Tests
 
             Assert.IsNotNull(reloadedCar);
             Assert.AreEqual(carName, reloadedCar.Name);
+            
+        }
+
+        [Test]
+        public async Task TimeShouldAlwaysBeSavedAsUtc()
+        {
+            // Arrange          
+            var inMemoryFactory = new InMemoryDbContextManager(Guid.NewGuid().ToString());
+
+            // Act
+            var context = inMemoryFactory.Create<TestModelContext>();
+            var carsSet = context.Cars;
+            var someCar = new CarEntity { ReleaseDateLocal = DateTime.Now, ReleaseDateUtc = DateTime.Now };
+            await carsSet.AddAsync(someCar);
+
+            await context.SaveChangesAsync();
+
+            context = inMemoryFactory.Create<TestModelContext>();
+            var reloadedCar = await context.Cars.FirstAsync();
+
+            // Assert
+            Assert.IsNotNull(reloadedCar);
+            Assert.AreEqual(DateTimeKind.Utc, reloadedCar.ReleaseDateUtc.Kind);
+            Assert.AreEqual(DateTimeKind.Local, reloadedCar.ReleaseDateLocal.Kind);
         }
     }
 }


### PR DESCRIPTION
With EF Core 6 and Npgsql 6 DateTimes can only be saved in UTC format. In order to fix that for all possible modules, the UOW will now check for DateTimes before it calles `DbContext.SaveChanges()`.

Additionally DateTimes where forgotten in the `EntryConvertGenerator`. Because of that it wasn't possible for Resources and Products to have DateTime properties. These properties would always be set to the default value.

