### PR TITLE
Fix exception on creating a bidirectional link to a new resource

### DIFF
--- a/src/Moryx.AbstractionLayer.Resources.Endpoints/Converter/ResourceToModelConverter.cs
+++ b/src/Moryx.AbstractionLayer.Resources.Endpoints/Converter/ResourceToModelConverter.cs
@@ -197,7 +197,7 @@ namespace Moryx.AbstractionLayer.Resources.Endpoints
                 Creatable = node.Creatable,
                 Name = node.Name,
                 BaseType = baseType?.Name,
-                DisplayName = resType.GetDisplayName(),
+                DisplayName = resType.GetDisplayName() ?? Regex.Replace(resType.Name, @"`\d", string.Empty),
                 Description = resType.GetDescription(),
                 // Convert resource constructors
                 Constructors = node.Constructors.Select(ctr => EntryConvert.EncodeMethod(ctr, Serialization)).ToArray()

--- a/src/Moryx.AbstractionLayer.Resources.Endpoints/Converter/ResourceToModelConverter.cs
+++ b/src/Moryx.AbstractionLayer.Resources.Endpoints/Converter/ResourceToModelConverter.cs
@@ -76,7 +76,7 @@ namespace Moryx.AbstractionLayer.Resources.Endpoints
                 Description = current.Description,
 
                 // Use simplified type reference
-                Type = current.ResourceType()
+                Type = current.ResourceType(),
             };
 
             // Set partial flag or load complex properties depending on details depth
@@ -197,14 +197,8 @@ namespace Moryx.AbstractionLayer.Resources.Endpoints
                 Creatable = node.Creatable,
                 Name = node.Name,
                 BaseType = baseType?.Name,
-
-                // Read display name of the type otherwise use type short name
-                DisplayName = resType.GetCustomAttribute<DisplayNameAttribute>(false)?.DisplayName ??
-                              Regex.Replace(resType.Name, @"`\d", string.Empty),
-
-                // Read description of the type
-                Description = resType.GetCustomAttribute<DescriptionAttribute>(false)?.Description,
-
+                DisplayName = resType.GetDisplayName(),
+                Description = resType.GetDescription(),
                 // Convert resource constructors
                 Constructors = node.Constructors.Select(ctr => EntryConvert.EncodeMethod(ctr, Serialization)).ToArray()
             };

--- a/src/Moryx.Resources.Management/Moryx.Resources.Management.csproj
+++ b/src/Moryx.Resources.Management/Moryx.Resources.Management.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+	<IsPackable>true</IsPackable>
     <Description>ResourceManagement module composing and maintaining the resource graph as the habitat for digital twins of manufacturing assets.</Description>
     <CreatePackage>true</CreatePackage>
     <PackageTags>MORYX;IIoT;IoT;Manufacturing;API;Resource</PackageTags>

--- a/src/Moryx.Resources.Management/Resources/ResourceEntityAccessor.cs
+++ b/src/Moryx.Resources.Management/Resources/ResourceEntityAccessor.cs
@@ -182,12 +182,12 @@ namespace Moryx.Resources.Management
         public ResourceRelationType RelationType => (ResourceRelationType)Entity.RelationType;
 
         /// <summary>
-        /// Id of the referenced resource
+        /// Id of the resource with the specified <see cref="Role"/> in the relation
         /// </summary>
         public long ReferenceId => Role == ResourceReferenceRole.Target ? Entity.TargetId : Entity.SourceId;
 
         /// <summary>
-        /// References entity
+        /// Entity of the resource with the specified <see cref="Role"/> in the relation
         /// </summary>
         public ResourceEntity ReferenceEntity => Role == ResourceReferenceRole.Target ? Entity.Target : Entity.Source;
 

--- a/src/Tests/Moryx.Resources.Management.Tests/Mocks/ReferenceResource.cs
+++ b/src/Tests/Moryx.Resources.Management.Tests/Mocks/ReferenceResource.cs
@@ -67,6 +67,12 @@ namespace Moryx.Resources.Management.Tests
         [ResourceReference(ResourceRelationType.CurrentExchangablePart)]
         public DerivedResource Reference2 { get; set; }
 
+        [ResourceReference(ResourceRelationType.Extension, ResourceReferenceRole.Target, nameof(TargetReference))]
+        public BidirectionalReferenceResource TargetReference { get; set; }
+
+        [ResourceReference(ResourceRelationType.Extension, ResourceReferenceRole.Target, nameof(NewTargetReference))]
+        public BidirectionalReferenceResource NewTargetReference { get; set; }
+
         [ResourceReference(ResourceRelationType.PossibleExchangablePart)]
         public IReferences<ISimpleResource> References { get; set; }
 
@@ -98,11 +104,16 @@ namespace Moryx.Resources.Management.Tests
                 References.Add(reference);
         }
 
-
         public INonPublicResource NonPublic { get; set; }
 
         public event EventHandler<ISimpleResource> ReferenceChanged;
 
         public event EventHandler<ISimpleResource[]> SomeChanged;
+    }
+
+    public class BidirectionalReferenceResource : PublicResource
+    {
+        [ResourceReference(ResourceRelationType.Extension, ResourceReferenceRole.Source, nameof(SourceReference))]
+        public ReferenceResource SourceReference { get; set; }
     }
 }

--- a/src/Tests/Moryx.Resources.Management.Tests/ResourceLinkerTests.cs
+++ b/src/Tests/Moryx.Resources.Management.Tests/ResourceLinkerTests.cs
@@ -127,6 +127,63 @@ namespace Moryx.Resources.Management.Tests
             };
         }
 
+        [Test(Description = "Save modified bidirectional references")]
+        public void SaveBidirectionalReferences()
+        {
+            // Arrange
+            var instance = new ReferenceResource { Id = 1 };
+            ResourceReferenceTools.InitializeCollections(instance);
+            // Prepare reference objects
+            var resource = new BidirectionalReferenceResource { Id = 2, Name = "resource" };
+            var collectionResource = new SimpleResource { Id = 3, Name = "collectionResource" };
+            var newResource = new BidirectionalReferenceResource() { Name = "newResource" };
+            ResourceReferenceTools.InitializeCollections(newResource);
+            var newCollectionResource = new SimpleResource() { Name = "newCollectionResource" };
+            ResourceReferenceTools.InitializeCollections(newCollectionResource);
+            // Fill graph
+            _graph[1] = new ResourceWrapper(instance);
+            _graph[2] = new ResourceWrapper(resource);
+            _graph[3] = new ResourceWrapper(collectionResource);
+            // Set single references
+            instance.TargetReference = resource; // The bidirectional reference is created with an existing resource
+            instance.NewTargetReference = newResource; // The bidirectional reference is created with a new resource
+            // Fill collections
+            instance.ChildReferences.Add(collectionResource); // An existing resource is added to the reference collection
+            instance.ChildReferences.Add(newCollectionResource); // A new resource is added to the reference collection
+            // Setup uow and repo to simulate the current database
+            var relations = new List<ResourceRelationEntity>();
+            var mocks = SetupDbMocks(relations);
+
+            // Act
+            var newResources = _linker.SaveReferences(mocks.Item1.Object, instance, new ResourceEntity { Id = 1 });
+
+            // Assert
+            Assert.Multiple(() =>
+            {
+                // Resources were created
+                Assert.DoesNotThrow(() => mocks.Item3.Verify(repo => repo.Create(), Times.Exactly(2)), "Linker did not detect the new resources");
+                Assert.That(newResources, Has.Count.EqualTo(2));
+                Assert.That(newResource, Is.EqualTo(newResources[0]));
+                Assert.That(newCollectionResource, Is.EqualTo(newResources[1]));
+                // Resources properties were set
+                Assert.That(resource.SourceReference, Is.EqualTo(instance), "Backlink sync failed for a reference to an existing resource");
+                Assert.That(newResource.SourceReference, Is.EqualTo(instance), "Backlink sync failed for a reference to a new resource");
+                Assert.That(collectionResource.Parent, Is.EqualTo(instance), "Backlink sync failed for collection reference to a new resource");
+                Assert.That(newCollectionResource.Parent, Is.EqualTo(instance), "Backlink sync failed for a collection reference to a new resource");
+                // Relations were created
+                Assert.DoesNotThrow(() => mocks.Item2.Verify(repo => repo.Create((int)ResourceRelationType.Extension), Times.Exactly(2)), "Linker did not create relations for references");
+                Assert.DoesNotThrow(() => mocks.Item2.Verify(repo => repo.Create((int)ResourceRelationType.ParentChild), Times.Exactly(2)), "Linker did not create relations for collection references");
+                Assert.That(relations.Where(r => r.RelationType == (int)ResourceRelationType.ParentChild).Count(), Is.EqualTo(2));
+                Assert.That(relations.Where(r => r.RelationType == (int)ResourceRelationType.Extension).Count(), Is.EqualTo(2));
+                // Relation sources and targets were set
+                Assert.That(relations.Where(r => r.Source.Id == instance.Id).Count(), Is.EqualTo(4));
+                Assert.DoesNotThrow(() => relations.Single(r => r.Target.Id == resource.Id));
+                Assert.DoesNotThrow(() => relations.Single(r => r.Target.Id == collectionResource.Id));
+                Assert.DoesNotThrow(() => relations.Single(r => r.Target.Name == newResource.Name));
+                Assert.DoesNotThrow(() => relations.Single(r => r.Target.Name == newCollectionResource.Name));
+            });
+        }
+
         [Test(Description = "Save modified references of a resource")]
         public void SaveReferences()
         {
@@ -200,7 +257,7 @@ namespace Moryx.Resources.Management.Tests
             Assert.AreEqual(1, possiblePart.Count(r => r.Target.Id == 0));
         }
 
-        [Test(Description = "Multiple references of the same relation type shoudl not interfere with each other")]
+        [Test(Description = "Multiple references of the same relation type should not interfere with each other")]
         public void ReferenceInterferenceOnSave()
         {
             // Arrange
@@ -407,7 +464,7 @@ namespace Moryx.Resources.Management.Tests
             var resRepo = new Mock<IResourceRepository>();
             resRepo.Setup(r => r.GetByKey(It.Is<long>(id => id > 0))).Returns<long>(id => new ResourceEntity { Id = id });
             resRepo.Setup(r => r.GetByKey(It.Is<long>(id => id == 0))).Returns((ResourceEntity)null);
-            resRepo.Setup(r => r.Create()).Returns(new ResourceEntity());
+            resRepo.Setup(r => r.Create()).Returns(() => new ResourceEntity());
 
             var uowMock = new Mock<IUnitOfWork>();
             uowMock.Setup(u => u.GetRepository<IResourceRelationRepository>()).Returns(relRepo.Object);


### PR DESCRIPTION
When creating a bidirectional relation the missing properties on the relation to be created caused an exception when creating the backlink.

Also fixes display name and description serialization on resource types in the controller