### PR TITLE
Fix the path for the HTTP request for database migrations

### DIFF
--- a/src/Moryx.CommandCenter.Web/src/databases/api/DatabasesRestClient.ts
+++ b/src/Moryx.CommandCenter.Web/src/databases/api/DatabasesRestClient.ts
@@ -54,7 +54,7 @@ export default class DatabasesRestClient extends RestClientBase {
     }
 
     public applyMigration(targetModel: string, migrationName: string, request: DatabaseConfigModel): Promise<DatabaseUpdateSummary> {
-        return this.post<DatabaseConfigModel, DatabaseUpdateSummary>(DatabasesRestClient.pathTo(targetModel, `/${migrationName}/migrate`), request, new DatabaseUpdateSummary());
+        return this.post<DatabaseConfigModel, DatabaseUpdateSummary>(DatabasesRestClient.pathTo(targetModel, `/migrate`), request, new DatabaseUpdateSummary());
     }
 
     public rollbackDatabase(targetModel: string, request: DatabaseConfigModel): Promise<InvocationResponse> {


### PR DESCRIPTION
This fix only changes the path to `{targetModel}/migrate` which applies all migrations. It does not address the UI, which gives the impression, that one would apply 'all up to' a single migrations.

