### PR TITLE
Add possibility to exlude parts

### DIFF
--- a/src/Moryx.AbstractionLayer.Products.Endpoints/ProductConverter.cs
+++ b/src/Moryx.AbstractionLayer.Products.Endpoints/ProductConverter.cs
@@ -46,7 +46,9 @@ namespace Moryx.AbstractionLayer.Products.Endpoints
                 HasWorkplans = typeof(IWorkplanRecipe).IsAssignableFrom(recipeType)
             };
         }
-        public ProductModel ConvertProduct(IProductType productType, bool flat)
+
+        /// <param name="includeParts">Determines whether parts should be included</param>
+        public ProductModel ConvertProduct(IProductType productType, bool flat, bool includeParts = true)
         {
             
             // Base object
@@ -77,7 +79,8 @@ namespace Moryx.AbstractionLayer.Products.Endpoints
             converted.Recipes = recipes.Select(ConvertRecipe).ToArray();
 
             // Parts
-            ConvertParts(productType, properties, converted);
+            if (includeParts)
+                ConvertParts(productType, properties, converted);
 
             return converted;
         }

--- a/src/Moryx.AbstractionLayer.Products.Endpoints/ProductManagementController.cs
+++ b/src/Moryx.AbstractionLayer.Products.Endpoints/ProductManagementController.cs
@@ -156,7 +156,7 @@ namespace Moryx.AbstractionLayer.Products.Endpoints
             var productModels = new List<ProductModel>();
             foreach (var t in productTypes)
             {
-                productModels.Add(_productConverter.ConvertProduct(t, false));
+                productModels.Add(_productConverter.ConvertProduct(t, false, query.NoPartLinks == false));
             }
             return productModels.ToArray();
         }

--- a/src/Moryx.AbstractionLayer/Products/ProductQuery.cs
+++ b/src/Moryx.AbstractionLayer/Products/ProductQuery.cs
@@ -73,6 +73,12 @@ namespace Moryx.AbstractionLayer.Products
         /// </summary>
         [DataMember]
         public List<PropertyFilter> PropertyFilters { get; set; }
+
+        /// <summary>
+        /// Select whether the parts should be excluded in the query
+        /// </summary>
+        [DataMember]
+        public bool NoPartLinks { get; set; }
     }
 
     /// <summary>

--- a/src/Moryx.Products.Management/Implementation/Storage/ProductStorage.cs
+++ b/src/Moryx.Products.Management/Implementation/Storage/ProductStorage.cs
@@ -353,6 +353,28 @@ namespace Moryx.Products.Management
             else if (query.RecipeFilter == RecipeFilter.WithoutRecipes)
                 productsQuery = productsQuery.Where(p => p.Recipes.Count == 0);
 
+            // Exclude parts
+            if (query.NoPartLinks)
+            {
+                productsQuery = productsQuery.Select(p => new ProductTypeEntity
+                {
+                   TypeName = p.TypeName,
+                   Identifier = p.Identifier,
+                   Revision = p.Revision,
+                   Name = p.Name,
+                   CurrentVersionId = p.CurrentVersionId,
+                   Parents = p.Parents,
+                   Files = p.Files,
+                   Recipes = p.Recipes,
+                   OldVersions = p.OldVersions,
+                   CurrentVersion = p.CurrentVersion, 
+                   Id = p.Id,
+                   Created = p.Created,
+                   Updated = p.Updated,
+                   Deleted = p.Deleted
+                });;
+            }
+
             // Apply selector
             switch (query.Selector)
             {

--- a/src/Moryx.Products.Model/Entities/ProductTypeEntity.cs
+++ b/src/Moryx.Products.Model/Entities/ProductTypeEntity.cs
@@ -28,7 +28,7 @@ namespace Moryx.Products.Model
 
         public virtual ICollection<ProductTypePropertiesEntity> OldVersions { get; set; }
 
-        public virtual ProductTypePropertiesEntity CurrentVersion { get; protected internal set; }
+        public virtual ProductTypePropertiesEntity CurrentVersion { get; set; }
 
         public ProductTypeEntity()
         {


### PR DESCRIPTION
By default, the LoadType method in the ProductMangementFacade returns the parts. Now there is an additional property called NoPartLinks in the ProductQuery class, which can be set to true to speed up the queries and exclude the parts.

