### PR TITLE
Navigate to `modules` by default

### DIFF
--- a/src/Moryx.CommandCenter.Web/src/common/container/App.tsx
+++ b/src/Moryx.CommandCenter.Web/src/common/container/App.tsx
@@ -104,7 +104,7 @@ function App(props: AppPropModel & AppDispatchPropModel) {
           <Routes>
             <Route path="/modules/*" element={<Modules />} />
             <Route path="/databases/*" element={<Databases />} />
-            <Route path="*" element={<Navigate to="/databases/*" />} />
+            <Route path="*" element={<Navigate to="/modules/*" />} />
           </Routes>
         </Container>
       </div>


### PR DESCRIPTION
It's more common to manage modules instead of databases, so that should be loaded by default.

