### PR TITLE
Removed facade.ValidateHealthState null check for module specific **ValidationHealthState** intial value handling.

### DIFF
--- a/src/Moryx.Runtime/Modules/ServerModuleFacadeControllerBase.cs
+++ b/src/Moryx.Runtime/Modules/ServerModuleFacadeControllerBase.cs
@@ -35,8 +35,7 @@ namespace Moryx.Runtime.Modules
         protected void ActivateFacade(IFacadeControl facade)
         {
             // First activation
-            if (facade.ValidateHealthState == null)
-                facade.ValidateHealthState = ValidateHealthState;
+            facade.ValidateHealthState = ValidateHealthState;
 
             FillProperties(facade, FillProperty);
             facade.Activate();


### PR DESCRIPTION
**NotificationFacade** and **WorkerSupportFacade** now have initial delegate value set in their constructor.

