### PR TITLE
Unresolved dependencies are removed from the dependency list of available modules

### DIFF
--- a/src/Moryx.CommandCenter.Web/src/modules/models/ModuleServerModuleState.ts
+++ b/src/Moryx.CommandCenter.Web/src/modules/models/ModuleServerModuleState.ts
@@ -11,4 +11,5 @@ export enum ModuleServerModuleState {
     Running = "Running",
     Stopping = "Stopping",
     Failure = "Failure",
+    Missing = "Missing",
 }

--- a/src/Moryx.Runtime.Kernel/Modules/MissingModuleDependency.cs
+++ b/src/Moryx.Runtime.Kernel/Modules/MissingModuleDependency.cs
@@ -1,0 +1,24 @@
+﻿using Moryx.Runtime.Modules;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Moryx.Runtime.Kernel.Modules
+{
+    /// <summary>
+    /// Class representing a missing module dependency
+    /// </summary>
+    internal class MissingModuleDependency : IModuleDependency
+    {
+        public IServerModule RepresentedModule { get; private set; }
+
+        public MissingModuleDependency(IServerModule representedModule)
+        {
+            RepresentedModule = representedModule;
+        }
+
+        public IReadOnlyList<IModuleDependency> Dependencies => throw new NotImplementedException();
+
+        public IReadOnlyList<IModuleDependency> Dependends => throw new NotImplementedException();
+    }
+}

--- a/src/Moryx.Runtime.Kernel/Modules/MissingServerModule.cs
+++ b/src/Moryx.Runtime.Kernel/Modules/MissingServerModule.cs
@@ -1,0 +1,62 @@
+﻿using Moryx.Modules;
+using Moryx.Runtime.Modules;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Moryx.Runtime.Kernel.Modules
+{
+    /// <summary>
+    /// Class representing a missing module in the application
+    /// </summary>
+    internal class MissingServerModule : IServerModule
+    {
+        public IServerModuleConsole Console => null;
+
+        public ServerModuleState State => ServerModuleState.Missing;
+
+        public string Name => GetName();
+
+        public INotificationCollection Notifications =>  null;
+
+        public event EventHandler<ModuleStateChangedEventArgs> StateChanged;
+
+        public MissingServerModule(Type service)
+        {
+            RepresentedService = service;
+        }
+
+        /// <summary>
+        /// Gets the name of the Module
+        /// </summary>
+        /// <returns></returns>
+        private string GetName()
+        {        
+            var isInterfaceAndHasIasFirstCharacter = RepresentedService.Name.ElementAt(0).ToString().ToLower() == "i" &&
+                RepresentedService.IsInterface;
+
+            if (isInterfaceAndHasIasFirstCharacter)
+                return RepresentedService.Name.Remove(0, 1); // remove "i" in the interface name
+            else return RepresentedService.Name;
+        }
+
+        public void AcknowledgeNotification(IModuleNotification notification)
+        {
+        }
+
+        public void Initialize()
+        {
+        }
+
+        public void Start()
+        {
+        }
+
+        public void Stop()
+        {
+        }
+
+        public Type RepresentedService { get; private set; }
+    }
+}

--- a/src/Moryx.Runtime/Modules/ServerModuleState.cs
+++ b/src/Moryx.Runtime/Modules/ServerModuleState.cs
@@ -41,6 +41,11 @@ namespace Moryx.Runtime.Modules
         /// <summary>
         /// Service failed
         /// </summary>
-        Failure = 0x4
+        Failure = 0x4,
+
+        /// <summary>
+        /// Service Missing
+        /// </summary>
+        Missing = 0x5
     }
 }

--- a/src/Moryx.Runtime/Modules/States/MissingState.cs
+++ b/src/Moryx.Runtime/Modules/States/MissingState.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Moryx.Runtime.Modules.States
+{
+    /// <summary>
+    /// Missing state , indicating that the server is missing.
+    /// Usefull for modules that are missing.
+    /// </summary>
+    internal class MissingState : ServerModuleStateBase
+    {
+        public override ServerModuleState Classification => ServerModuleState.Missing;
+
+        public MissingState(IServerModuleStateContext context, StateMap stateMap)
+            : base(context, stateMap)
+        {
+        }
+
+        public override void Initialize()
+        {
+            // Nothing to do here
+        }
+
+        public override void Start()
+        {
+            // Nothing to do here
+        }
+
+        public override void Stop()
+        {
+            // Nothing to do here
+        }
+    }
+}

--- a/src/Tests/Moryx.Runtime.Kernel.Tests/ModuleManagerTests.cs
+++ b/src/Tests/Moryx.Runtime.Kernel.Tests/ModuleManagerTests.cs
@@ -165,7 +165,28 @@ namespace Moryx.Runtime.Kernel.Tests
             Assert.AreEqual(3, moduleManager.AllModules.Count());
             var available = moduleManager.DependencyTree.RootModules
                 .Flatten(md => md.Dependends).ToList();
-            Assert.AreEqual(1, available.Count);
+            Assert.AreEqual(2, available.Count);
+        }
+
+        [Test]
+        public void ShouldIncludeMissingFacadeInDependencyList()
+        {
+            // Arrange
+            var moduleBUsingA = new ModuleBUsingA();
+            var moduleManager = CreateObjectUnderTest(new IServerModule[]
+            {
+                new ModuleB1(),
+                moduleBUsingA,
+                new ModuleC()
+            });
+
+            // Act
+            moduleManager.StartModules();
+
+            // Assert
+            Assert.AreEqual(3, moduleManager.AllModules.Count());
+            var moduleBUsingA_Dependencies = moduleManager.StartDependencies(moduleBUsingA);
+            Assert.AreEqual(1,moduleBUsingA_Dependencies.Count());
         }
 
         [Test]


### PR DESCRIPTION
Added **MissingState**, **MissingServerModule** and **MissingModuleDependency**. **MissingServerModule** now represent module that can't be resolved, it contains a property **RepresentedService** that holds the type of the Server that is missing. And has a static state **Missing**.

**Final result**:
![commandCenterMissingDependency](https://github.com/PHOENIXCONTACT/MORYX-Framework/assets/24854338/e6196301-fddb-4133-9397-f58c001347e8)
