### PR TITLE
When invoking the TextBindingResolverFactory with a null template string, it crashes.

### DIFF
--- a/src/Moryx/Bindings/TextBindingResolverFactory.cs
+++ b/src/Moryx/Bindings/TextBindingResolverFactory.cs
@@ -19,6 +19,10 @@ namespace Moryx.Bindings
         /// </summary>
         public static ITextBindingResolver Create(string parameterWithBindings, IBindingResolverFactory resolverFactory)
         {
+            //null check to make sure the parameterWithBinding is not null
+            if (parameterWithBindings == null)
+                return new NullResolver(parameterWithBindings);
+
             // Parse bindings
             var matches = Regex.Matches(parameterWithBindings, BindingRegex);
 
@@ -102,7 +106,8 @@ namespace Moryx.Bindings
                 foreach (var resolver in _resolvers)
                 {
                     var resolvedReference = resolver.Value.Resolve(source);
-                    result = result.Replace(resolver.Key, resolvedReference?.ToString() ?? "'null'");
+                    result = resolvedReference is null ? 
+                             result : result.Replace(resolver.Key, resolvedReference.ToString());
                 }
                 return result;
             }

--- a/src/Tests/Moryx.Tests/Bindings/BindingResolverExtensionTests.cs
+++ b/src/Tests/Moryx.Tests/Bindings/BindingResolverExtensionTests.cs
@@ -125,6 +125,19 @@ namespace Moryx.Tests.Bindings
             Assert.AreEqual(5 - removeCount, CountChainLinks(_resolver));
         }
 
+        [TestCase(null, Description = "should return null value")]
+        [TestCase("This is a wrong binding", Description = "Should return original string value")]
+        [TestCase("This text used {Branch.Nmae} on data which was not found", Description = "Should return original string value")]
+        public void ShouldReturnOriginalValue(string textToFormat)
+        {
+            var data = new Foo { Branch = new Branch { Name = "Binded Text"} };
+            var bindingResolverFactory = new BindingResolverFactory();
+            var resolver = TextBindingResolverFactory.Create(textToFormat, bindingResolverFactory);
+            var result = resolver.Resolve(data);
+
+            Assert.That(result, Is.EqualTo(textToFormat));
+        }
+
         private int CountChainLinks(IBindingResolverChain chain)
         {
             var links = 0;
@@ -179,5 +192,6 @@ namespace Moryx.Tests.Bindings
                 }
             };
         }
+
     }
 }


### PR DESCRIPTION
Added a null check in the **Create** method, to check if the value is null, returns **NullResolver(originalValue)**. Added a test case for Null and wrong string format.
[Issue link](https://github.com/PHOENIXCONTACT/MORYX-Framework/issues/136)
