### PR TITLE
Fix `DisposedObjectException` in DatabaseController

### DIFF
--- a/MORYX-Framework.sln
+++ b/MORYX-Framework.sln
@@ -114,7 +114,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Moryx.Notifications.Tests",
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Moryx.Resources.Management.Tests", "src\Tests\Moryx.Resources.Management.Tests\Moryx.Resources.Management.Tests.csproj", "{FEB3BA44-2CD9-445A-ABF2-C92378C443F7}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Moryx.Runtime.Endpoints.Tests", "src\Tests\Moryx.Runtime.Endpoints.Tests\Moryx.Runtime.Endpoints.Tests.csproj", "{7792C4E0-6D07-42C9-AC29-BAB76836FC11}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Moryx.Runtime.Endpoints.Tests", "src\Tests\Moryx.Runtime.Endpoints.Tests\Moryx.Runtime.Endpoints.Tests.csproj", "{7792C4E0-6D07-42C9-AC29-BAB76836FC11}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Moryx.Runtime.Endpoints.IntegrationTests", "src\Tests\Moryx.Runtime.Endpoints.IntegrationTests\Moryx.Runtime.Endpoints.IntegrationTests.csproj", "{4FFB98A7-9A4C-476F-8BCC-C19B7F757BF8}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -290,6 +292,10 @@ Global
 		{7792C4E0-6D07-42C9-AC29-BAB76836FC11}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7792C4E0-6D07-42C9-AC29-BAB76836FC11}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7792C4E0-6D07-42C9-AC29-BAB76836FC11}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4FFB98A7-9A4C-476F-8BCC-C19B7F757BF8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4FFB98A7-9A4C-476F-8BCC-C19B7F757BF8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4FFB98A7-9A4C-476F-8BCC-C19B7F757BF8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4FFB98A7-9A4C-476F-8BCC-C19B7F757BF8}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -333,10 +339,11 @@ Global
 		{E84A977E-6C8C-4603-B5C5-3EA99C72DAFC} = {0A466330-6ED6-4861-9C94-31B1949CDDB9}
 		{FEB3BA44-2CD9-445A-ABF2-C92378C443F7} = {0A466330-6ED6-4861-9C94-31B1949CDDB9}
 		{7792C4E0-6D07-42C9-AC29-BAB76836FC11} = {0A466330-6ED6-4861-9C94-31B1949CDDB9}
+		{4FFB98A7-9A4C-476F-8BCC-C19B7F757BF8} = {8517D209-5BC1-47BD-A7C7-9CF9ADD9F5B6}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
-		    RESX_ShowErrorsInErrorList = True
-		RESX_TaskErrorCategory = Message
 		SolutionGuid = {36EFC961-F4E7-49DC-A36A-99594FFB8243}		
+		RESX_TaskErrorCategory = Message
+		    RESX_ShowErrorsInErrorList = True
 	EndGlobalSection
 EndGlobal

--- a/src/Moryx.AbstractionLayer.TestTools/InMemoryUnitOfWorkFactoryBuilder.cs
+++ b/src/Moryx.AbstractionLayer.TestTools/InMemoryUnitOfWorkFactoryBuilder.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
+using Moryx.Model;
 using Moryx.Model.Repositories;
 using Moryx.Model.Sqlite;
 
@@ -15,11 +16,26 @@ namespace Moryx.AbstractionLayer.TestTools
     {
 
         /// <summary>
-        /// Instanciate a `UnitOfWorkFactory` of type `T`
+        /// Instantiate a `UnitOfWorkFactory` of type `T`
         /// </summary>
         public static UnitOfWorkFactory<T> Sqlite<T>() where T : DbContext
         {
+            return SqliteDbContextManager().Factory<T>();
+        }
 
+        /// <summary>
+        /// Instantiate a `UnitOfWorkFactory` of type `T`
+        /// </summary>
+        public static UnitOfWorkFactory<T> Factory<T>(this IDbContextManager dbContextManager) where T : DbContext
+        {
+            return new UnitOfWorkFactory<T>(dbContextManager);
+        }
+
+        /// <summary>
+        /// Instantiate an in memory `SqliteDbContextProvider`
+        /// </summary>
+        public static IDbContextManager SqliteDbContextManager()
+        {
             // The in memory tests using SQLite need a permanently opened connection. Otherwise,
             // opening a database connection would result in creating a new in memory database
             var connectionStringBuilder = new SqliteConnectionStringBuilder
@@ -30,7 +46,7 @@ namespace Moryx.AbstractionLayer.TestTools
             var inMemoryDbConnection = new SqliteConnection(connectionStringBuilder.ConnectionString);
             inMemoryDbConnection.Open();
 
-            return new UnitOfWorkFactory<T>(new SqliteDbContextManager(inMemoryDbConnection));
+            return new SqliteDbContextManager(inMemoryDbConnection);
         }
 
         /// <summary>
@@ -46,5 +62,6 @@ namespace Moryx.AbstractionLayer.TestTools
             uow.DbContext.Database.EnsureCreated();
             return factory;
         }
+
     }
 }

--- a/src/Moryx.Model.Sqlite/Moryx.Model.Sqlite.csproj
+++ b/src/Moryx.Model.Sqlite/Moryx.Model.Sqlite.csproj
@@ -13,6 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Moryx.Runtime.Kernel\Moryx.Runtime.Kernel.csproj" />
     <ProjectReference Include="..\Moryx\Moryx.csproj" />
     <ProjectReference Include="..\Moryx.Model\Moryx.Model.csproj" />
   </ItemGroup>

--- a/src/Moryx.Model/ModelSetupExecutor.cs
+++ b/src/Moryx.Model/ModelSetupExecutor.cs
@@ -41,12 +41,12 @@ namespace Moryx.Model
         public IReadOnlyList<IModelSetup> GetAllSetups() => _setups;
 
         /// <inheritdoc />
-        public Task Execute(IDatabaseConfig config, IModelSetup setup, string setupData)
+        public async Task Execute(IDatabaseConfig config, IModelSetup setup, string setupData)
         {
             var unitOfWorkFactory = new UnitOfWorkFactory<TContext>(_dbContextManager);
             using var uow = unitOfWorkFactory.Create(config);
 
-            return setup.Execute(uow, setupData);
+            await setup.Execute(uow, setupData);
         }
     }
 }

--- a/src/Moryx.Model/ModelSetupExecutor.cs
+++ b/src/Moryx.Model/ModelSetupExecutor.cs
@@ -14,7 +14,7 @@ using Moryx.Tools;
 namespace Moryx.Model
 {
     /// <inheritdoc />
-    internal class ModelSetupExecutor<TContext> : IModelSetupExecutor
+    public class ModelSetupExecutor<TContext> : IModelSetupExecutor
         where TContext : DbContext
     {
         private readonly IDbContextManager _dbContextManager;

--- a/src/Moryx.Runtime.Endpoints/Databases/Endpoint/DatabaseController.cs
+++ b/src/Moryx.Runtime.Endpoints/Databases/Endpoint/DatabaseController.cs
@@ -227,7 +227,7 @@ namespace Moryx.Runtime.Endpoints.Databases.Endpoint
 
         [HttpPost("{targetModel}/setup")]
         [Authorize(Policy = RuntimePermissions.DatabaseCanSetup)]
-        public ActionResult<InvocationResponse> ExecuteSetup(string targetModel, ExecuteSetupRequest request)
+        public async Task<ActionResult<InvocationResponse>> ExecuteSetup(string targetModel, ExecuteSetupRequest request)
         {
             var contextType = _dbContextManager.Contexts.First(c => TargetModelName(c) == targetModel);
             var targetConfigurator = _dbContextManager.GetConfigurator(contextType);
@@ -250,7 +250,7 @@ namespace Moryx.Runtime.Endpoints.Databases.Endpoint
             // ReSharper disable once SuspiciousTypeConversion.Global
             try
             {
-                setupExecutor.Execute(config, targetSetup, request.Setup.SetupData);
+                await setupExecutor.Execute(config, targetSetup, request.Setup.SetupData);
                 return new InvocationResponse();
             }
             catch (Exception ex)

--- a/src/Moryx.TestTools.Test.Model/Setups/DisposedObjectSetup.cs
+++ b/src/Moryx.TestTools.Test.Model/Setups/DisposedObjectSetup.cs
@@ -1,0 +1,35 @@
+// Copyright (c) 2023, Phoenix Contact GmbH & Co. KG
+// Licensed under the Apache License, Version 2.0
+
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Moryx.Model;
+using Moryx.Model.Attributes;
+using Moryx.Model.Repositories;
+
+namespace Moryx.TestTools.Test.Model
+{
+    [ModelSetup(typeof(TestModelContext))]
+    public class DisposedObjectSetup : IModelSetup
+    {
+        public int SortOrder => 1;
+
+        public string Name => "Raw SQL Setup";
+
+        public string Description => "";
+
+        public string SupportedFileRegex => string.Empty;
+
+        public async Task Execute(IUnitOfWork openContext, string setupData)
+        {
+            // If the caller wouldn't await this method, 
+            // the DbContext might be disposed before it's
+            // being used in here. 
+            // Adding a delay to ensure that the is actually
+            // gone then.
+            await Task.Delay(50);
+            await openContext.DbContext.Database.ExecuteSqlRawAsync("SELECT * FROM \"Cars\"");
+        }
+    }
+}

--- a/src/Tests/Moryx.Products.IntegrationTests/ProductStorageSqliteTests.cs
+++ b/src/Tests/Moryx.Products.IntegrationTests/ProductStorageSqliteTests.cs
@@ -13,9 +13,11 @@ namespace Moryx.Products.IntegrationTests
     {
         protected override UnitOfWorkFactory<ProductsContext> BuildUnitOfWorkFactory()
         {
-            return InMemoryUnitOfWorkFactoryBuilder
-                .Sqlite<ProductsContext>()
-                .EnsureDbIsCreated();
+            var uowFactory = InMemoryUnitOfWorkFactoryBuilder
+                .Sqlite<ProductsContext>();
+            uowFactory.EnsureDbIsCreated();
+
+            return uowFactory;
         }
     }
 }

--- a/src/Tests/Moryx.Products.IntegrationTests/RecipeStorage/RecipeStorageSqliteTests.cs
+++ b/src/Tests/Moryx.Products.IntegrationTests/RecipeStorage/RecipeStorageSqliteTests.cs
@@ -14,9 +14,11 @@ namespace Moryx.Products.IntegrationTests
 
         protected override UnitOfWorkFactory<ProductsContext> BuildUnitOfWorkFactory()
         {
-            return InMemoryUnitOfWorkFactoryBuilder
-                .Sqlite<ProductsContext>()
-                .EnsureDbIsCreated();
+            var uowFactory = InMemoryUnitOfWorkFactoryBuilder
+                .Sqlite<ProductsContext>();
+            uowFactory.EnsureDbIsCreated();
+
+            return uowFactory;
         }
     }
 }

--- a/src/Tests/Moryx.Resources.Management.Tests/ResourceManagerSqliteTests.cs
+++ b/src/Tests/Moryx.Resources.Management.Tests/ResourceManagerSqliteTests.cs
@@ -13,9 +13,11 @@ namespace Moryx.Resources.Management.Tests
     {
         protected override UnitOfWorkFactory<ResourcesContext> BuildUnitOfWorkFactory()
         {
-            return InMemoryUnitOfWorkFactoryBuilder
-                .Sqlite<ResourcesContext>()
-                .EnsureDbIsCreated();
+            var uowFactory = InMemoryUnitOfWorkFactoryBuilder
+                .Sqlite<ResourcesContext>();
+            uowFactory.EnsureDbIsCreated();
+
+            return uowFactory;
         }
     }
 }

--- a/src/Tests/Moryx.Runtime.Endpoints.IntegrationTests/Databases/Controller/ModelSetupTests.cs
+++ b/src/Tests/Moryx.Runtime.Endpoints.IntegrationTests/Databases/Controller/ModelSetupTests.cs
@@ -1,0 +1,66 @@
+﻿// Copyright (c) 2023, Phoenix Contact GmbH & Co. KG
+// Licensed under the Apache License, Version 2.0
+
+using Moryx.Model;
+using Moryx.TestTools.Test.Model;
+using NUnit.Framework;
+using System.Threading.Tasks;
+using Moryx.Runtime.Endpoints.Databases.Endpoint;
+using Moryx.AbstractionLayer.TestTools;
+using System;
+using System.Collections.Generic;
+
+namespace Moryx.Runtime.Endpoints.IntegrationTests.Databases.Controller
+{
+    internal class ModelSetupTests
+    {
+        private IDbContextManager? _dbContextManager;
+        private DatabaseController? _databaseController;
+        private readonly List<Exception> _exceptions = new List<Exception>();
+
+        [SetUp]
+        public void Setup()
+        {
+            _dbContextManager = InMemoryUnitOfWorkFactoryBuilder
+                .SqliteDbContextManager();
+
+            _dbContextManager
+                .Factory<TestModelContext>()
+                .EnsureDbIsCreated();
+
+            _databaseController = new DatabaseController(_dbContextManager);
+
+            _exceptions.Clear();
+        }
+
+        [Test] 
+        public void ExecuteSetupDoesNotThrowDisposedObjectException()
+        {
+            // Add unobserved task exceptions to a list, to be checked later.
+            TaskScheduler.UnobservedTaskException += (sender, e) =>
+            {
+                _exceptions.Add(e.Exception);
+            };
+
+            var result = _databaseController?.ExecuteSetup("Moryx.TestTools.Test.Model.TestModelContext", new()
+            {
+                Config = new()
+                {
+                    ConfiguratorTypename = "1",
+                    Entries = new() { { "ConnectionString", "DataSource=:memory:" } }
+                },
+                Setup = new Endpoints.Databases.Endpoint.Models.SetupModel { Fullname = "Moryx.TestTools.Test.Model.DisposedObjectSetup" }
+            });
+
+            // ExecuteSetup lead to unobserved task exceptions. We give them 
+            // some time to be thrown.
+            Task.Delay(100).Wait();
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+            GC.Collect();
+
+            Assert.That(result?.Value?.Success, Is.True);
+            Assert.That(_exceptions.Count, Is.EqualTo(0));
+        }
+    }
+}

--- a/src/Tests/Moryx.Runtime.Endpoints.IntegrationTests/Databases/Controller/ModelSetupTests.cs
+++ b/src/Tests/Moryx.Runtime.Endpoints.IntegrationTests/Databases/Controller/ModelSetupTests.cs
@@ -15,7 +15,7 @@ namespace Moryx.Runtime.Endpoints.IntegrationTests.Databases.Controller
     internal class ModelSetupTests
     {
         private IDbContextManager? _dbContextManager;
-        private DatabaseController? _databaseController;
+        private DatabaseController _databaseController;
         private readonly List<Exception> _exceptions = new List<Exception>();
 
         [SetUp]
@@ -34,7 +34,7 @@ namespace Moryx.Runtime.Endpoints.IntegrationTests.Databases.Controller
         }
 
         [Test] 
-        public void ExecuteSetupDoesNotThrowDisposedObjectException()
+        public async Task ExecuteSetupDoesNotThrowDisposedObjectException()
         {
             // Add unobserved task exceptions to a list, to be checked later.
             TaskScheduler.UnobservedTaskException += (sender, e) =>
@@ -42,7 +42,7 @@ namespace Moryx.Runtime.Endpoints.IntegrationTests.Databases.Controller
                 _exceptions.Add(e.Exception);
             };
 
-            var result = _databaseController?.ExecuteSetup("Moryx.TestTools.Test.Model.TestModelContext", new()
+            var result = await _databaseController!.ExecuteSetup("Moryx.TestTools.Test.Model.TestModelContext", new()
             {
                 Config = new()
                 {

--- a/src/Tests/Moryx.Runtime.Endpoints.IntegrationTests/Moryx.Runtime.Endpoints.IntegrationTests.csproj
+++ b/src/Tests/Moryx.Runtime.Endpoints.IntegrationTests/Moryx.Runtime.Endpoints.IntegrationTests.csproj
@@ -1,0 +1,34 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+    <PackageReference Include="coverlet.collector" Version="3.2.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="NUnit" />
+    <PackageReference Include="NUnit3TestAdapter" />
+    <PackageReference Include="Moq" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Moryx.AbstractionLayer.TestTools\Moryx.AbstractionLayer.TestTools.csproj" />
+    <ProjectReference Include="..\..\Moryx.Model.Sqlite\Moryx.Model.Sqlite.csproj" />
+    <ProjectReference Include="..\..\Moryx.Runtime.Endpoints\Moryx.Runtime.Endpoints.csproj" />
+    <ProjectReference Include="..\..\Moryx.Runtime.Kernel\Moryx.Runtime.Kernel.csproj" />
+    <ProjectReference Include="..\..\Moryx.TestTools.Test.Model\Moryx.TestTools.Test.Model.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Not awaiting the `setup.Execute` call in `ModelSetupExecutor.Execute` lead to
`DisposedObjectException`