### PR TITLE
Fix test steps in build pipeline

### DIFF
--- a/.build/BuildToolkit.ps1
+++ b/.build/BuildToolkit.ps1
@@ -265,20 +265,7 @@ function Invoke-CoverTests($SearchPath = $RootPath, $SearchFilter = "*.csproj", 
         return;
     }
 
-    if (-not (Test-Path $global:NUnitCli)) {
-        Install-Tool "NUnit.Console" $NunitVersion $global:NunitCli;
-    }
-
-    if (-not (Test-Path $global:OpenCoverCli)) {
-        Install-Tool "OpenCover" $OpenCoverVersion $global:OpenCoverCli;
-    }
-
-    if (-not (Test-Path $global:OpenCoverToCoberturaCli)) {
-        Install-Tool "OpenCoverToCoberturaConverter" $OpenCoverToCoberturaVersion $global:OpenCoverToCoberturaCli;
-    }
-
-    CreateFolderIfNotExists $OpenCoverReportsDir;
-    CreateFolderIfNotExists $NunitReportsDir;
+    CreateFolderIfNotExists $CoberturaReportsDir;
 
     $includeFilter = "+[Moryx*]*";
     $excludeFilter = "-[*nunit*]* -[*Tests]* -[*Model*]*";
@@ -309,55 +296,26 @@ function Invoke-CoverTests($SearchPath = $RootPath, $SearchFilter = "*.csproj", 
 
     ForEach($testProject in $testProjects ) { 
         $projectName = ([System.IO.Path]::GetFileNameWithoutExtension($testProject.Name));
-        $testAssembly = [System.IO.Path]::Combine($testProject.DirectoryName, "bin", $env:MORYX_BUILD_CONFIG, "$projectName.dll");
-        $isNetCore = Get-CsprojIsNetCore($testProject);
-
-        Write-Host "OpenCover Test: ${projectName}:";
-
-        $nunitXml = ($NunitReportsDir + "\$projectName.TestResult.xml");
-        $openCoverXml = ($OpenCoverReportsDir + "\$projectName.OpenCover.xml");
-        $coberturaXml = ($CoberturaReportsDir + "\$projectName.Cobertura.xml");
-
-        if ($isNetCore) {
-            $targetArgs = '"test -v ' + $env:MORYX_TEST_VERBOSITY + ' -c ' + $env:MORYX_BUILD_CONFIG + ' ' + $testProject + '"';
-            $openCoverAgs = "-target:$global:DotNetCli", "-targetargs:$targetArgs"
-        }
-        else {
-            # If assembly does not exists, the project will be build
-            if (-not (Test-Path $testAssembly)) {
-                Invoke-Build $testProject 
-            }
-
-            $openCoverAgs = "-target:$global:NunitCli", "-targetargs:/config:$env:MORYX_BUILD_CONFIG /result:$nunitXml $testAssembly"
-        }
-
-        $openCoverAgs += "-log:Debug", "-register:administrator", "-output:$openCoverXml", "-hideskipped:all", "-skipautoprops";
-        $openCoverAgs += "-returntargetcode" # We need the nunit return code
-        $openCoverAgs += "-filter:$includeFilter $excludeFilter"
-
-        & $global:OpenCoverCli $openCoverAgs
+        Write-Host "Testing ${projectName}...";
         
-        $exitCode = [int]::Parse($LastExitCode);
-        if ($exitCode -ne 0) {
-            $errorText = "";
-            switch ($exitCode) {
-                -1 { $errorText = "INVALID_ARG"; }
-                -2 { $errorText = "INVALID_ASSEMBLY"; }
-                -4 { $errorText = "INVALID_TEST_FIXTURE"; }
-                -5 { $errorText = "UNLOAD_ERROR"; }
-                Default { $errorText = "UNEXPECTED_ERROR"; }
-            }
+        dotnet test ${testProject} --collect:"XPlat Code Coverage" `
+            /p:CoverletOutputFormat="cobertura" `
+            /p:Include="$includeFilter" `
+            /p:Exclude="$excludeFilter"
 
-            if ($exitCode -gt 0) {
-                $errorText = "FAILED_TESTS ($exitCode)";
-            }
-
-            Write-Host-Error "Nunit exited with $errorText for $projectName";
-            Invoke-ExitCodeCheck $exitCode;
-        }
-
-        & $global:OpenCoverToCoberturaCli -input:$openCoverXml -output:$coberturaXml -sources:$rootPath
         Invoke-ExitCodeCheck $LastExitCode;
+
+        $testsDir = [System.IO.Path]::Combine([System.IO.Path]::GetDirectoryName($testProject), "TestResults");
+
+        $testResults = Get-ChildItem -Path $testsDir -Recurse -File
+        foreach ($resultFile in $testResults) {
+            $destinationFile = $resultFile.FullName.Replace($testsDir, $CoberturaReportsDir);
+            $destinationPath = [System.IO.Path]::GetDirectoryName($destinationFile);
+
+            CreateFolderIfNotExists $destinationPath;
+
+            Move-Item -Path $resultFile -Destination $destinationFile
+        }
     }
 }
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -105,7 +105,7 @@ jobs:
       - name: Upload test results
         uses: actions/upload-artifact@v4
         with:
-          name: test-results
+          name: integration-test-results
           path: artifacts/Tests/
           if-no-files-found: error
           retention-days: 1
@@ -117,13 +117,19 @@ jobs:
       - name: Download test results
         uses: actions/download-artifact@v4
         with:
+          name: test-results
+          path: artifacts/Tests/
+
+      - name: Download test results
+        uses: actions/download-artifact@v4
+        with:
           name: integration-test-results
           path: artifacts/Tests/
 
       - name: Codecov
         uses: codecov/codecov-action@v1
         with:
-          files: '*.OpenCover.xml'
+          files: '*coverage.cobertura.xml'
 
   Documentation:
     needs: [Build]

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -12,6 +12,7 @@ on:
     branches: 
       - dev
       - future
+      - release/3
 
 env:
   MORYX_OPTIMIZE_CODE: "false"
@@ -76,6 +77,7 @@ jobs:
         with:
           name: test-results
           path: artifacts/Tests/
+          if-no-files-found: error
           retention-days: 1
 
   IntegrationTests:
@@ -105,6 +107,7 @@ jobs:
         with:
           name: test-results
           path: artifacts/Tests/
+          if-no-files-found: error
           retention-days: 1
 
   Codecov:
@@ -114,7 +117,7 @@ jobs:
       - name: Download test results
         uses: actions/download-artifact@v4
         with:
-          name: test-results
+          name: integration-test-results
           path: artifacts/Tests/
 
       - name: Codecov

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -15,6 +15,7 @@
     <PackageReference Update="Moq" Version="4.16.1" />
     <PackageReference Update="NUnit" Version="3.13.2" />
     <PackageReference Update="NUnit3TestAdapter" Version="4.1.0" />
+    <PackageReference Update="coverlet.collector" Version="5.8.0" />
 
     <PackageReference Update="CommandLineParser" Version="2.8.0" />
     <PackageReference Update="System.ComponentModel.Annotations" Version="4.7.0" />

--- a/src/Tests/Moryx.Communication.Sockets.IntegrationTests/Moryx.Communication.Sockets.IntegrationTests.csproj
+++ b/src/Tests/Moryx.Communication.Sockets.IntegrationTests/Moryx.Communication.Sockets.IntegrationTests.csproj
@@ -4,6 +4,7 @@
     <OutputType>Library</OutputType>
     <TargetFramework>net5.0</TargetFramework>
     <DebugType>full</DebugType>
+    <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 
   <ItemGroup>
@@ -11,6 +12,7 @@
     <PackageReference Include="Moq" />
     <PackageReference Include="NUnit" />
     <PackageReference Include="NUnit3TestAdapter" />
+    <PackageReference Include="coverlet.collector" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Tests/Moryx.Container.Tests/Moryx.Container.Tests.csproj
+++ b/src/Tests/Moryx.Container.Tests/Moryx.Container.Tests.csproj
@@ -4,12 +4,14 @@
     <TargetFramework>net5.0</TargetFramework>
     <OutputType>Library</OutputType>
     <DebugType>full</DebugType>
+    <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="NUnit" />
     <PackageReference Include="NUnit3TestAdapter" />
+    <PackageReference Include="coverlet.collector" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Tests/Moryx.Runtime.Kernel.Tests/Moryx.Runtime.Kernel.Tests.csproj
+++ b/src/Tests/Moryx.Runtime.Kernel.Tests/Moryx.Runtime.Kernel.Tests.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net5.0</TargetFramework>
     <OutputType>Library</OutputType>
     <DebugType>full</DebugType>
+    <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 
   <ItemGroup>
@@ -11,6 +12,7 @@
     <PackageReference Include="Moq" />
     <PackageReference Include="NUnit" />
     <PackageReference Include="NUnit3TestAdapter" />
+    <PackageReference Include="coverlet.collector" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Tests/Moryx.Runtime.SystemTests/Moryx.Runtime.SystemTests.csproj
+++ b/src/Tests/Moryx.Runtime.SystemTests/Moryx.Runtime.SystemTests.csproj
@@ -4,12 +4,14 @@
     <TargetFramework>net45</TargetFramework>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <DebugType>full</DebugType>
+    <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="NUnit" />
     <PackageReference Include="NUnit3TestAdapter" />
+    <PackageReference Include="coverlet.collector" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Tests/Moryx.Runtime.Tests/Moryx.Runtime.Tests.csproj
+++ b/src/Tests/Moryx.Runtime.Tests/Moryx.Runtime.Tests.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net5.0</TargetFramework>
     <OutputType>Library</OutputType>
     <DebugType>full</DebugType>
+    <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 
   <ItemGroup>
@@ -11,6 +12,7 @@
     <PackageReference Include="Moq" />
     <PackageReference Include="NUnit" />
     <PackageReference Include="NUnit3TestAdapter" />
+    <PackageReference Include="coverlet.collector" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Tests/Moryx.Tests/Moryx.Tests.csproj
+++ b/src/Tests/Moryx.Tests/Moryx.Tests.csproj
@@ -4,12 +4,14 @@
     <TargetFramework>net5.0</TargetFramework>
     <OutputType>Library</OutputType>
     <DebugType>full</DebugType>
+    <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="NUnit" />
     <PackageReference Include="NUnit3TestAdapter" />
+    <PackageReference Include="coverlet.collector" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Tests/Moryx.Tools.Wcf.SystemTests/Moryx.Tools.Wcf.SystemTests.csproj
+++ b/src/Tests/Moryx.Tools.Wcf.SystemTests/Moryx.Tools.Wcf.SystemTests.csproj
@@ -4,12 +4,14 @@
     <TargetFramework>net45</TargetFramework>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <DebugType>full</DebugType>
+    <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="NUnit" />
     <PackageReference Include="NUnit3TestAdapter" />
+    <PackageReference Include="coverlet.collector" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Test projects now reference `coverlet.collector` to create test coverage reports.

Version 5.8.0 is used since newer versions result in build errors because some dependency to `Newtonsoft.Json` couldn't be resolved.

Notice, that 5.8 does not exist and gets resolved to 6.0.0 instead. But using 6.0.0 gave the same dependency issues described above.

Providing an output path doesn't seem to work as before, so test files get copied manually now.

The artifacts plugin was configured to report an error if not test results were found: No test results found does either mean there are not tests in the project, so no need to run this step anyway or that for some reason those results could not be generated which is considered an error

