### PR TITLE
Mixed usage of Type.Name and FullName caused UI mismatch

### DIFF
--- a/src/Moryx.AbstractionLayer.Products.Endpoints/ProductConverter.cs
+++ b/src/Moryx.AbstractionLayer.Products.Endpoints/ProductConverter.cs
@@ -27,16 +27,22 @@ namespace Moryx.AbstractionLayer.Products.Endpoints
         {
             _productManagement = productManagement;
         }
+
         public ProductDefinitionModel ConvertProductType(Type productType)
         {
+            var baseType = productType.BaseType;
+            var baseTypeName = baseType == typeof(ProductType)
+                ? string.Empty : baseType.FullName;
+
             return new()
             {
                 Name = productType.FullName,
                 DisplayName = productType.GetDisplayName() ?? productType.Name,
-                BaseDefinition = productType.BaseType?.Name,
+                BaseDefinition = baseTypeName,
                 Properties = EntryConvert.EncodeClass(productType, ProductSerialization)
             };
         }
+
         public RecipeDefinitionModel ConvertRecipeType(Type recipeType)
         {
             return new()


### PR DESCRIPTION
The MORYX UI and other consumers of the endpoint could not reconstruct the type tree, because `Name` used the `Type.FullName` with namespace, while the base type only used `Type.Name`.

We now use the FullName consistently and use `string.Empty` instead of the MORYX base type `ProductType`.