### PR TITLE
Exclude interfaces based on generic interfaces in proxy creation

### DIFF
--- a/src/Moryx.Resources.Management/Resources/ResourceTypeController.cs
+++ b/src/Moryx.Resources.Management/Resources/ResourceTypeController.cs
@@ -137,7 +137,7 @@ namespace Moryx.Resources.Management
 
         public Resource Create(string type)
         {
-            if(!_typeCache.ContainsKey(type))
+            if (!_typeCache.ContainsKey(type))
                 throw new KeyNotFoundException($"No resource of type {type} found!");
 
             var linker = _typeCache[type];
@@ -337,6 +337,10 @@ namespace Moryx.Resources.Management
                 return true;
 
             if (resourceInterface.GetMethods().Any(method => method.IsGenericMethod || method.ContainsGenericParameters))
+                return true;
+
+            // We also need to filter all interfaces that contain/inherit generic interfaces
+            if (resourceInterface.GetInterfaces().Any(IsGenericResourceInterface))
                 return true;
 
             return false;

--- a/src/Tests/Moryx.Resources.Management.Tests/Mocks/ResourceWithGenericMethod.cs
+++ b/src/Tests/Moryx.Resources.Management.Tests/Mocks/ResourceWithGenericMethod.cs
@@ -19,11 +19,18 @@ namespace Moryx.Resources.Management.Tests
         IList<TChannel> GenericMethod<TChannel>(string identifier);
     }
 
-    public class ResourceWithGenericMethod : Resource, IGenericMethodCall, ISimpleResource
+    public interface IDerivedFromGeneric : IGenericMethodCall
+    {
+        bool SkippedByInheritance { get; }
+    }
+
+    public class ResourceWithGenericMethod : Resource, IGenericMethodCall, ISimpleResource, IDerivedFromGeneric
     {
         public int Foo { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
 
         public ICapabilities Capabilities => throw new NotImplementedException();
+
+        public bool SkippedByInheritance => throw new NotImplementedException();
 
         public event EventHandler<int> FooChanged;
         public event EventHandler<bool> FooEven;


### PR DESCRIPTION
In #344 we filtered generic interfaces in proxy creation, however an interface that contained a generic was not filtered.

E.g.

````cs
public interface IGenericInterface : IResource
{
     T GetSomeT<T>();
}

public IContainsGeneric : IGenericInterface
{
}
````

Since we filtered `IGenericInterface`, but not `IContainsGeneric ` the ProxyBuilder threw an exception for a missing implementation.