### PR TITLE
Extend PossibleValuesAttribute with ServiceProvider

### DIFF
--- a/docs/articles/Core/Serialization/PossibleValues.md
+++ b/docs/articles/Core/Serialization/PossibleValues.md
@@ -26,15 +26,15 @@ public abstract class PossibleValuesAttribute : Attribute
     public abstract bool UpdateFromPredecessor { get; }
 
     /// <summary>
-    /// All possible values for this member represented as strings. The given container might be null
+    /// All possible values for this member represented as strings. The given containers might be null
     /// and can be used to resolve possible values
     /// </summary>
-    public abstract IEnumerable<string> GetValues(IContainer container);
+    public virtual IEnumerable<string> GetValues(IContainer container, IServiceProvider serviceProvider);
 
     /// <summary>
     /// String to value conversion. Must be override if <see cref="OverridesConversion"/> is set to true"/>
     /// </summary>
-    public virtual object Parse(IContainer container, string value)
+    public virtual object Parse(IContainer container, IServiceProvider serviceProvider), string value)
     {
        return value;
     }

--- a/src/Moryx.AbstractionLayer.Products.Endpoints/Moryx.AbstractionLayer.Products.Endpoints.csproj
+++ b/src/Moryx.AbstractionLayer.Products.Endpoints/Moryx.AbstractionLayer.Products.Endpoints.csproj
@@ -15,6 +15,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Moryx.AbstractionLayer\Moryx.AbstractionLayer.csproj" />
 	<ProjectReference Include="..\Moryx.Asp.Extensions\Moryx.Asp.Extensions.csproj" />
+	<ProjectReference Include="..\Moryx.Runtime\Moryx.Runtime.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Moryx.AbstractionLayer.Products.Endpoints/PartialSerialization.cs
+++ b/src/Moryx.AbstractionLayer.Products.Endpoints/PartialSerialization.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using Moryx.Configuration;
+using Moryx.Container;
 using Moryx.Serialization;
 
 namespace Moryx.AbstractionLayer.Products.Endpoints
@@ -28,7 +29,21 @@ namespace Moryx.AbstractionLayer.Products.Endpoints
             _serialization = new EntrySerializeSerialization();
         }
 
-        public PartialSerialization() : base(null, new EmptyValueProvider())
+        /// <summary>
+        /// Creates a new <see cref="PartialSerialization{T}"/>  instance
+        /// </summary>
+        [Obsolete("Use serialization with containers instead")]
+        public PartialSerialization() : this(null, null)
+        {
+        }
+
+        /// <summary>
+        /// Create serialization with access to global and local container
+        /// </summary>
+        /// <param name="localContainer"></param>
+        /// <param name="serviceProvider"></param>
+        public PartialSerialization(IContainer localContainer, IServiceProvider serviceProvider) 
+            : base(localContainer, serviceProvider, new EmptyValueProvider())
         {
         }
 

--- a/src/Moryx.AbstractionLayer.Products.Endpoints/ProductConverter.cs
+++ b/src/Moryx.AbstractionLayer.Products.Endpoints/ProductConverter.cs
@@ -326,7 +326,12 @@ namespace Moryx.AbstractionLayer.Products.Endpoints
             }
         }
 
-        public RecipeModel ConvertRecipe(IRecipe recipe)
+        [Obsolete("Use ConvertRecipe on instance")]
+        public static RecipeModel ConvertRecipe(IRecipe recipe) => ConvertRecipe(recipe, new PartialSerialization<ProductionRecipe>(null, null));
+
+        public RecipeModel ConvertRecipeV2(IRecipe recipe) => ConvertRecipe(recipe, _recipeSerialization);
+
+        private static RecipeModel ConvertRecipe(IRecipe recipe, ICustomSerialization serialization)
         {
             // Transform to DTO and transmit
             var converted = new RecipeModel
@@ -336,7 +341,7 @@ namespace Moryx.AbstractionLayer.Products.Endpoints
                 Type = recipe.GetType().Name,
                 State = recipe.State,
                 Revision = recipe.Revision,
-                Properties = EntryConvert.EncodeObject(recipe, _recipeSerialization),
+                Properties = EntryConvert.EncodeObject(recipe, serialization),
                 IsClone = recipe.Classification.HasFlag(RecipeClassification.Clone)
             };
 

--- a/src/Moryx.AbstractionLayer.Products.Endpoints/ProductConverter.cs
+++ b/src/Moryx.AbstractionLayer.Products.Endpoints/ProductConverter.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0
 
 using Moryx.AbstractionLayer.Recipes;
+using Moryx.Container;
 using Moryx.Serialization;
 using Moryx.Tools;
 using Moryx.Workplans;
@@ -20,12 +21,19 @@ namespace Moryx.AbstractionLayer.Products.Endpoints
         // Null object pattern for identity
         private static readonly ProductIdentity EmptyIdentity = new ProductIdentity(string.Empty, 0);
 
-        private static readonly ICustomSerialization ProductSerialization = new PartialSerialization<ProductType>();
-        private static readonly ICustomSerialization RecipeSerialization = new PartialSerialization<ProductionRecipe>();
+        private readonly ICustomSerialization _productSerialization;
+        private readonly ICustomSerialization _recipeSerialization;
 
-        public ProductConverter(IProductManagement productManagement)
+        public IContainer ProductManagerContainer { get; }
+        public IServiceProvider GlobalContainer { get; }
+
+        public ProductConverter(IProductManagement productManagement, IContainer localContainer, IServiceProvider globalContainer)
         {
             _productManagement = productManagement;
+            ProductManagerContainer = localContainer;
+            GlobalContainer = globalContainer;
+            _productSerialization = new PartialSerialization<ProductType>(localContainer, globalContainer);
+            _recipeSerialization = new PartialSerialization<ProductionRecipe>(localContainer, globalContainer);
         }
 
         public ProductDefinitionModel ConvertProductType(Type productType)
@@ -39,7 +47,7 @@ namespace Moryx.AbstractionLayer.Products.Endpoints
                 Name = productType.FullName,
                 DisplayName = productType.GetDisplayName() ?? productType.Name,
                 BaseDefinition = baseTypeName,
-                Properties = EntryConvert.EncodeClass(productType, ProductSerialization)
+                Properties = EntryConvert.EncodeClass(productType, _productSerialization)
             };
         }
 
@@ -73,7 +81,7 @@ namespace Moryx.AbstractionLayer.Products.Endpoints
             // Properties
             var typeWrapper = _productManagement.GetTypeWrapper(productType.GetType().FullName);
             var properties = typeWrapper != null ? typeWrapper.Properties.ToArray() : productType.GetType().GetProperties();
-            converted.Properties = EntryConvert.EncodeObject(productType, ProductSerialization);
+            converted.Properties = EntryConvert.EncodeObject(productType, _productSerialization);
 
             // Files         
             converted.Files = ConvertFiles(productType, properties);
@@ -124,7 +132,7 @@ namespace Moryx.AbstractionLayer.Products.Endpoints
                         DisplayName = displayName,
                         Type = FetchProductType(property.PropertyType),
                         Parts = partModel is null ? new PartModel[0] : new[] { partModel },
-                        PropertyTemplates = EntryConvert.EncodeClass(property.PropertyType, ProductSerialization)
+                        PropertyTemplates = EntryConvert.EncodeClass(property.PropertyType, _productSerialization)
                     };
                     connectors.Add(connector);
                 }
@@ -139,7 +147,7 @@ namespace Moryx.AbstractionLayer.Products.Endpoints
                         DisplayName = displayName,
                         Type = FetchProductType(linkType),
                         Parts = links?.Select(ConvertPart).ToArray(),
-                        PropertyTemplates = EntryConvert.EncodeClass(linkType, ProductSerialization)
+                        PropertyTemplates = EntryConvert.EncodeClass(linkType, _productSerialization)
                     };
                     connectors.Add(connector);
                 }
@@ -165,7 +173,7 @@ namespace Moryx.AbstractionLayer.Products.Endpoints
             {
                 Id = link.Id,
                 Product = ConvertProduct(link.Product, true),
-                Properties = EntryConvert.EncodeObject(link, ProductSerialization)
+                Properties = EntryConvert.EncodeObject(link, _productSerialization)
             };
             return part;
         }
@@ -214,7 +222,7 @@ namespace Moryx.AbstractionLayer.Products.Endpoints
             // Copy extended properties
             var typeWrapper = _productManagement.GetTypeWrapper(converted.GetType().FullName);
             var properties = typeWrapper != null ? typeWrapper.Properties.ToArray() : converted.GetType().GetProperties();
-            EntryConvert.UpdateInstance(converted, source.Properties, ProductSerialization);
+            EntryConvert.UpdateInstance(converted, source.Properties, _productSerialization);
 
             // Copy Files
             ConvertFilesBack(converted, source, properties);
@@ -318,7 +326,7 @@ namespace Moryx.AbstractionLayer.Products.Endpoints
             }
         }
 
-        public static RecipeModel ConvertRecipe(IRecipe recipe)
+        public RecipeModel ConvertRecipe(IRecipe recipe)
         {
             // Transform to DTO and transmit
             var converted = new RecipeModel
@@ -328,7 +336,7 @@ namespace Moryx.AbstractionLayer.Products.Endpoints
                 Type = recipe.GetType().Name,
                 State = recipe.State,
                 Revision = recipe.Revision,
-                Properties = EntryConvert.EncodeObject(recipe, RecipeSerialization),
+                Properties = EntryConvert.EncodeObject(recipe, _recipeSerialization),
                 IsClone = recipe.Classification.HasFlag(RecipeClassification.Clone)
             };
 
@@ -377,7 +385,7 @@ namespace Moryx.AbstractionLayer.Products.Endpoints
                 productRecipe.Product = productType;
             }
 
-            EntryConvert.UpdateInstance(productRecipe, recipe.Properties, RecipeSerialization);
+            EntryConvert.UpdateInstance(productRecipe, recipe.Properties, _recipeSerialization);
 
             // Do not update a clones classification
             if (productRecipe.Classification.HasFlag(RecipeClassification.Clone))

--- a/src/Moryx.AbstractionLayer.Products.Endpoints/ProductManagementController.cs
+++ b/src/Moryx.AbstractionLayer.Products.Endpoints/ProductManagementController.cs
@@ -14,6 +14,11 @@ using Microsoft.AspNetCore.Authorization;
 using Moryx.Configuration;
 using Moryx.Asp.Extensions;
 using Moryx.AbstractionLayer.Properties;
+using Microsoft.Extensions.DependencyInjection;
+using Moryx.AbstractionLayer.Resources;
+using Moryx.Runtime.Modules;
+using System.ComponentModel;
+using Moryx.Runtime.Container;
 
 namespace Moryx.AbstractionLayer.Products.Endpoints
 {
@@ -27,10 +32,15 @@ namespace Moryx.AbstractionLayer.Products.Endpoints
     {
         private readonly IProductManagement _productManagement;
         private readonly ProductConverter _productConverter;
-        public ProductManagementController(IProductManagement productManagement)
+        public ProductManagementController(IProductManagement productManagement,
+            IModuleManager moduleManager,
+            IServiceProvider serviceProvider)
         {
             _productManagement = productManagement;
-            _productConverter = new ProductConverter(_productManagement);
+
+            var module = moduleManager.AllModules.FirstOrDefault(module => module is IFacadeContainer<IResourceManagement>);
+            var host = (IContainerHost)module;
+            _productConverter = new ProductConverter(_productManagement, host.Container, serviceProvider);
         }
 
         #region importers
@@ -39,6 +49,8 @@ namespace Moryx.AbstractionLayer.Products.Endpoints
         [Authorize(Policy = ProductPermissions.CanViewTypes)]
         public ActionResult<ProductCustomization> GetProductCustomization()
         {
+            var parameterSerialization = new PossibleValuesSerialization(_productConverter.ProductManagerContainer, _productConverter.GlobalContainer,
+                new ValueProviderExecutor(new ValueProviderExecutorSettings().AddDefaultValueProvider()));
             return new ProductCustomization
             {
                 ProductTypes = GetProductTypes(),
@@ -46,7 +58,7 @@ namespace Moryx.AbstractionLayer.Products.Endpoints
                 Importers = _productManagement.Importers.Select(i => new ProductImporter
                 {
                     Name = i.Key,
-                    Parameters = EntryConvert.EncodeObject(i.Value, new PossibleValuesSerialization(null, new ValueProviderExecutor(new ValueProviderExecutorSettings().AddDefaultValueProvider())))
+                    Parameters = EntryConvert.EncodeObject(i.Value, parameterSerialization) 
                 }).ToArray()
             };
         }
@@ -247,7 +259,7 @@ namespace Moryx.AbstractionLayer.Products.Endpoints
             var recipes = _productManagement.GetRecipes(productType, (RecipeClassification)classification);
             var recipeModels = new List<RecipeModel>();
             foreach (var recipe in recipes)
-                recipeModels.Add(ProductConverter.ConvertRecipe(recipe));
+                recipeModels.Add(_productConverter.ConvertRecipe(recipe));
             return recipeModels.ToArray();
         }
         #endregion
@@ -330,7 +342,7 @@ namespace Moryx.AbstractionLayer.Products.Endpoints
             var recipe = _productManagement.LoadRecipe(id);
             if (recipe == null)
                 return NotFound(new MoryxExceptionResponse {Title= string.Format(Strings.RecipeNotFoundException_Message, id) });
-            return ProductConverter.ConvertRecipe(recipe);
+            return _productConverter.ConvertRecipe(recipe);
         }
 
         [HttpPost]
@@ -380,7 +392,7 @@ namespace Moryx.AbstractionLayer.Products.Endpoints
             var recipe = _productManagement.CreateRecipe(recipeType);
             if (recipe == null)
                 recipe = (IProductRecipe)TypeTool.CreateInstance<IProductRecipe>(recipeType);
-            return ProductConverter.ConvertRecipe(recipe);
+            return _productConverter.ConvertRecipe(recipe);
         }
         #endregion
     }

--- a/src/Moryx.AbstractionLayer.Products.Endpoints/ProductManagementController.cs
+++ b/src/Moryx.AbstractionLayer.Products.Endpoints/ProductManagementController.cs
@@ -38,8 +38,8 @@ namespace Moryx.AbstractionLayer.Products.Endpoints
         {
             _productManagement = productManagement;
 
-            var module = moduleManager.AllModules.FirstOrDefault(module => module is IFacadeContainer<IResourceManagement>);
-            var host = (IContainerHost)module;
+            var module = moduleManager.AllModules.FirstOrDefault(module => module is IFacadeContainer<IProductManagement>);
+            var host = (IContainerHost)module;      
             _productConverter = new ProductConverter(_productManagement, host.Container, serviceProvider);
         }
 
@@ -259,7 +259,7 @@ namespace Moryx.AbstractionLayer.Products.Endpoints
             var recipes = _productManagement.GetRecipes(productType, (RecipeClassification)classification);
             var recipeModels = new List<RecipeModel>();
             foreach (var recipe in recipes)
-                recipeModels.Add(_productConverter.ConvertRecipe(recipe));
+                recipeModels.Add(_productConverter.ConvertRecipeV2(recipe));
             return recipeModels.ToArray();
         }
         #endregion
@@ -342,7 +342,7 @@ namespace Moryx.AbstractionLayer.Products.Endpoints
             var recipe = _productManagement.LoadRecipe(id);
             if (recipe == null)
                 return NotFound(new MoryxExceptionResponse {Title= string.Format(Strings.RecipeNotFoundException_Message, id) });
-            return _productConverter.ConvertRecipe(recipe);
+            return _productConverter.ConvertRecipeV2(recipe);
         }
 
         [HttpPost]
@@ -392,7 +392,7 @@ namespace Moryx.AbstractionLayer.Products.Endpoints
             var recipe = _productManagement.CreateRecipe(recipeType);
             if (recipe == null)
                 recipe = (IProductRecipe)TypeTool.CreateInstance<IProductRecipe>(recipeType);
-            return _productConverter.ConvertRecipe(recipe);
+            return _productConverter.ConvertRecipeV2(recipe);
         }
         #endregion
     }

--- a/src/Moryx.AbstractionLayer.Resources.Endpoints/ResourceManagementController.cs
+++ b/src/Moryx.AbstractionLayer.Resources.Endpoints/ResourceManagementController.cs
@@ -32,13 +32,16 @@ namespace Moryx.AbstractionLayer.Resources.Endpoints
         private readonly IResourceTypeTree _resourceTypeTree;
         private readonly ResourceSerialization _serialization;
 
-        public ResourceModificationController(IResourceManagement resourceManagement, IResourceTypeTree resourceTypeTree, IModuleManager moduleManager)
+        public ResourceModificationController(IResourceManagement resourceManagement, 
+            IResourceTypeTree resourceTypeTree, 
+            IModuleManager moduleManager,
+            IServiceProvider serviceProvider)
         {
             _resourceManagement = resourceManagement ?? throw new ArgumentNullException(nameof(resourceManagement));
             _resourceTypeTree = resourceTypeTree ?? throw new ArgumentNullException(nameof(resourceTypeTree));
             var module = moduleManager.AllModules.FirstOrDefault(module => module is IFacadeContainer<IResourceManagement>);
             var containerHost = (IContainerHost)module;
-            _serialization = new ResourceSerialization(containerHost.Container);
+            _serialization = new ResourceSerialization(containerHost.Container, serviceProvider);
         }
 
         [HttpGet]

--- a/src/Moryx.AbstractionLayer.Resources.Endpoints/ResourceSerialization.cs
+++ b/src/Moryx.AbstractionLayer.Resources.Endpoints/ResourceSerialization.cs
@@ -18,7 +18,7 @@ namespace Moryx.AbstractionLayer.Resources.Endpoints
         /// </summary>
         private EntrySerializeSerialization _memberFilter = new();
 
-        public ResourceSerialization(IContainer container) : base(container, new ValueProviderExecutor(new ValueProviderExecutorSettings()))
+        public ResourceSerialization(IContainer container, IServiceProvider serviceProvider) : base(container, serviceProvider, new ValueProviderExecutor(new ValueProviderExecutorSettings()))
         {
         }
 

--- a/src/Moryx.Products.Samples/Moryx.Products.Samples.csproj
+++ b/src/Moryx.Products.Samples/Moryx.Products.Samples.csproj
@@ -8,6 +8,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Moryx.AbstractionLayer\Moryx.AbstractionLayer.csproj" />
     <ProjectReference Include="..\Moryx.Products.Management\Moryx.Products.Management.csproj" />
+    <ProjectReference Include="..\Moryx.TestModule\Moryx.TestModule.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Moryx.Products.Samples/Recipe/FacacadeRecipeValueAttribute.cs
+++ b/src/Moryx.Products.Samples/Recipe/FacacadeRecipeValueAttribute.cs
@@ -1,0 +1,25 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using Moryx.Container;
+using Moryx.Serialization;
+using Moryx.TestModule;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Moryx.Products.Samples.Recipe
+{
+    public class FacacadeRecipeValueAttribute : PossibleValuesAttribute
+    {
+        public override bool OverridesConversion => false;
+
+        public override bool UpdateFromPredecessor => false;
+
+        public override IEnumerable<string> GetValues(IContainer localContainer, IServiceProvider serviceProvider)
+        {
+            var module = serviceProvider.GetRequiredService<ITestModule>();
+            return new[] { module.Bla.ToString("D") };
+        }
+    }
+}

--- a/src/Moryx.Products.Samples/Recipe/WatchProductRecipe.cs
+++ b/src/Moryx.Products.Samples/Recipe/WatchProductRecipe.cs
@@ -21,7 +21,7 @@ namespace Moryx.Products.Samples.Recipe
             Case = source.Case;
         }
 
-        [EntrySerialize]
+        [EntrySerialize, FacacadeRecipeValue]
         [DisplayName("Cores Installed")]
         public int CoresInstalled { get; set; }
 

--- a/src/Moryx.Runtime.Endpoints/Modules/Endpoint/ModulesController.cs
+++ b/src/Moryx.Runtime.Endpoints/Modules/Endpoint/ModulesController.cs
@@ -26,12 +26,14 @@ namespace Moryx.Runtime.Endpoints.Modules.Endpoint
         private readonly IModuleManager _moduleManager;
         private readonly IConfigManager _configManager;
         private readonly IParallelOperations _parallelOperations;
+        private readonly IServiceProvider _serviceProvider;
 
-        public ModulesController(IModuleManager moduleManager, IConfigManager configManager, IParallelOperations parallelOperations)
+        public ModulesController(IModuleManager moduleManager, IConfigManager configManager, IParallelOperations parallelOperations, IServiceProvider serviceProvider)
         {
             _moduleManager = moduleManager;
             _configManager = configManager;
             _parallelOperations = parallelOperations;
+            _serviceProvider = serviceProvider;
         }
 
         [HttpGet("dependencies")]
@@ -254,7 +256,7 @@ namespace Moryx.Runtime.Endpoints.Modules.Endpoint
         {
             var host = (IContainerHost)module;
             // TODO: This is dangerous
-            return new PossibleValuesSerialization(host.Container, (IEmptyPropertyProvider)_configManager)
+            return new PossibleValuesSerialization(host.Container, _serviceProvider, (IEmptyPropertyProvider)_configManager)
             {
                 FormatProvider = Thread.CurrentThread.CurrentUICulture
             };

--- a/src/Moryx/Moryx.csproj
+++ b/src/Moryx/Moryx.csproj
@@ -7,7 +7,6 @@
     <Description>Core package of the MORYX ecosystem. It defines the necessary types for MORYX compatibility as well as commonly required tools.</Description>
     <CreatePackage>true</CreatePackage>
     <PackageTags>MORYX;Serialization;Configuration;Logging;Core;Modules;Workplans</PackageTags>
-	  <IsPackable>true</IsPackable>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'net6.0'">

--- a/src/Moryx/Moryx.csproj
+++ b/src/Moryx/Moryx.csproj
@@ -7,6 +7,7 @@
     <Description>Core package of the MORYX ecosystem. It defines the necessary types for MORYX compatibility as well as commonly required tools.</Description>
     <CreatePackage>true</CreatePackage>
     <PackageTags>MORYX;Serialization;Configuration;Logging;Core;Modules;Workplans</PackageTags>
+	  <IsPackable>true</IsPackable>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'net6.0'">

--- a/src/Moryx/Serialization/PossibleValues/PossibleValuesAttribute.cs
+++ b/src/Moryx/Serialization/PossibleValues/PossibleValuesAttribute.cs
@@ -27,14 +27,39 @@ namespace Moryx.Serialization
         /// All possible values for this member represented as strings. The given container might be null
         /// and can be used to resolve possible values
         /// </summary>
-        public abstract IEnumerable<string> GetValues(IContainer container);
+        [Obsolete("Replaced by PossibleValues with access to global service registration")]
+        public virtual IEnumerable<string> GetValues(IContainer container)
+        {
+            return Array.Empty<string>();
+        }
+
+        /// <summary>
+        /// Extract possible values from local or global DI registration
+        /// </summary>
+        // TODO: Make abstract in MORYX 10
+        public virtual IEnumerable<string> GetValues(IContainer localContainer, IServiceProvider serviceProvider)
+        {
+            return GetValues(localContainer);
+        }
 
         /// <summary>
         /// String to value conversion
         /// </summary>
+        [Obsolete("Replaced by Parse with ServiceProvider reference")]
         public virtual object Parse(IContainer container, string value)
         {
             return value;
+        }
+
+        /// <summary>
+        /// Parse value from string using local or global DI container
+        /// </summary>
+        /// <param name="container">Module local DI container</param>
+        /// <param name="serviceProvider">Global service registration</param>
+        /// <param name="value">Value to parse</param>
+        public virtual object Parse(IContainer container, IServiceProvider serviceProvider, string value)
+        {
+            return Parse(container, value);
         }
     }
 }

--- a/src/Tests/Moryx.Products.Management.Tests/ProductConverterTests.cs
+++ b/src/Tests/Moryx.Products.Management.Tests/ProductConverterTests.cs
@@ -227,7 +227,7 @@ namespace Moryx.AbstractionLayer.Products.Endpoints.Tests
 
 
             // Act
-            var convertedModel = _productConverter.ConvertRecipe(originalRecipe);
+            var convertedModel = _productConverter.ConvertRecipeV2(originalRecipe);
             var recoveredOriginal = _productConverter.ConvertRecipeBack(convertedModel, targetDummyRecipe, backupProductType);
 
 

--- a/src/Tests/Moryx.Products.Management.Tests/ProductConverterTests.cs
+++ b/src/Tests/Moryx.Products.Management.Tests/ProductConverterTests.cs
@@ -27,7 +27,7 @@ namespace Moryx.AbstractionLayer.Products.Endpoints.Tests
         {
             _productManagerMock = new Mock<IProductManagement>();
 
-            _productConverter = new ProductConverter(_productManagerMock.Object);
+            _productConverter = new ProductConverter(_productManagerMock.Object, null, null);
         }
 
         #region Products
@@ -227,7 +227,7 @@ namespace Moryx.AbstractionLayer.Products.Endpoints.Tests
 
 
             // Act
-            var convertedModel = ProductConverter.ConvertRecipe(originalRecipe);
+            var convertedModel = _productConverter.ConvertRecipe(originalRecipe);
             var recoveredOriginal = _productConverter.ConvertRecipeBack(convertedModel, targetDummyRecipe, backupProductType);
 
 


### PR DESCRIPTION
For legacy reasons the `PossibleValuesAttribute` accepts the local container of its host module back in the day when endpoints were located inside modules and not on their facade. We migrated that logic to keep migration efforts to MORYX 6 reasonable. With this addition attributes can access the service provide and through it all relevant facades of the application.