### PR TITLE
Filter resource interfaces with generic parameters or generic methods.

### DIFF
--- a/src/Moryx.Resources.Management/Extensions/ResourceExtensions.cs
+++ b/src/Moryx.Resources.Management/Extensions/ResourceExtensions.cs
@@ -10,6 +10,9 @@ namespace Moryx.Resources.Management
         public static TResource Proxify<TResource>(this TResource source, IResourceTypeController typeController)
             where TResource : class, IPublicResource
         {
+            if (ResourceTypeController.IsGenericResourceInterface(typeof(TResource)))
+                throw new NotSupportedException("Generic resource interfaces are not supported through the facade!");
+
             return (TResource)typeController.GetProxy(source as Resource);
         }
 

--- a/src/Moryx.Resources.Management/Resources/ResourceTypeController.cs
+++ b/src/Moryx.Resources.Management/Resources/ResourceTypeController.cs
@@ -325,7 +325,21 @@ namespace Moryx.Resources.Management
                                            && relevantInterfaces.Any(generalInterface.IsAssignableFrom) // It is a base type of a relevant interface
                                         select generalInterface);
 
+            // Filter all interfaces that are generic OR contain generic methods
+            relevantInterfaces = relevantInterfaces.Where(candidate => !IsGenericResourceInterface(candidate)).ToList();
+
             return relevantInterfaces;
+        }
+
+        internal static bool IsGenericResourceInterface(Type resourceInterface)
+        {
+            if (resourceInterface.IsGenericType || resourceInterface.IsGenericTypeDefinition)
+                return true;
+
+            if (resourceInterface.GetMethods().Any(method => method.IsGenericMethod || method.ContainsGenericParameters))
+                return true;
+
+            return false;
         }
     }
 }

--- a/src/Tests/Moryx.Resources.Management.Tests/Mocks/ResourceWithGenericMethod.cs
+++ b/src/Tests/Moryx.Resources.Management.Tests/Mocks/ResourceWithGenericMethod.cs
@@ -1,0 +1,53 @@
+﻿using Moryx.AbstractionLayer.Capabilities;
+using Moryx.AbstractionLayer.Drivers;
+using Moryx.AbstractionLayer.Drivers.InOut;
+using Moryx.AbstractionLayer.Drivers.Message;
+using Moryx.AbstractionLayer.Resources;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Moryx.Resources.Management.Tests
+{
+    public interface IGenericMethodCall : IPublicResource
+    {
+        /// <summary>
+        /// Get channel using specialized API
+        /// </summary>
+        IList<TChannel> GenericMethod<TChannel>(string identifier);
+    }
+
+    public class ResourceWithGenericMethod : Resource, IGenericMethodCall, ISimpleResource
+    {
+        public int Foo { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+
+        public ICapabilities Capabilities => throw new NotImplementedException();
+
+        public event EventHandler<int> FooChanged;
+        public event EventHandler<bool> FooEven;
+        public event EventHandler SomeEvent;
+        public event EventHandler<ICapabilities> CapabilitiesChanged;
+
+        public IList<TChannel> GenericMethod<TChannel>(string identifier)
+        {
+            throw new NotImplementedException();
+        }
+
+        public int MultiplyFoo(int factor)
+        {
+            throw new NotImplementedException();
+        }
+
+        public int MultiplyFoo(int factor, ushort offset)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void RaiseEvent()
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/Tests/Moryx.Resources.Management.Tests/TypeControllerTests.cs
+++ b/src/Tests/Moryx.Resources.Management.Tests/TypeControllerTests.cs
@@ -194,6 +194,30 @@ namespace Moryx.Resources.Management.Tests
         }
 
         [Test]
+        public void ProxyBuilderFiltersGenericInterfaces()
+        {
+            // Arrange
+            var driver = new ResourceWithGenericMethod { Id = 2, Name = "Some other Resource" };
+
+            // Act
+            var proxy = (ISimpleResource)_typeController.GetProxy(driver);
+
+            // Assert
+            Assert.IsNotNull(proxy);
+            Assert.IsFalse(typeof(IGenericMethodCall).IsAssignableFrom(proxy.GetType()));
+        }
+
+        [Test]
+        public void FacadeExceptionForGenericProxy()
+        {
+            // Arrange
+            var driver = new ResourceWithGenericMethod { Id = 2, Name = "Some other Resource" };
+
+            // Assert
+            Assert.Throws<NotSupportedException>(() => ResourceExtensions.Proxify<IGenericMethodCall>(driver, _typeController));
+        }
+
+        [Test]
         public void ReplaceWithProxy()
         {
             // Arrange: Create instance and reference


### PR DESCRIPTION
As we discovered and discussed in #343 we will currently not support generic interfaces and instead filter them in the ProxyBuilder and throw a `NotSupportedException` if a generic type is requested through the facade.