### PR TITLE
Fix disposed exception on shutdown

### DIFF
--- a/src/Moryx.Runtime.Kernel/KernelServiceCollectionExtensions.cs
+++ b/src/Moryx.Runtime.Kernel/KernelServiceCollectionExtensions.cs
@@ -87,24 +87,27 @@ namespace Moryx.Runtime.Kernel
             return configManager;
         }
 
+        private static IModuleManager _moduleManager;
         /// <summary>
         /// Boot system and start all modules
         /// </summary>
         /// <param name="serviceProvider"></param>
         /// <returns></returns>
+        [Obsolete("Resolve IModuleManager and call StartModules directly")]
         public static IModuleManager StartMoryxModules(this IServiceProvider serviceProvider)
         {
             var moduleManager = serviceProvider.GetRequiredService<IModuleManager>();
             moduleManager.StartModules();
-            return moduleManager;
+            return _moduleManager = moduleManager;
         }
 
         /// <summary>
         /// Stop all modules
         /// </summary>
+        [Obsolete("Stopping modules on service collection causes an exception, call StopModules on the return value of StartModules")]
         public static IModuleManager StopMoryxModules(this IServiceProvider serviceProvider)
         {
-            var moduleManager = serviceProvider.GetRequiredService<IModuleManager>();
+            var moduleManager = _moduleManager ?? serviceProvider.GetRequiredService<IModuleManager>();
             moduleManager.StopModules();
             return moduleManager;
         }

--- a/src/StartProject.Asp/Program.cs
+++ b/src/StartProject.Asp/Program.cs
@@ -4,6 +4,8 @@ using Moryx.Runtime.Kernel;
 using Moryx.Tools;
 using Moryx.Model;
 using Moryx.Runtime.Endpoints;
+using Microsoft.Extensions.DependencyInjection;
+using Moryx.Runtime.Modules;
 
 namespace StartProject.Asp
 {
@@ -26,11 +28,13 @@ namespace StartProject.Asp
                 }).Build();
 
             host.Services.UseMoryxConfigurations("Config");
-            host.Services.StartMoryxModules();
+
+            var moduleManager = host.Services.GetRequiredService<IModuleManager>();
+            moduleManager.StartModules();
 
             host.Run();
 
-            host.Services.StopMoryxModules();
+            moduleManager.StopModules();
         }
     }
 }

--- a/src/Tests/Moryx.Runtime.Kernel.Tests/KernelServiceCollectionExtensionsTests.cs
+++ b/src/Tests/Moryx.Runtime.Kernel.Tests/KernelServiceCollectionExtensionsTests.cs
@@ -85,11 +85,11 @@ namespace Moryx.Runtime.Kernel.Tests
         }
 
         [Test]
-        public void StartAllModules()
+        public void StartAndStopAllModules()
         {
             // Arrange
             var moduleManagerMock = new Mock<IModuleManager>();
-            _serviceCollection.AddSingleton<IModuleManager>(moduleManagerMock.Object);
+            _serviceCollection.AddSingleton(moduleManagerMock.Object);
             var provider = _serviceCollection.BuildServiceProvider();
 
             // Act
@@ -98,22 +98,12 @@ namespace Moryx.Runtime.Kernel.Tests
             // Assert
             moduleManagerMock.Verify(m => m.StartModules(), Times.Once);
             moduleManagerMock.VerifyNoOtherCalls();
-        }
-
-        [Test]
-        public void StopAllModules()
-        {
-            // Arrange
-            var moduleManagerMock = new Mock<IModuleManager>();
-            _serviceCollection.AddSingleton<IModuleManager>(moduleManagerMock.Object);
-            var provider = _serviceCollection.BuildServiceProvider();
 
             // Act
             provider.StopMoryxModules();
 
             // Assert
             moduleManagerMock.Verify(m => m.StopModules(), Times.Once);
-            moduleManagerMock.VerifyNoOtherCalls();
         }
     }
 }


### PR DESCRIPTION
Accessing the service provider after exiting host.Run() causes an exception. I fixed the current extensions, but would recommend to simply call the three methods directly, since the added benefit of our extensions is negligable