### PR TITLE
Add `ICameraDriver`

### DIFF
--- a/src/Moryx.AbstractionLayer/Drivers/Camera/ICameraDriver.cs
+++ b/src/Moryx.AbstractionLayer/Drivers/Camera/ICameraDriver.cs
@@ -1,0 +1,31 @@
+﻿using Moryx.AbstractionLayer.Drivers;
+using System.Threading.Tasks;
+
+namespace Moryx.Drivers.Camera.Interfaces
+{
+    /// <summary>
+    /// Interface for camera devices, that provide image data
+    /// </summary>
+    public interface ICameraDriver<TImage> : IDriver where TImage : class
+    {
+        /// <summary>
+        /// Registers an ICameraDriverListener that should be provided
+        /// with images.
+        /// </summary>
+        void Register(ICameraDriverListener<TImage> listener);
+
+        /// <summary>
+        /// Unregisters an ICameraDriverListener
+        /// </summary>
+        void Unregister(ICameraDriverListener<TImage> listener);
+
+        /// <summary>
+        /// Capture a single image from the camera
+        /// </summary>
+        /// <returns>
+        ///     The image that was captured or null in case no image 
+        ///     could be retrieved
+        /// </returns>
+        Task<TImage?> CaptureImage();
+    }
+}

--- a/src/Moryx.AbstractionLayer/Drivers/Camera/ICameraDriverListener.cs
+++ b/src/Moryx.AbstractionLayer/Drivers/Camera/ICameraDriverListener.cs
@@ -1,0 +1,18 @@
+﻿using Moryx.AbstractionLayer.Drivers;
+using System.Threading.Tasks;
+
+namespace Moryx.Drivers.Camera.Interfaces
+{
+    /// <summary>
+    /// Interface for objects that register as listeners to camera drivers
+    /// </summary>
+    public interface ICameraDriverListener<T> where T : class
+    {
+        /// <summary>
+        /// Invoked, when a new image is received by the camera
+        /// </summary>
+        /// <param name="image"></param>
+        /// <returns></returns>
+        Task OnImage(T image);
+    }
+}


### PR DESCRIPTION
Defines the interfaces for retrieving images from camera devices. Either directly or by registering for continuous streams.

