### PR TITLE
LoadVersions only returns the current version

### DIFF
--- a/src/Moryx.Products.Model/ProductsContext.cs
+++ b/src/Moryx.Products.Model/ProductsContext.cs
@@ -61,12 +61,12 @@ namespace Moryx.Products.Model
             // Workplane reference
             modelBuilder.Entity<WorkplanReferenceEntity>()
                 .HasOne(w => w.Target)
-                .WithMany(w => w.TargetReferences).IsRequired()
+                .WithMany(w => w.SourceReferences).IsRequired()
                 .HasForeignKey(s => s.TargetId);
 
             modelBuilder.Entity<WorkplanReferenceEntity>()
                 .HasOne(w => w.Source)
-                .WithMany(w => w.SourceReferences).IsRequired()
+                .WithMany(w => w.TargetReferences).IsRequired()
                 .HasForeignKey(s => s.SourceId);
 
             // Product Instances


### PR DESCRIPTION
Currently **LoadVersions** only returns the current version

Updated **LoadVersions** to collect both targetReferences and sourceReferences and concatenate them. Return all the versions ordered by version.

![LoadVersions](https://github.com/PHOENIXCONTACT/MORYX-Framework/assets/24854338/240d6817-df6b-45cf-8ccc-d74aa279eb71)



