### PR TITLE
Prevent hidden config values from being rendered

### DIFF
--- a/src/Moryx.CommandCenter.Web/src/modules/components/ConfigEditor/ClassEditor.tsx
+++ b/src/Moryx.CommandCenter.Web/src/modules/components/ConfigEditor/ClassEditor.tsx
@@ -30,9 +30,12 @@ export default class ClassEditor extends CollapsibleEntryEditorBase<ClassEditorS
         return (
             <div>
                 <Collapse in={this.props.IsExpanded}>
-                    <Container style={{paddingRight: "0"}}>
-                        {this.preRenderConfigEditor()}
-                    </Container>
+                    {
+                        this.props.IsExpanded &&
+                        <Container style={{paddingRight: "0"}}>
+                            {this.preRenderConfigEditor()}
+                        </Container>
+                    }
                 </Collapse>
             </div>
         );

--- a/src/Moryx.CommandCenter.Web/src/modules/components/ConfigEditor/CollectionEditor.tsx
+++ b/src/Moryx.CommandCenter.Web/src/modules/components/ConfigEditor/CollectionEditor.tsx
@@ -128,7 +128,7 @@ export default class CollectionEditor extends CollapsibleEntryEditorBase<Collect
         return (
             <Collapse in={this.props.IsExpanded}>
                 <Grid container={true} item={true} sx={{paddingLeft: 3, paddingRight: 0}}>
-                    {
+                    {   this.props.IsExpanded &&
                         this.props.Entry.subEntries.map((entry, idx) => {
                             if (Entry.isClassOrCollection(entry)) {
                                 return (


### PR DESCRIPTION
The contents of `CollectionEditor` and `ClassEditor` shouldn't get rendered unless they are visible, i.e. expanded.

This prevents the UI from loading for a long time with huge configurations.

