### PR TITLE
Fix 'stuck' database inputs

### DIFF
--- a/src/Moryx.CommandCenter.Web/package.json
+++ b/src/Moryx.CommandCenter.Web/package.json
@@ -21,7 +21,7 @@
         "bootstrap": "5.3.3",
         "bootstrap5-toggle": "^5.0.6",
         "moment": "^2.30.1",
-        "query-string": "^8.2.0",
+        "query-string": "^9.0.0",
         "react": "18.2.0",
         "react-bootstrap-toggle": "^2.3.2",
         "react-dom": "18.2.0",

--- a/src/Moryx.CommandCenter.Web/package.json
+++ b/src/Moryx.CommandCenter.Web/package.json
@@ -41,7 +41,7 @@
         "@types/react-router-redux": "^5.0.27",
         "css-loader": "^6.10.0",
         "html-webpack-plugin": "^5.6.0",
-        "node-sass": "^9.0.0",
+        "sass": "^1.72.0",
         "sass-loader": "^14.1.0",
         "source-map-loader": "^5.0.0",
         "style-loader": "^3.3.4",
@@ -50,7 +50,7 @@
         "tslint-react": "^5.0.0",
         "typescript": "^5.3.3",
         "url-loader": "^4.1.1",
-        "webpack": "^5.90.2",
+        "webpack": "^5.91.0",
         "webpack-cli": "^5.1.4",
         "webpack-dev-server": "^5.0.2",
         "webpack-merge": "^5.10.0"

--- a/src/Moryx.CommandCenter.Web/package.json
+++ b/src/Moryx.CommandCenter.Web/package.json
@@ -5,7 +5,7 @@
     "main": "index.js",
     "scripts": {
         "start": "npm dev",
-        "dev": "webpack-dev-server --watch --progress --mode development --config webpack.dev.config.js",
+        "dev": "webpack-dev-server --progress --mode development --config webpack.dev.config.js",
         "test": "echo \"Error: no test specified\" && exit 1",
         "build": "npm install && rimraf wwwroot/*.js && webpack --mode production --config webpack.prod.config.js"
     },

--- a/src/Moryx.CommandCenter.Web/src/common/components/Menu/RoutingMenuItem.tsx
+++ b/src/Moryx.CommandCenter.Web/src/common/components/Menu/RoutingMenuItem.tsx
@@ -44,10 +44,20 @@ function RoutingMenuItem(props: MenuItemProps) {
         }
     };
 
-    const isActive = isOpened(location);
+    const isActive = (location: Location): boolean => {
+        // Path has to be equal to be 'active' or must be a sub path (following
+        // after a `/`). Otherwise, with similar entries, multiple list items
+        // could be highlighted. E.g.: 'Orders' and 'OrdersSimulator' would both
+        // match the condition of `OrdersSimulator.startsWith(Orders)`.
+        return location.pathname === props.MenuItem.NavPath
+           || (location.pathname.startsWith(props.MenuItem.NavPath)
+                && location.pathname.replace(props.MenuItem.NavPath, "")[0] === "/");
+    };
+
+    const isLocationActive = isActive(location);
 
     return (
-        <ListGroupItem active={isActive} className="menu-item" onClick={(e: React.MouseEvent<HTMLElement>) => handleMenuItemClick(e)}>
+        <ListGroupItem active={isLocationActive} className="menu-item" onClick={(e: React.MouseEvent<HTMLElement>) => handleMenuItemClick(e)}>
             <Link to={props.MenuItem.NavPath}>
                 {props.MenuItem.Name}
             </Link>

--- a/src/Moryx.CommandCenter.Web/src/databases/container/DatabaseModel.tsx
+++ b/src/Moryx.CommandCenter.Web/src/databases/container/DatabaseModel.tsx
@@ -54,7 +54,7 @@ class DatabaseModel extends React.Component<DatabaseModelPropsModel & DatabaseMo
         super(props);
         this.state = {
             activeTab: "1",
-            config: this.getConfigValue(),
+            config: this.props.DataModel.config,
             selectedMigration: (this.props.DataModel.availableMigrations.length !== 0 ? this.props.DataModel.availableMigrations[0].name : ""),
             selectedSetup: (this.props.DataModel.setups.length !== 0 ? 0 : -1),
             selectedBackup: (this.props.DataModel.backups.length !== 0 ? this.props.DataModel.backups[0].fileName : ""),
@@ -101,8 +101,9 @@ class DatabaseModel extends React.Component<DatabaseModelPropsModel & DatabaseMo
     }
 
     public onInputChanged(e: React.FormEvent<HTMLInputElement>, entryName: string): void {
+        this.props.DataModel.config.entries[entryName] = (e.target as HTMLSelectElement).value
         this.setState({
-            config: { ...this.state.config, entries: { ...this.state.config.entries, [entryName]: (e.target as HTMLSelectElement).value } }
+            config: { ...this.props.DataModel.config }
         });
     }
 
@@ -111,9 +112,9 @@ class DatabaseModel extends React.Component<DatabaseModelPropsModel & DatabaseMo
     }
 
     public createEntriesInput() {
-        return Object.keys(this.state.config.entries)?.map((element) => {
+        return Object.keys(this.props.DataModel.config.entries)?.map((element) => {
             return (<Col md={12} className="up-space">
-                <Input placeholder={element} {...this.getValidationState(element)} value={this.state.config.entries[element]} onBlur={() => this.onTestConnection()} onChange={(e: React.FormEvent<HTMLInputElement>) => this.onInputChanged(e, element)} />
+                <Input placeholder={element} {...this.getValidationState(element)} value={this.props.DataModel.config.entries[element]} onBlur={() => this.onTestConnection()} onChange={(e: React.FormEvent<HTMLInputElement>) => this.onInputChanged(e, element)} />
             </Col>);
         });
     }
@@ -134,7 +135,7 @@ class DatabaseModel extends React.Component<DatabaseModelPropsModel & DatabaseMo
         return newEntries;
     }
 
-    public getConfigValue() {
+    public getConfigValue(): DatabaseConfigModel {
         return {
             ...this.props.DataModel.config,
             entries: this.props.DataModel.config.entries ?
@@ -333,11 +334,11 @@ class DatabaseModel extends React.Component<DatabaseModelPropsModel & DatabaseMo
                                     <Row >
                                         <Col md={12}>
                                             <Input type="select" placeholder="Configurator Type Name" onChange={(e: React.FormEvent<HTMLInputElement>) => this.onConfiguratorTypeChanged(e)}
-                                                value={this.state.config.configuratorTypename} onBlur={() => this.onTestConnection()}>
+                                                value={this.props.DataModel.config.configuratorTypename} onBlur={() => this.onTestConnection()}>
                                                 {this.props.DataModel.possibleConfigurators.map((config, idx) => (<option key={idx} value={config.configuratorTypename}>{config.name}</option>))}
                                             </Input>
                                         </Col>
-                                        {this.state.config.configuratorTypename && this.createEntriesInput()}
+                                        {this.props.DataModel.config.configuratorTypename && this.createEntriesInput()}
                                     </Row>
                                     <Row className="up-space-lg">
                                         <Col md={12}>

--- a/src/Moryx.CommandCenter.Web/src/modules/components/ConsoleMethodConfigurator.tsx
+++ b/src/Moryx.CommandCenter.Web/src/modules/components/ConsoleMethodConfigurator.tsx
@@ -16,9 +16,6 @@ export interface ConsoleMethodConfiguratorPropModel {
 }
 
 function ConsoleMethodConfigurator(props: ConsoleMethodConfiguratorPropModel) {
-    const navigate = useNavigate();
-    const location = useLocation();
-
     const invokeSelectedMethod = (): void => {
         props.onInvokeMethod(props.Method);
     };

--- a/src/Moryx.CommandCenter.Web/src/modules/components/ConsoleMethodResult.tsx
+++ b/src/Moryx.CommandCenter.Web/src/modules/components/ConsoleMethodResult.tsx
@@ -17,9 +17,6 @@ export interface ConsoleMethodResultPropModel {
 }
 
 function ConsoleMethodResult(props: ConsoleMethodResultPropModel) {
-    const navigate = useNavigate();
-    const location = useLocation();
-
     const resetInvokeResult = (): void => {
         props.onResetInvokeResult(props.Method.name);
     };

--- a/src/Moryx.CommandCenter.Web/src/modules/container/ModuleConfiguration.tsx
+++ b/src/Moryx.CommandCenter.Web/src/modules/container/ModuleConfiguration.tsx
@@ -30,7 +30,6 @@ interface ModuleConfigurationStateModel {
 
 function ModuleConfiguration(props: ModuleConfigurationPropModel) {
     const navigate = useNavigate();
-    const location = useLocation();
 
     const config = new Config();
     config.module = props.ModuleName;

--- a/src/Moryx.CommandCenter.Web/webpack.config.js
+++ b/src/Moryx.CommandCenter.Web/webpack.config.js
@@ -17,7 +17,7 @@ module.exports = (env, options) => {
         },
 
         devServer: {
-            contentBase: __dirname + "/wwwroot"
+            static: __dirname + "/wwwroot"
         },
 
         resolve: {

--- a/src/Moryx.Products.Management/Implementation/RecipeStorage.cs
+++ b/src/Moryx.Products.Management/Implementation/RecipeStorage.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.Eventing.Reader;
 using System.Drawing;
 using System.Linq;
 using Moryx.AbstractionLayer;
@@ -137,7 +138,7 @@ namespace Moryx.Products.Management
 
                 // Restore parameters from JSON
                 if (step is ITaskStep<IParameters> taskStep)
-                    JsonConvert.PopulateObject(stepEntity.Parameters, taskStep.Parameters);
+                    PopulateStepParameters(stepEntity, taskStep);
 
                 // Restore Subworkplan if necessary
                 if (step is ISubworkplanStep subworkplanStep)
@@ -151,6 +152,16 @@ namespace Moryx.Products.Management
             }
 
             return steps;
+        }
+
+        private static void PopulateStepParameters(WorkplanStepEntity stepEntity, ITaskStep<IParameters> taskStep)
+        {
+            if (taskStep.Parameters is null)
+                throw new InvalidOperationException($"{nameof(taskStep.Parameters)} could not " +
+                    $"be populated from the database. Make sure the property of {taskStep.GetType()} " +
+                    $"is initilized on instance creation.");
+            else
+                JsonConvert.PopulateObject(stepEntity.Parameters, taskStep.Parameters);
         }
 
         /// <summary>


### PR DESCRIPTION
Input fields of database connection switch properly now, when clicking throug database contexts.

When reviewing, it would be greate if you could test that this fix didn't break anything else.