### PR TITLE
load type from database before raising TypeChange event

### DIFF
--- a/src/Moryx.AbstractionLayer.Products.Endpoints/ProductConverter.cs
+++ b/src/Moryx.AbstractionLayer.Products.Endpoints/ProductConverter.cs
@@ -270,16 +270,21 @@ namespace Moryx.AbstractionLayer.Products.Endpoints
                     continue;
 
                 var match = unused.Find(r => r.Id == partModel?.Id);
+                // new partlink
                 if (match == null)
                 {
                     match = (IProductPartLink)Activator.CreateInstance(elemType);
+                    match.Product = _productManagement.LoadType(partModel.Product.Id);
                     value.Add(match);
                 }
+                //modified reference
+                else if (match.Product.Id != partModel.Product.Id)
+                    match.Product = _productManagement.LoadType(partModel.Product.Id);
                 else
+                 //part removed
                     unused.Remove(match);
 
                 EntryConvert.UpdateInstance(match, partModel.Properties);
-                match.Product = _productManagement.LoadType(partModel.Product.Id);
             }
 
             // Clear all values no longer present in the model

--- a/src/Moryx.Products.Management/Implementation/ProductManager.cs
+++ b/src/Moryx.Products.Management/Implementation/ProductManager.cs
@@ -79,7 +79,10 @@ namespace Moryx.Products.Management
         public long SaveType(IProductType modifiedInstance)
         {
             var saved = Storage.SaveType(modifiedInstance);
-            RaiseProductChanged(modifiedInstance);
+            //reload the object for correct references
+            var loadedType = Storage.LoadType(saved);
+            RaiseProductChanged(loadedType);
+
             return saved;
         }
 

--- a/src/Tests/Moryx.Products.Management.Tests/ProductConverterTests.cs
+++ b/src/Tests/Moryx.Products.Management.Tests/ProductConverterTests.cs
@@ -129,10 +129,7 @@ namespace Moryx.AbstractionLayer.Products.Endpoints.Tests
             // - If there are ProductPartLinks the ProductManagement should be called
             var targetDummyTypeWithParts = recoveredOriginal as DummyProductTypeWithParts;
             if (targetDummyTypeWithParts?.ProductPartLink?.Product is not null)
-            {
                 _productManagerMock.Verify(pm => pm.LoadType(targetDummyTypeWithParts.ProductPartLink.Product.Id));
-                _productManagerMock.Verify(pm => pm.LoadType(targetDummyTypeWithParts.ProductPartLinkEnumerable.First().Product.Id));
-            }
         }
 
         private static bool HasChangedProperties<T>(object A, object B)


### PR DESCRIPTION
TypeChanged event does not provide "singleton" types when saving via UI

- load product type form database before raising the TypeChangedEvent
- update how to set references if a part was: `added` `modified` and `removed`