### PR TITLE
Support generic methods in the ResourceProxyBuilder

### DIFF
--- a/src/Tests/Moryx.Resources.Management.Tests/Mocks/ResourceWithGenericMethod.cs
+++ b/src/Tests/Moryx.Resources.Management.Tests/Mocks/ResourceWithGenericMethod.cs
@@ -1,0 +1,28 @@
+﻿using Moryx.AbstractionLayer.Drivers;
+using Moryx.AbstractionLayer.Drivers.InOut;
+using Moryx.AbstractionLayer.Drivers.Message;
+using Moryx.AbstractionLayer.Resources;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Moryx.Resources.Management.Tests
+{
+    public interface IGenericMethodCall<T> : IResource
+    {
+        /// <summary>
+        /// Get channel using specialized API
+        /// </summary>
+        IList<TChannel> GenericMethod<TChannel>(string identifier);
+    }
+
+    public class ResourceWithGenericMethod : Driver, IGenericMethodCall<object>
+    {
+        public IList<TChannel> GenericMethod<TChannel>(string identifier)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/Tests/Moryx.Resources.Management.Tests/TypeControllerTests.cs
+++ b/src/Tests/Moryx.Resources.Management.Tests/TypeControllerTests.cs
@@ -194,6 +194,19 @@ namespace Moryx.Resources.Management.Tests
         }
 
         [Test]
+        public void ProxyForGenericMethod()
+        {
+            // Arrange
+            var driver = new ResourceWithGenericMethod { Id = 2, Name = "Some other Resource" };
+
+            // Act
+            var proxy = (IGenericMethodCall<object>)_typeController.GetProxy(driver);
+
+            // Assert
+            Assert.IsNotNull(proxy);
+        }
+
+        [Test]
         public void ReplaceWithProxy()
         {
             // Arrange: Create instance and reference


### PR DESCRIPTION
Resource interfaces with generic with generic methods or properties can currently not be proxied. We noticed that when we accessed simulated drivers that also implement `IMessageDriver<object>`.

Defining generic methods (return types, parameters, ...) with System.Emit is much more complicated than non generic definitions. On the other hand we didn't need this for several years now and even in the case above we only noticed it by accident, not because the simulated requires a generic interface to work.

Decision:
- We keep this PR as a starting point and for future discussion, if the feature is required
- We filter any generic interfaces in the proxy definition and assume they are only used internally
- Requesting a generic type through the facade gives a NotSupportedException

References to pick up later:
- https://learn.microsoft.com/en-us/dotnet/framework/reflection-and-codedom/how-to-define-a-generic-method-with-reflection-emit
- https://learn.microsoft.com/en-us/dotnet/framework/reflection-and-codedom/how-to-examine-and-instantiate-generic-types-with-reflection