### PR TITLE
Mising modules stopped dependend from starting, even when optional

### DIFF
--- a/src/Moryx.Runtime.Kernel/Modules/Components/ModuleDependencyManager.cs
+++ b/src/Moryx.Runtime.Kernel/Modules/Components/ModuleDependencyManager.cs
@@ -226,7 +226,7 @@ namespace Moryx.Runtime.Kernel
                 // when there is no facade provider for the dependency,
                 // add a missing dependency for the property type
                 if(dependencyProviders.Count() == 0)
-                    dependencyServices.Add(new MissingServerModule(propType));
+                    dependencyServices.Add(new MissingServerModule(propType, importingProperty.Attribute.IsOptional));
             }
 
             return dependencyServices;

--- a/src/Moryx.Runtime.Kernel/Modules/Components/ModuleStarter.cs
+++ b/src/Moryx.Runtime.Kernel/Modules/Components/ModuleStarter.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using Microsoft.Extensions.Logging;
+using Moryx.Runtime.Kernel.Modules;
 using Moryx.Runtime.Modules;
 
 namespace Moryx.Runtime.Kernel
@@ -75,6 +76,8 @@ namespace Moryx.Runtime.Kernel
             // Now we check for any not running dependencies and start them
             var awaitingDependecies = _dependencyManager.GetDependencyBranch(module).Dependencies
                                      .Where(item => !item.RepresentedModule.State.HasFlag(ServerModuleState.Running))
+                                     // Filter missing modules if they are optional
+                                     .Where(item => item.RepresentedModule is not MissingServerModule module || !module.Optional)
                                      .Select(item => item.RepresentedModule).ToArray();
             if (awaitingDependecies.Any())
                 EnqueServiceAndStartDependencies(awaitingDependecies, module);

--- a/src/Moryx.Runtime.Kernel/Modules/MissingServerModule.cs
+++ b/src/Moryx.Runtime.Kernel/Modules/MissingServerModule.cs
@@ -22,9 +22,10 @@ namespace Moryx.Runtime.Kernel.Modules
 
         public event EventHandler<ModuleStateChangedEventArgs> StateChanged;
 
-        public MissingServerModule(Type service)
+        public MissingServerModule(Type service, bool optional)
         {
             RepresentedService = service;
+            Optional = optional;
         }
 
         /// <summary>
@@ -58,5 +59,6 @@ namespace Moryx.Runtime.Kernel.Modules
         }
 
         public Type RepresentedService { get; private set; }
+        public bool Optional { get; }
     }
 }


### PR DESCRIPTION
Unfortunately the changes from #326 caused modules with missing optional dependencies from starting. This does adds a workaround to restore functionality, but the concept of missing fake modules, needs to be rewritten for MORYX 8.