### PR TITLE
Fix LoadComponents for private types with missing reference

### DIFF
--- a/src/Moryx.Container/CastleContainer.cs
+++ b/src/Moryx.Container/CastleContainer.cs
@@ -160,7 +160,28 @@ namespace Moryx.Container
             {
                 _knownTypes = ReflectionTool.GetAssemblies()
                     .Where(a => a.GetCustomAttribute<ComponentLoaderIgnoreAttribute>() == null)
-                    .SelectMany(a => a.GetTypes())
+                    .SelectMany(a => 
+                    {
+                        // TODO: Replace with exported types in MORYX 8
+                        try
+                        {
+                            // This should only return exported types
+                            return a.GetTypes();
+                        }
+                        catch
+                        {
+                            // Fall back to exported types in case of exception
+                            try
+                            {
+                                return a.GetExportedTypes();
+                            }
+                            catch
+                            {
+                                // Give up
+                                return new Type[0];
+                            }
+                        }
+                    })
                     .Where(t => t.GetCustomAttribute<RegistrationAttribute>(true) != null).ToArray();
             }
 


### PR DESCRIPTION
Our colleagues at [Optano](https://github.com/OPTANO) reported exceptions when combining their modeling package with MORYX. It turns out our usage of Reflection and `GetTypes` caused missing references which do not occur at runtime.

The issue is resolved when switching from `GetTypes` to `GetExportedTypes` which would be breaking if any application registers internal classes as components in MORYX. For MORYX 6 we keep the current behaviour, for MORYX 8 we restricht loading to exported types.

/cc @svflake-optano 
/cc @cmensendiek-optano