### PR TITLE
Fix repository validation for inverted type list

### DIFF
--- a/src/Moryx.Model/Repositories/Proxy/RepositoryProxyBuilder.cs
+++ b/src/Moryx.Model/Repositories/Proxy/RepositoryProxyBuilder.cs
@@ -48,7 +48,7 @@ namespace Moryx.Model.Repositories.Proxy
         public Type Build(Type repoApi)
         {
             // Check interface
-            ValidateRepositoryApi(repoApi, false);
+            ValidateRepositoryApi(repoApi);
 
             var proxyName = CreateProxyName(repoApi);
 
@@ -89,7 +89,7 @@ namespace Moryx.Model.Repositories.Proxy
         public Type Build(Type repoApi, Type repoImpl)
         {
             // Check interface
-            ValidateRepositoryApi(repoApi, false);
+            ValidateRepositoryApi(repoApi);
 
             var proxyName = CreateProxyName(repoImpl);
 
@@ -201,7 +201,7 @@ namespace Moryx.Model.Repositories.Proxy
             return typeof(IModificationTrackedEntity).IsAssignableFrom(entityType);
         }
 
-        private static void ValidateRepositoryApi(Type repoApi, bool additionalApis)
+        private static void ValidateRepositoryApi(Type repoApi)
         {
             if (!repoApi.IsInterface)
             {
@@ -209,11 +209,7 @@ namespace Moryx.Model.Repositories.Proxy
             }
 
             var repoInterfaces = repoApi.GetInterfaces();
-            if (additionalApis && (repoInterfaces.Length > 2 || repoInterfaces.First().GetGenericTypeDefinition() != typeof(IRepository<>)))
-            {
-                throw new InvalidOperationException($"'{repoApi.Name}' API does not inherit from IRepository<T>");
-            }
-            else if (repoInterfaces.Length != 2 || repoInterfaces.First().GetGenericTypeDefinition() != typeof(IRepository<>))
+            if (!repoInterfaces.Any(rI => rI.IsGenericType && rI.GetGenericTypeDefinition() == typeof(IRepository<>)))
             {
                 throw new InvalidOperationException($"'{repoApi.Name}' API does not inherit from IRepository<T>");
             }


### PR DESCRIPTION
Our validation assumed, that the generic interface `IRepository<T>` is **always** the first one in the list, which to my suprise was the case for years. Somehow the licensing obfuscation finally identified that false assumption. This changes the validation to be independent of type order.