### PR TITLE
NUnit Test Tools

### DIFF
--- a/MORYX-Framework.sln
+++ b/MORYX-Framework.sln
@@ -116,7 +116,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Moryx.Resources.Management.
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Moryx.Runtime.Endpoints.Tests", "src\Tests\Moryx.Runtime.Endpoints.Tests\Moryx.Runtime.Endpoints.Tests.csproj", "{7792C4E0-6D07-42C9-AC29-BAB76836FC11}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Moryx.Runtime.Endpoints.IntegrationTests", "src\Tests\Moryx.Runtime.Endpoints.IntegrationTests\Moryx.Runtime.Endpoints.IntegrationTests.csproj", "{4FFB98A7-9A4C-476F-8BCC-C19B7F757BF8}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Moryx.Runtime.Endpoints.IntegrationTests", "src\Tests\Moryx.Runtime.Endpoints.IntegrationTests\Moryx.Runtime.Endpoints.IntegrationTests.csproj", "{4FFB98A7-9A4C-476F-8BCC-C19B7F757BF8}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Moryx.TestTools.NUnit", "src\Moryx.TestTools.NUnit\Moryx.TestTools.NUnit.csproj", "{6FF878E0-AF61-4C3A-9B9C-71C35A949E51}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -296,6 +298,10 @@ Global
 		{4FFB98A7-9A4C-476F-8BCC-C19B7F757BF8}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{4FFB98A7-9A4C-476F-8BCC-C19B7F757BF8}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{4FFB98A7-9A4C-476F-8BCC-C19B7F757BF8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6FF878E0-AF61-4C3A-9B9C-71C35A949E51}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6FF878E0-AF61-4C3A-9B9C-71C35A949E51}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6FF878E0-AF61-4C3A-9B9C-71C35A949E51}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6FF878E0-AF61-4C3A-9B9C-71C35A949E51}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -340,10 +346,11 @@ Global
 		{FEB3BA44-2CD9-445A-ABF2-C92378C443F7} = {0A466330-6ED6-4861-9C94-31B1949CDDB9}
 		{7792C4E0-6D07-42C9-AC29-BAB76836FC11} = {0A466330-6ED6-4861-9C94-31B1949CDDB9}
 		{4FFB98A7-9A4C-476F-8BCC-C19B7F757BF8} = {8517D209-5BC1-47BD-A7C7-9CF9ADD9F5B6}
+		{6FF878E0-AF61-4C3A-9B9C-71C35A949E51} = {953AAE25-26C8-4A28-AB08-61BAFE41B22F}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
-		SolutionGuid = {36EFC961-F4E7-49DC-A36A-99594FFB8243}		
-		RESX_TaskErrorCategory = Message
 		    RESX_ShowErrorsInErrorList = True
+		RESX_TaskErrorCategory = Message
+		SolutionGuid = {36EFC961-F4E7-49DC-A36A-99594FFB8243}		
 	EndGlobalSection
 EndGlobal

--- a/src/Moryx.TestTools.NUnit/MAssert.cs
+++ b/src/Moryx.TestTools.NUnit/MAssert.cs
@@ -1,0 +1,54 @@
+﻿using NUnit.Framework;
+using NUnit.Framework.Constraints;
+using NUnit.Framework.Internal;
+using System;
+using System.Linq.Expressions;
+using System.Runtime.CompilerServices;
+using System.Text.RegularExpressions;
+using System.Xml.Linq;
+
+namespace Moryx.TestTools.NUnit
+{
+    public abstract class MAssert
+    {
+        public static void That(bool condition, string? message = null, [CallerArgumentExpression(nameof(condition))] string? predicateExpression = null)
+        {
+            That(condition, Is.True, message, predicateExpression);
+        }
+        public static void That(Func<bool> predicate, string? message = null, [CallerArgumentExpression(nameof(predicate))]string? predicateExpression = null)
+        {
+            That(predicate, Is.True, message, predicateExpression);
+        }
+
+        public static void That<T>(T actual, IResolveConstraint constraint, string? message = null, [CallerArgumentExpression(nameof(actual))] string? predicateExpression = null)
+        {
+            if (message != null)
+            {
+                message = $"{message}\nExpression: {predicateExpression}";
+            }
+            else
+            {
+                message = predicateExpression;
+            }
+            Assert.That(actual, constraint, message);
+        }
+
+        public static void That<T>(Func<T> actualExpression, Constraint constraint, string? message = null, [CallerArgumentExpression(nameof(actualExpression))] string? predicateExpression = null)
+        {
+            if (message != null)
+            {
+                message = $"{message}\nExpression: {predicateExpression}";
+            }
+            else
+            {
+                message = predicateExpression;
+            }
+            int fails = TestExecutionContext.CurrentContext.CurrentResult.PendingFailures;
+            T value = default(T)!; 
+            Assert.That<T>(() => value = actualExpression(), new ThrowsNothingConstraint(), $"{message}\nExpected {constraint.Description} and");
+            if (TestExecutionContext.CurrentContext.CurrentResult.PendingFailures > fails) return; // TODO: Check if we there could be multithreading issues and whether or not we care
+            Assert.That(value, constraint, message);
+        }
+    }
+
+}

--- a/src/Moryx.TestTools.NUnit/Moryx.TestTools.NUnit.csproj
+++ b/src/Moryx.TestTools.NUnit/Moryx.TestTools.NUnit.csproj
@@ -1,0 +1,13 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="NUnit" />
+    </ItemGroup>
+
+</Project>

--- a/src/Tests/Moryx.Tests/Moryx.Tests.csproj
+++ b/src/Tests/Moryx.Tests/Moryx.Tests.csproj
@@ -14,6 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\Moryx.TestTools.NUnit\Moryx.TestTools.NUnit.csproj" />
     <ProjectReference Include="..\..\Moryx\Moryx.csproj" />
   </ItemGroup>
 

--- a/src/Tests/Moryx.Tests/Workplans/TransitionTests.cs
+++ b/src/Tests/Moryx.Tests/Workplans/TransitionTests.cs
@@ -1,8 +1,10 @@
 // Copyright (c) 2023, Phoenix Contact GmbH & Co. KG
 // Licensed under the Apache License, Version 2.0
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
+using Moryx.TestTools.NUnit;
 using Moryx.Workplans;
 using Moryx.Workplans.Transitions;
 using NUnit.Framework;
@@ -56,14 +58,15 @@ namespace Moryx.Tests.Workplans
             // Act
             trans.Initialize();
             _inputs[0].Add(_token);
-
+            
             // Assert
-            Assert.AreEqual(0, _inputs[0].Tokens.Count());
-            Assert.IsTrue(_outputs.All(o => o.Tokens.Count() == 1));
-            Assert.IsInstanceOf<SplitToken>(_outputs[0].Tokens.First());
-            Assert.IsInstanceOf<SplitToken>(_outputs[1].Tokens.First());
-            Assert.AreEqual(_token, ((SplitToken)_outputs[0].Tokens.First()).Original);
-            Assert.AreEqual(_token, ((SplitToken)_outputs[1].Tokens.First()).Original);
+            Assert.Multiple(() =>
+            {
+                MAssert.That(_inputs[0].Tokens, Is.Empty);
+                MAssert.That(_outputs.Select(o => o.Tokens), Has.All.Count.EqualTo(1));
+                MAssert.That(() => ((SplitToken)_outputs[0].Tokens.First()).Original, Is.EqualTo(_token));
+                MAssert.That(() => ((SplitToken)_outputs[1].Tokens.First()).Original, Is.EqualTo(_token));
+            });
         }
 
         [Test]
@@ -83,11 +86,13 @@ namespace Moryx.Tests.Workplans
             trans.Initialize();
             _inputs[0].Add(split1);
             _inputs[1].Add(split2);
-
             // Assert
-            Assert.IsTrue(_inputs.All(i => !i.Tokens.Any()));
-            Assert.AreEqual(1, _outputs[0].Tokens.Count());
-            Assert.AreEqual(_token, _outputs[0].Tokens.First());
+            Assert.Multiple(() =>
+            {
+                MAssert.That(_inputs.All(i => !i.Tokens.Any()));
+                MAssert.That(_outputs[0].Tokens.Count(), Is.EqualTo(1), "The split token should be joined into one");
+                MAssert.That(_outputs[0].Tokens.First(), Is.EqualTo(_token));
+            });
         }
 
         [TestCase(0, Description = "Place only one split token on the first input")]
@@ -108,9 +113,12 @@ namespace Moryx.Tests.Workplans
             _inputs[index].Add(split);
 
             // Assert
-            Assert.AreEqual(1, _inputs[index].Tokens.Count());
-            Assert.AreEqual(0, _inputs[(index + 1) % 2].Tokens.Count());
-            Assert.AreEqual(0, _outputs[0].Tokens.Count());
+            Assert.Multiple(() =>
+            {
+                MAssert.That(_inputs[index].Tokens, Has.Count.EqualTo(1));
+                MAssert.That(_inputs[(index + 1) % 2].Tokens, Is.Empty);
+                MAssert.That(_outputs[0].Tokens, Is.Empty);
+            });
         }
 
         [Test]
@@ -138,10 +146,12 @@ namespace Moryx.Tests.Workplans
             _inputs[0].Add(_token);
 
             // Assert
-            Assert.AreEqual(0, _inputs[0].Tokens.Count());
-            Assert.AreEqual(_token, _outputs[0].Tokens.First());
-            Assert.AreEqual(2, triggered.Count);
-            Assert.IsTrue(triggered.All(t => t is DummyTransition));
+            Assert.Multiple(() => { 
+                MAssert.That(_inputs[0].Tokens, Is.Empty);
+                MAssert.That(_outputs[0].Tokens.First(), Is.EqualTo(_token));
+                MAssert.That(triggered.Count, Is.EqualTo(2));
+                MAssert.That(triggered, Has.All.InstanceOf<DummyTransition>());
+            });
         }
 
         [Test]
@@ -171,14 +181,17 @@ namespace Moryx.Tests.Workplans
             trans.Resume();
 
             // Assert
-            Assert.AreEqual(0, _inputs[0].Tokens.Count());
-            Assert.AreEqual(_token, _outputs[0].Tokens.First());
-            Assert.AreEqual(1, triggered.Count);
-            Assert.IsInstanceOf<WorkplanSnapshot>(state);
-            var snapshot = (WorkplanSnapshot)state;
-            Assert.AreEqual(1, snapshot.Holders.Length);
-            var stepId = workplan.Steps.First(s => s is PausableStep).Id;
-            Assert.AreEqual(stepId, snapshot.Holders[0].HolderId);
+            Assert.Multiple(() =>
+            {
+                MAssert.That(_inputs[0].Tokens, Is.Empty);
+                MAssert.That(_outputs[0].Tokens.First(), Is.EqualTo(_token));
+                MAssert.That(triggered, Has.Count.Zero);
+                MAssert.That(state, Is.InstanceOf<WorkplanSnapshot>());
+                var snapshot = (WorkplanSnapshot)state;
+                MAssert.That(snapshot.Holders, Has.Count.EqualTo(1));
+                var stepId = workplan.Steps.First(s => s is PausableStep).Id;
+                MAssert.That(snapshot.Holders[0].HolderId, Is.EqualTo(stepId));
+            });
         }
     }
 }


### PR DESCRIPTION
## General idea

Given that test are often run in CICD Pipelines it is important to be able to interpret the test failures given the test reports.
To test complex behaviors properly we often have multiple assertions in a single test.

Unless a message is manually specified on an assert, the test report the report will have no meaningful details about the condition that failed and it's possible you have to rely on the line number to find the failed assertion.
Manual messages have further drawbacks like copy paste mistakes or not being maintained once the condition is changed.

The idea to solve this is to create a drop in replacement for NUnit `Assert.That` that gives more detailed test results.
It relies on the `CallerArgumentExpression` Attribute to get include the expression being tested in the test report.

The only scenario I know off where this is not a drop in replacement, is when the Assert has a message and format parameters.

## Changed behavior for functions/delegates
One maybe controversial, but in my eyes very helpful, aspect, is the handling of functions being passed into the test expression.
The test will implicitly Assert that the function does not throw and then check the return value with the given constraints.
This is helpful in `Assert.Multiple` blocks because later assertions can still be evaluated.

I think @seveneleven had a good analogy for this:
Given a text input field with validation logic it is very annoying if only the first broken rule is shown. 
We have to fix one rule at a time, only to discover the next broken rule. 

Given this functionality we only need to wrap expressions that can fail into a lambda and still check all the rules at the same time.