### PR TITLE
Port: Add `FunctionResult<TResult>` to allow functions return 'proper' results

### DIFF
--- a/src/Moryx/Tools/FunctionResult.cs
+++ b/src/Moryx/Tools/FunctionResult.cs
@@ -1,0 +1,246 @@
+﻿// Copyright (c) 2023, Phoenix Contact GmbH & Co. KG
+// Licensed under the Apache License, Version 2.0
+
+using System;
+
+namespace Moryx.Tools.FunctionResult
+{
+    /// <summary>
+    /// Generic type that allows functions to always return a proper result,
+    /// that either contains a valid value or an error and helps exercising
+    /// error handling.
+    /// </summary>
+    /// <typeparam name="TResult"></typeparam>
+    public class FunctionResult<TResult>
+    {
+        /// <summary>
+        /// Result value in case of success
+        /// </summary>
+        public TResult? Result { get; } = default;
+
+        /// <summary>
+        /// Error in case of failure
+        /// </summary>
+        public FunctionResultError? Error { get; } = null;
+
+        /// <summary>
+        /// Indicates if the result contains a valid value
+        /// or not
+        /// </summary>
+        public bool Success => Error == null;
+
+        /// <summary>
+        /// Creates a result with a value
+        /// </summary>
+        /// <param name="result"></param>
+        public FunctionResult(TResult result)
+        {
+            Result = result;
+        }
+
+        /// <summary>
+        /// Creates an error result with <see cref="FunctionResultError"/>
+        /// </summary>
+        /// <param name="error"></param>
+        public FunctionResult(FunctionResultError error)
+        {
+            Error = error;
+        }
+
+        /// <inheritdoc/>
+        public override string ToString()
+        {
+            return Success
+                ? Result?.ToString() ?? "null"
+                : Error!.ToString();
+        }
+
+        /// <summary>
+        /// Process result value and errors in a 'pattern matching '-like way
+        /// </summary>
+        /// <param name="success">Function to be excecuted in case of success</param>
+        /// <param name="error">Function to be excecuted in case of an error</param>
+        /// <returns><see cref="FunctionResult{TResult}" /> of the executed function</returns>
+        public FunctionResult<TResult> Match(Func<TResult, FunctionResult<TResult>> success, Func<FunctionResultError, FunctionResult<TResult>> error)
+            => Success ? success(Result!) : error(Error!);
+
+        /// <summary>
+        /// Process result value and errors in a 'pattern matching '-like way
+        /// </summary>
+        /// <param name="success">Action to be excecuted in case of success</param>
+        /// <param name="error">Action to be excecuted in case of an error</param>
+        /// <returns>The current <see cref="FunctionResult{TResult}" /></returns>
+        public FunctionResult<TResult> Match(Action<TResult> success, Action<FunctionResultError> error)
+            => Match(
+                s =>
+                {
+                    success(s);
+                    return this;
+                },
+                e =>
+                {
+                    error(e);
+                    return this;
+                });
+    }
+
+    /// <summary>
+    /// <see cref="FunctionResult"/> of type <see cref="Nothing"/> to be used
+    /// for functions that would return <see cref="void"/>
+    /// </summary>
+    public class FunctionResult : FunctionResult<Nothing>
+    {
+        /// <summary>
+        /// Creates a `successful` <see cref="FunctionResult"/> with 'no' value
+        /// <typeparam name="TResult"></typeparam>
+        public FunctionResult() : base(new Nothing())
+        {
+        }
+
+
+        /// <summary>
+        /// Creates an error result with <see cref="FunctionResultError"/>
+        /// </summary>
+        /// <param name="error"></param>
+        public FunctionResult(FunctionResultError error) : base(error)
+        {
+        }
+
+        /// <summary>
+        /// Helper to create an Ok <see cref="FunctionResult"/> in a descriptive way.
+        /// </summary>
+        /// <returns><see cref="FunctionResult"/></returns>
+        public static FunctionResult Ok()
+            => new FunctionResult();
+
+        /// <summary>
+        /// Helper to create a <see cref="FunctionResult"/> with an error message in a descriptive way.
+        /// </summary>
+        /// <returns><see cref="FunctionResult"/></returns>
+        public static FunctionResult WithError(string message)
+            => new(new FunctionResultError(message));
+
+        /// <summary>
+        /// Helper to create a <see cref="FunctionResult"/> with an <see cref="Exception"/> in a descriptive way.
+        /// </summary>
+        /// <returns><see cref="FunctionResult"/></returns>
+        public static FunctionResult WithError(Exception exception)
+            => new(new FunctionResultError(exception));
+
+        /// <summary>
+        /// Helper to create an Ok <see cref="FunctionResult"/> in a descriptive way.
+        /// </summary>
+        /// <returns><see cref="FunctionResult"/> of <see cref="TResult"/></returns>
+        public static FunctionResult<TResult> Ok<TResult>(TResult result)
+            => new(result);
+
+        /// <summary>
+        /// Helper to create a <see cref="FunctionResult{TResult}"/> with an error message in a descriptive way.
+        /// </summary>
+        /// <returns><see cref="FunctionResult{TResult}"/></returns>
+        public static FunctionResult<TResult> WithError<TResult>(string message)
+            => new(new FunctionResultError(message));
+
+        /// <summary>
+        /// Helper to create an Ok <see cref="FunctionResult"/> in a descriptive way.
+        /// </summary>
+        /// <returns><see cref="FunctionResult{TResult}"/></returns>
+        public static FunctionResult<TResult> WithError<TResult>(Exception exception)
+            => new(new FunctionResultError(exception));
+
+    }
+
+    /// <summary>
+    /// Holds a description of the error and optionally an
+    /// <see cref="Exception"/>
+    public class FunctionResultError
+    {
+        /// <summary>
+        /// Error message
+        /// </summary>
+        public string Message { get; }
+
+        /// <summary>
+        /// Exception that might be the reason for the error
+        /// </summary>
+        public Exception? Exception { get; } = null;
+
+
+        /// <summary>
+        /// Creates an error with error message
+        /// </summary>
+        /// <exception cref="ArgumentNullException">In case of <paramref name="message"/> is null</exception>
+        public FunctionResultError(string message)
+        {
+            if (message is null)
+                throw new ArgumentNullException(nameof(message));
+
+            Message = message;
+        }
+
+        /// <summary>
+        /// Creates an error with error message
+        /// </summary>
+        /// <exception cref="ArgumentNullException">In case of <paramref name="exception"/> is null</exception>
+        public FunctionResultError(Exception exception)
+        {
+            if (exception is null)
+                throw new ArgumentNullException(nameof(exception));
+
+            Message = exception.Message;
+            Exception = exception;
+        }
+
+        /// <inheritdoc/>
+        public override string ToString()
+        {
+            return Exception != null
+                ? Exception.Message
+                : Message;
+        }
+
+    }
+
+
+    /// <summary>
+    /// Placeholder type to return nothing when for example <see cref="void"/>
+    /// would be returned
+    /// </summary>
+    public class Nothing
+    {
+    }
+
+    /// <summary>
+    /// Extensions for <see cref="FunctionResult{TResult}"/>
+    /// </summary>
+    public static class FunctionResultExtensions
+    {
+        /// <summary>
+        /// Executes the provided function in case of a successful result
+        /// </summary>
+        /// <returns><see cref=" FunctionResult{TResult}"/> returned by <paramref name="func"/></returns>
+        public static FunctionResult<TResult> Then<TResult>(this FunctionResult<TResult> result, Func<TResult, FunctionResult<TResult>> func)
+            => result.Match(func, _ => result);
+
+        /// <summary>
+        /// Executes the provided function in case of an error result
+        /// </summary>
+        /// <returns><see cref=" FunctionResult{TResult}"/> returned by <paramref name="func"/></returns>
+        public static FunctionResult<TResult> Catch<TResult>(this FunctionResult<TResult> result, Func<FunctionResultError, FunctionResult<TResult>> func)
+            => result.Match(_ => result, func);
+
+        /// <summary>
+        /// Executes the provided action in case of a successful result
+        /// </summary>
+        /// <returns>The underlying <see cref="FunctionResult{TResult}"/></returns>
+        public static FunctionResult<TResult> Then<TResult>(this FunctionResult<TResult> result, Action<TResult> action)
+            => result.Match(action, _ => { });
+
+        /// <summary>
+        /// Executes the provided action in case of a error result
+        /// </summary>
+        /// <returns>The underlying <see cref="FunctionResult{TResult}"/></returns>
+        public static FunctionResult<TResult> Catch<TResult>(this FunctionResult<TResult> result, Action<FunctionResultError> action)
+            => result.Match(_ => { }, action);
+    }
+}

--- a/src/Tests/Moryx.Tests/Moryx.Tests.csproj
+++ b/src/Tests/Moryx.Tests/Moryx.Tests.csproj
@@ -9,6 +9,7 @@
   <ItemGroup>
 	<PackageReference Include="coverlet.collector" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Moq" />
     <PackageReference Include="NUnit" />
     <PackageReference Include="NUnit3TestAdapter" />
   </ItemGroup>

--- a/src/Tests/Moryx.Tests/Tools/FunctionResultTestsBase.cs
+++ b/src/Tests/Moryx.Tests/Tools/FunctionResultTestsBase.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) 2023, Phoenix Contact GmbH & Co. KG
+// Licensed under the Apache License, Version 2.0
+
+using NUnit.Framework;
+
+namespace Moryx.Tests.Tools
+{
+    [TestFixture]
+    public class FunctionResultTestsBase
+    {
+        protected const string Message = "Error occured!";
+        protected const string ExceptionMessage = "Exception Message";
+    }
+}

--- a/src/Tests/Moryx.Tests/Tools/FunctionResultWithNothingTests.cs
+++ b/src/Tests/Moryx.Tests/Tools/FunctionResultWithNothingTests.cs
@@ -1,0 +1,171 @@
+// Copyright (c) 2023, Phoenix Contact GmbH & Co. KG
+// Licensed under the Apache License, Version 2.0
+
+using NUnit.Framework;
+using Moryx.Tools.FunctionResult;
+using System;
+using Moq;
+
+namespace Moryx.Tests.Tools;
+
+[TestFixture]
+public class FunctionResultWithNothingTests : FunctionResultTestsBase
+{
+    protected Mock<Func<Nothing, FunctionResult<Nothing>>> _funcMockSuccess;
+    protected Mock<Func<FunctionResultError, FunctionResult<Nothing>>> _funcMockError;
+
+    protected Mock<Action<Nothing>> _actionMockSuccess;
+    protected Mock<Action<FunctionResultError>> _actionMockError;
+
+    [SetUp]
+    public void Setup()
+    {
+        _funcMockSuccess = new Mock<Func<Nothing, FunctionResult<Nothing>>>();
+        _funcMockSuccess
+            .Setup(f => f(It.IsAny<Nothing>()))
+            .Returns((Nothing arg) => new FunctionResult<Nothing>(arg));
+        _funcMockError = new Mock<Func<FunctionResultError, FunctionResult<Nothing>>>();
+        _funcMockError
+            .Setup(f => f(It.IsAny<FunctionResultError>()))
+            .Returns((FunctionResultError arg) => new FunctionResult<Nothing>(arg));
+
+        _actionMockSuccess = new Mock<Action<Nothing>>();
+        _actionMockError = new Mock<Action<FunctionResultError>>();
+    }
+
+
+    [Test]
+    public void ResultWithValueGetCreated()
+    {
+        var result = new FunctionResult();
+
+        Assert.That(result.Success, Is.True);
+        Assert.That(result.Error, Is.Null);
+        Assert.That(result.Result, Is.TypeOf<Nothing>());
+        Assert.That(result.ToString(), Contains.Substring("Nothing"));
+    }
+
+    [Test]
+    public void ErrorResultWithMessageGetsCreated()
+    {
+        var result = new FunctionResult(new FunctionResultError(Message));
+
+        Assert.That(result.Success, Is.False);
+        Assert.That(result.Result, Is.Null);
+
+        Assert.That(result.Error.Message, Is.EqualTo(Message));
+        Assert.That(result.Error.Exception, Is.Null);
+        Assert.That(result.ToString(), Is.EqualTo(Message));
+    }
+
+    [Test]
+    public void ErrorResultWithExceptionGetsCreated()
+    {
+        var result = new FunctionResult(new FunctionResultError(new Exception(ExceptionMessage)));
+
+        Assert.That(result.Success, Is.False);
+        Assert.That(result.Result, Is.Null);
+
+        Assert.That(result.Error.Message, Is.EqualTo(ExceptionMessage));
+        Assert.That(result.Error.Exception, Is.TypeOf<Exception>());
+        Assert.That(result.ToString(), Is.EqualTo(ExceptionMessage));
+    }
+
+    [Test]
+    public void ResultWithNothingGetsCreatedByUsingExtension()
+    {
+        var result = FunctionResult.Ok();
+
+        Assert.That(result.Success, Is.True);
+        Assert.That(result.Result, Is.TypeOf<Nothing>());
+        Assert.That(result.Error, Is.Null);
+        Assert.That(result.ToString(), Contains.Substring("Nothing"));
+    }
+
+    [Test]
+    public void ErrorResultWithMessageGetsCreatedByUsingExtension()
+    {
+        var result = FunctionResult.WithError(Message);
+
+        Assert.That(result.Success, Is.False);
+        Assert.That(result.Result, Is.Null);
+
+
+        Assert.That(result.Error.Message, Is.EqualTo(Message));
+        Assert.That(result.Error.Exception, Is.Null);
+        Assert.That(result.ToString(), Is.EqualTo(Message));
+    }
+
+    [Test]
+    public void ErrorResultWithExceptionGetsCreatedByUsingExtension()
+    {
+        FunctionResult result = FunctionResult.WithError(new Exception(ExceptionMessage));
+
+        Assert.That(result.Success, Is.False);
+        Assert.That(result.Result, Is.Null);
+
+        Assert.That(result.Error.Message, Is.EqualTo(ExceptionMessage));
+        Assert.That(result.Error.Exception, Is.TypeOf<Exception>());
+        Assert.That(result.ToString(), Is.EqualTo(ExceptionMessage));
+    }
+
+    [Test]
+    public void CannotCreateErrorResultWithNullExeption()
+    {
+        Assert.Throws<ArgumentNullException>(() => { FunctionResult.WithError((Exception)null); });
+    }
+
+    [Test]
+    public void CannotCreateErrorResultWithNullMessage()
+    {
+        Assert.Throws<ArgumentNullException>(() => { FunctionResult.WithError((string)null); });
+    }
+
+    [Test]
+    public void ExecutesFuncOnError()
+    {
+        FunctionResult.WithError("500")
+            .Then(_funcMockSuccess.Object)
+            .Catch(_funcMockError.Object)
+            ;
+
+        _funcMockSuccess.Verify(f => f(It.IsAny<Nothing>()), Times.Never);
+        _funcMockError.Verify(f => f(It.IsAny<FunctionResultError>()), Times.Once);
+    }
+
+    [Test]
+    public void ExecutesFuncOnSuccess()
+    {
+        FunctionResult.Ok()
+            .Catch(_funcMockError.Object)
+            .Then(_funcMockSuccess.Object)
+            ;
+
+        _funcMockSuccess.Verify(f => f(It.IsAny<Nothing>()), Times.Once);
+        _funcMockError.Verify(f => f(It.IsAny<FunctionResultError>()), Times.Never);
+    }
+
+    [Test]
+    public void ExecutesActionOnError()
+    {
+        FunctionResult.WithError("500")
+            .Then(_actionMockSuccess.Object)
+            .Catch(_actionMockError.Object)
+            ;
+
+        _actionMockSuccess.Verify(a => a(It.IsAny<Nothing>()), Times.Never);
+        _actionMockError.Verify(a => a(It.IsAny<FunctionResultError>()), Times.Once);
+    }
+
+    [Test]
+    public void ExecutesActionOnSuccess()
+    {
+        FunctionResult.Ok()
+             .Catch(_actionMockError.Object)
+             .Then(_actionMockSuccess.Object)
+             ;
+
+        _actionMockSuccess.Verify(a => a(It.IsAny<Nothing>()), Times.Once);
+        _actionMockError.Verify(a => a(It.IsAny<FunctionResultError>()), Times.Never);
+    }
+}

--- a/src/Tests/Moryx.Tests/Tools/FunctionResultWithTypeTests.cs
+++ b/src/Tests/Moryx.Tests/Tools/FunctionResultWithTypeTests.cs
@@ -1,0 +1,293 @@
+// Copyright (c) 2023, Phoenix Contact GmbH & Co. KG
+// Licensed under the Apache License, Version 2.0
+
+using NUnit.Framework;
+using System;
+using Moq;
+using Moryx.Tools.FunctionResult;
+
+namespace Moryx.Tests.Tools;
+
+[TestFixture]
+public class FunctionResultWithTypeTests : FunctionResultTestsBase
+{
+    protected Mock<Func<int, FunctionResult<int>>> _funcMockSuccess;
+    protected Mock<Func<FunctionResultError, FunctionResult<int>>> _funcMockError;
+
+    protected Mock<Action<int>> _actionMockSuccess;
+    protected Mock<Action<FunctionResultError>> _actionMockError;
+
+    [SetUp]
+    public void Setup()
+    {
+        _funcMockSuccess = new Mock<Func<int, FunctionResult<int>>>();
+        _funcMockSuccess
+            .Setup(f => f(It.IsAny<int>()))
+            .Returns((int arg) => new FunctionResult<int>(arg));
+        _funcMockError = new Mock<Func<FunctionResultError, FunctionResult<int>>>();
+        _funcMockError
+            .Setup(f => f(It.IsAny<FunctionResultError>()))
+            .Returns((FunctionResultError arg) => new FunctionResult<int>(arg));
+
+        _actionMockSuccess = new Mock<Action<int>>();
+        _actionMockError = new Mock<Action<FunctionResultError>>();
+    }
+
+    [Test]
+    public void ResultWithValueGetsCreated()
+    {
+        var result = new FunctionResult<int>(1);
+
+        Assert.That(result.Success, Is.True);
+        Assert.That(result.Error, Is.Null);
+        Assert.That(result.Result, Is.EqualTo(1));
+        Assert.That(result.ToString(), Is.EqualTo("1"));
+    }
+
+    [Test]
+    public void ErrorResultWithMessageGetsCreated()
+    {
+        var result = new FunctionResult<int>(new FunctionResultError(Message));
+
+        Assert.That(result.Success, Is.False);
+        Assert.That(result.Result, Is.EqualTo(0));
+
+        Assert.That(result.Error.Message, Is.EqualTo(Message));
+        Assert.That(result.Error.Exception, Is.Null);
+        Assert.That(result.ToString(), Is.EqualTo(Message));
+    }
+
+    [Test]
+    public void ErrorResultWithExceptionGetsCreated()
+    {
+        var result = new FunctionResult<int>(new FunctionResultError(new Exception(ExceptionMessage)));
+
+        Assert.That(result.Success, Is.False);
+        Assert.That(result.Result, Is.EqualTo(0));
+
+        Assert.That(result.Error.Message, Is.EqualTo(ExceptionMessage));
+        Assert.That(result.Error.Exception, Is.TypeOf<Exception>());
+        Assert.That(result.ToString(), Is.EqualTo(ExceptionMessage));
+    }
+
+    [Test]
+    public void ResultWithValueGetsCreatedByUsingExtension()
+    {
+        var result = FunctionResult.Ok(10);
+
+        Assert.That(result.Success, Is.True);
+        Assert.That(result.Result, Is.EqualTo(10));
+
+        Assert.That(result.Error, Is.Null);
+        Assert.That(result.ToString(), Is.EqualTo("10"));
+    }
+
+    [Test]
+    public void ErrorResultWithMessageGetsCreatedByUsingExtension()
+    {
+        var result = FunctionResult.WithError<int>(Message);
+
+        Assert.That(result.Success, Is.False);
+        Assert.That(result.Result, Is.EqualTo(0));
+
+
+        Assert.That(result.Error.Message, Is.EqualTo(Message));
+        Assert.That(result.Error.Exception, Is.Null);
+        Assert.That(result.ToString(), Is.EqualTo(Message));
+    }
+
+    [Test]
+    public void ErrorResultWithExceptionGetsCreatedByUsingExtension()
+    {
+        var result = FunctionResult.WithError<int>(new Exception(ExceptionMessage));
+
+        Assert.That(result.Success, Is.False);
+        Assert.That(result.Result, Is.EqualTo(0));
+
+        Assert.That(result.Error.Message, Is.EqualTo(ExceptionMessage));
+        Assert.That(result.Error.Exception, Is.TypeOf<Exception>());
+        Assert.That(result.ToString(), Is.EqualTo(ExceptionMessage));
+    }
+
+    [Test]
+    public void ResultToStringEqualsTheResultsToStringReturnValue()
+    {
+        var floatResult = FunctionResult.Ok(3.14f);
+        string floatAsString = Convert.ToString(3.14f); // avoid localization issues
+        var noResult = FunctionResult.Ok(new Nothing());
+        var nullResult = FunctionResult.Ok<object>(null);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That($"{floatResult}", Is.EqualTo(floatAsString));
+            Assert.That($"{noResult}", Is.EqualTo(new Nothing().ToString()));
+            Assert.That($"{nullResult}", Is.EqualTo("null"));
+        });
+    }
+
+    [Test]
+    public void CannotCreateErrorResultWithNullExeption()
+    {
+        Assert.Throws<ArgumentNullException>(() => { FunctionResult.WithError<int>((Exception)null); });
+    }
+
+    [Test]
+    public void CannotCreateErrorResultWithNullMessage()
+    {
+        Assert.Throws<ArgumentNullException>(() => { FunctionResult.WithError<int>((string)null); });
+    }
+
+    [Test]
+    public void SuccessResultMatchesSuccess()
+    {
+        var result = FunctionResult.Ok(200);
+
+        var matchResult = result
+            .Match(
+                success: _funcMockSuccess.Object,
+                error: _funcMockError.Object
+            );
+
+        _funcMockSuccess.Verify(f => f(It.IsAny<int>()), Times.Once);
+        _funcMockError.Verify(f => f(It.IsAny<FunctionResultError>()), Times.Never);
+
+        Assert.That(result, Is.Not.SameAs(matchResult));
+    }
+
+
+    [Test]
+    public void ErrorResultMatchesErrorWithException()
+    {
+        var result = FunctionResult.WithError<int>(new Exception("Internal server error"));
+
+        var matchResult = result
+            .Match(
+                success: _funcMockSuccess.Object,
+                error: _funcMockError.Object
+            );
+
+        _funcMockSuccess.Verify(f => f(It.IsAny<int>()), Times.Never);
+        _funcMockError.Verify(f => f(It.IsAny<FunctionResultError>()), Times.Once);
+
+        // The assertion verifies, that the result can be different from the original
+        Assert.That(result, Is.Not.SameAs(matchResult));
+    }
+
+    [Test]
+    public void ErrorResultMatchesErrorWithMessage()
+    {
+        var result = FunctionResult.WithError<int>("500");
+
+        var matchResult = result
+            .Match(
+                success: _funcMockSuccess.Object,
+                error: _funcMockError.Object
+            );
+
+        _funcMockSuccess.Verify(f => f(It.IsAny<int>()), Times.Never);
+        _funcMockError.Verify(f => f(It.IsAny<FunctionResultError>()), Times.Once);
+
+        // The assertion verifies, that the result can be different from the original
+        Assert.That(result, Is.Not.SameAs(matchResult));
+    }
+
+    [Test]
+    public void SuccessResultMatchesSuccessAction()
+    {
+        var result = FunctionResult.Ok(200);
+
+        var matchResult = result
+             .Match(
+                success: _actionMockSuccess.Object,
+                error: _actionMockError.Object
+            );
+
+        _actionMockSuccess.Verify(a => a(It.IsAny<int>()), Times.Once);
+        _actionMockError.Verify(a => a(It.IsAny<FunctionResultError>()), Times.Never);
+
+        Assert.That(result, Is.SameAs(matchResult));
+    }
+
+    [Test]
+    public void ExceptionResultMatchesErrorAction()
+    {
+        var result = FunctionResult.WithError<int>(new Exception("Internal server error"));
+
+        var matchResult = result
+            .Match(
+                success: _actionMockSuccess.Object,
+                error: _actionMockError.Object
+            );
+
+        _actionMockSuccess.Verify(a => a(It.IsAny<int>()), Times.Never);
+        _actionMockError.Verify(a => a(It.IsAny<FunctionResultError>()), Times.Once);
+
+        Assert.That(result, Is.SameAs(matchResult));
+    }
+
+    [Test]
+    public void ErrorMessageResultMatchesErrorAction()
+    {
+        var result = FunctionResult.WithError<int>("500");
+
+        var matchResult = result
+            .Match(
+                success: _actionMockSuccess.Object,
+                error: _actionMockError.Object
+            );
+
+        _actionMockSuccess.Verify(a => a(It.IsAny<int>()), Times.Never);
+        _actionMockError.Verify(a => a(It.IsAny<FunctionResultError>()), Times.Once);
+
+        Assert.That(result, Is.SameAs(matchResult));
+    }
+
+    [Test]
+    public void ExecutesFuncOnError()
+    {
+        FunctionResult.WithError<int>("500")
+            .Then(_funcMockSuccess.Object)
+            .Catch(_funcMockError.Object)
+            ;
+
+        _funcMockSuccess.Verify(f => f(It.IsAny<int>()), Times.Never);
+        _funcMockError.Verify(f => f(It.IsAny<FunctionResultError>()), Times.Once);
+    }
+
+    [Test]
+    public void ExecutesFuncOnSuccess()
+    {
+        FunctionResult.Ok(201)
+            .Catch(_funcMockError.Object)
+            .Then(_funcMockSuccess.Object)
+            ;
+
+        _funcMockSuccess.Verify(f => f(It.IsAny<int>()), Times.Once);
+        _funcMockError.Verify(f => f(It.IsAny<FunctionResultError>()), Times.Never);
+    }
+
+    [Test]
+    public void ExecutesActionOnError()
+    {
+        FunctionResult.WithError<int>("500")
+            .Then(_actionMockSuccess.Object)
+            .Catch(_actionMockError.Object)
+            ;
+
+        _actionMockSuccess.Verify(a => a(It.IsAny<int>()), Times.Never);
+        _actionMockError.Verify(a => a(It.IsAny<FunctionResultError>()), Times.Once);
+    }
+
+    [Test]
+    public void ExecutesActionOnSuccess()
+    {
+        FunctionResult.Ok(42)
+             .Catch(_actionMockError.Object)
+             .Then(_actionMockSuccess.Object)
+             ;
+
+        _actionMockSuccess.Verify(a => a(It.IsAny<int>()), Times.Once);
+        _actionMockError.Verify(a => a(It.IsAny<FunctionResultError>()), Times.Never);
+    }
+
+}


### PR DESCRIPTION
Add generic `FunctionResult<TResult>` that allows functions to always return a proper result, that either contains a valid value or an error and helps exercising error handling.

