### PR TITLE
Filter generic base types when seaching for the resource proxy type

### DIFF
--- a/.build/Common.props
+++ b/.build/Common.props
@@ -1,16 +1,16 @@
 <Project>
 
   <PropertyGroup>
-    <AssemblyVersion>0.0.0</AssemblyVersion>
+    <AssemblyVersion>6.0.0</AssemblyVersion>
     <AssemblyVersion Condition="'$(MORYX_ASSEMBLY_VERSION)'!=''">$(MORYX_ASSEMBLY_VERSION)</AssemblyVersion>
 
-    <FileVersion>0.0.0.0</FileVersion>
+    <FileVersion>6.0.0.0</FileVersion>
     <FileVersion Condition="'$(MORYX_FILE_VERSION)'!=''">$(MORYX_FILE_VERSION)</FileVersion>
 
-    <InformationalVersion>0.0.0.0</InformationalVersion>
+    <InformationalVersion>6.0.0.0</InformationalVersion>
     <InformationalVersion Condition="'$(MORYX_INFORMATIONAL_VERSION)'!=''">$(MORYX_INFORMATIONAL_VERSION)</InformationalVersion>
 
-    <PackageVersion>0.0.0</PackageVersion>
+    <PackageVersion>6.0.0</PackageVersion>
     <PackageVersion Condition="'$(MORYX_PACKAGE_VERSION)'!=''">$(MORYX_PACKAGE_VERSION)</PackageVersion>
 
     <Authors>PHOENIXCONTACT</Authors>

--- a/MORYX-Framework.sln
+++ b/MORYX-Framework.sln
@@ -60,6 +60,7 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{DFC092A6-B935-4D19-A564-9AEDEEF999B9}"
 	ProjectSection(SolutionItems) = preProject
 		Build.ps1 = Build.ps1
+		.build\Common.props = .build\Common.props
 		Directory.build.props = Directory.build.props
 		Directory.Build.targets = Directory.Build.targets
 		LICENSE = LICENSE
@@ -118,9 +119,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Moryx.Runtime.Endpoints.Tes
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Moryx.Runtime.Endpoints.IntegrationTests", "src\Tests\Moryx.Runtime.Endpoints.IntegrationTests\Moryx.Runtime.Endpoints.IntegrationTests.csproj", "{4FFB98A7-9A4C-476F-8BCC-C19B7F757BF8}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Moryx.TestTools.NUnit", "src\Moryx.TestTools.NUnit\Moryx.TestTools.NUnit.csproj", "{6FF878E0-AF61-4C3A-9B9C-71C35A949E51}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Moryx.TestTools.NUnit", "src\Moryx.TestTools.NUnit\Moryx.TestTools.NUnit.csproj", "{6FF878E0-AF61-4C3A-9B9C-71C35A949E51}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Moryx.TestTools.IntegrationTest", "src\Moryx.TestTools.IntegrationTest\Moryx.TestTools.IntegrationTest.csproj", "{C949164C-0345-4893-9E4C-A79BC1F93F85}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Moryx.TestTools.IntegrationTest", "src\Moryx.TestTools.IntegrationTest\Moryx.TestTools.IntegrationTest.csproj", "{C949164C-0345-4893-9E4C-A79BC1F93F85}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -356,8 +357,8 @@ Global
 		{C949164C-0345-4893-9E4C-A79BC1F93F85} = {953AAE25-26C8-4A28-AB08-61BAFE41B22F}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
-		    RESX_ShowErrorsInErrorList = True
-		RESX_TaskErrorCategory = Message
 		SolutionGuid = {36EFC961-F4E7-49DC-A36A-99594FFB8243}		
+		RESX_TaskErrorCategory = Message
+		    RESX_ShowErrorsInErrorList = True
 	EndGlobalSection
 EndGlobal

--- a/src/Moryx.AbstractionLayer.Resources.Endpoints/Moryx.AbstractionLayer.Resources.Endpoints.csproj
+++ b/src/Moryx.AbstractionLayer.Resources.Endpoints/Moryx.AbstractionLayer.Resources.Endpoints.csproj
@@ -6,6 +6,7 @@
     <Description>REST Api in order to interact with the resource management</Description>
     <CreatePackage>true</CreatePackage>
     <PackageTags>MORYX;IIoT;IoT;Resource</PackageTags>
+	<IsPackable>true</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Moryx.AbstractionLayer/Moryx.AbstractionLayer.csproj
+++ b/src/Moryx.AbstractionLayer/Moryx.AbstractionLayer.csproj
@@ -6,6 +6,7 @@
     <Description>Domain model types and definitions of Cyber-physical systems in IIoT projects.</Description>
     <CreatePackage>true</CreatePackage>
     <PackageTags>MORYX;IIoT;IoT;Hardware;Communication;Manufacturing;Industrial;Abstraction;Realtime</PackageTags>
+    <IsPackable>true</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Moryx.Asp.Extensions/Moryx.Asp.Extensions.csproj
+++ b/src/Moryx.Asp.Extensions/Moryx.Asp.Extensions.csproj
@@ -5,6 +5,7 @@
 		<Description>Extensions for the Integration of MORYX in ASP.NET Core</Description>
 		<CreatePackage>true</CreatePackage>
 		<PackageTags>MORYX;ASP</PackageTags>
+		<IsPackable>true</IsPackable>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/src/Moryx.Container/Moryx.Container.csproj
+++ b/src/Moryx.Container/Moryx.Container.csproj
@@ -6,6 +6,7 @@
     <Description>MORYX container functionality based on Castle.Windsor.</Description>
     <CreatePackage>true</CreatePackage>
     <PackageTags>MORYX;Container;IoC</PackageTags>
+    <IsPackable>true</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Moryx.Model.InMemory/Moryx.Model.InMemory.csproj
+++ b/src/Moryx.Model.InMemory/Moryx.Model.InMemory.csproj
@@ -6,6 +6,7 @@
     <Description>InMemory extension for unit tests referencing Moryx.Model</Description>
     <CreatePackage>true</CreatePackage>
     <PackageTags>MORYX;Entity;Framework;EntityFramework;DataModel;Model;Database;InMemory;Effort</PackageTags>
+	<IsPackable>true</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Moryx.Model.PostgreSQL/Moryx.Model.PostgreSQL.csproj
+++ b/src/Moryx.Model.PostgreSQL/Moryx.Model.PostgreSQL.csproj
@@ -6,6 +6,7 @@
     <Description>Adapter for Moryx.Model on PostgreSQL</Description>
     <CreatePackage>true</CreatePackage>
     <PackageTags>MORYX;Entity;Framework;EntityFramework;DataModel;Model;Database;Npgsql;PostgreSQL;Postgres</PackageTags>
+	<IsPackable>true</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Moryx.Model.Sqlite/Moryx.Model.Sqlite.csproj
+++ b/src/Moryx.Model.Sqlite/Moryx.Model.Sqlite.csproj
@@ -6,6 +6,7 @@
     <Description>Adapter for Moryx.Model on Sqlite</Description>
     <CreatePackage>true</CreatePackage>
     <PackageTags>MORYX;Entity;Framework;EntityFramework;DataModel;Model;Database;Sqlite</PackageTags>
+	<IsPackable>true</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Moryx.Model/Moryx.Model.csproj
+++ b/src/Moryx.Model/Moryx.Model.csproj
@@ -6,6 +6,7 @@
     <Description>Datamodel integration for MORYX applications based on Entity Framework</Description>
     <CreatePackage>true</CreatePackage>
     <PackageTags>MORYX;Entity;Framework;EntityFramework;DataModel;Model;Database</PackageTags>
+	<IsPackable>true</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Moryx.Notifications/Moryx.Notifications.csproj
+++ b/src/Moryx.Notifications/Moryx.Notifications.csproj
@@ -6,6 +6,7 @@
     <Description>Types and interfaces for notifications within MORYX applications</Description>
     <CreatePackage>true</CreatePackage>
     <PackageTags>MORYX;IIoT;IoT;Notifications</PackageTags>
+	<IsPackable>true</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Moryx.Resources.Management/Moryx.Resources.Management.csproj
+++ b/src/Moryx.Resources.Management/Moryx.Resources.Management.csproj
@@ -7,6 +7,7 @@
     <Description>ResourceManagement module composing and maintaining the resource graph as the habitat for digital twins of manufacturing assets.</Description>
     <CreatePackage>true</CreatePackage>
     <PackageTags>MORYX;IIoT;IoT;Manufacturing;API;Resource</PackageTags>
+	<IsPackable>true</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Moryx.Resources.Management/Resources/ResourceTypeController.cs
+++ b/src/Moryx.Resources.Management/Resources/ResourceTypeController.cs
@@ -264,17 +264,19 @@ namespace Moryx.Resources.Management
         /// </summary>
         private void ProvideProxyType(Type resourceType)
         {
-            // Step 1: Find the least specific base type that offers the same amount of interfaces
+            // Step 1: Find the least specific base type that offers the same amount of interfaces and is not a generic itself
             // ReSharper disable once AssignNullToNotNullAttribute -> FullName should be not null
             var targetType = _typeCache[resourceType.ResourceType()];
             var linker = targetType;
 
             var interfaces = RelevantInterfaces(linker);
-            // Move up the type tree until the parent offers less interfaces than the current linker
-            while (linker.BaseType != null && interfaces.Count == RelevantInterfaces(linker.BaseType).Count)
+            // Move up the type tree until the parent offers less interfaces than the current linker, is abstract or a generic
+            while (linker.BaseType != null && !linker.BaseType.ResourceType.IsGenericType 
+                && interfaces.Count == RelevantInterfaces(linker.BaseType).Count)
             {
                 linker = linker.BaseType;
             }
+                
 
             // Step 2: Check if we already created a proxy for this type. If we already
             // did use this one for the requested type as well.

--- a/src/Moryx.Runtime.Kernel/Moryx.Runtime.Kernel.csproj
+++ b/src/Moryx.Runtime.Kernel/Moryx.Runtime.Kernel.csproj
@@ -6,6 +6,7 @@
     <Description>Kernel components that comprise the MORYX server side runtime environment</Description>
     <CreatePackage>true</CreatePackage>
     <PackageTags>MORYX;Kernel;Runtime;Server</PackageTags>
+    <IsPackable>true</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Moryx.Runtime/Moryx.Runtime.csproj
+++ b/src/Moryx.Runtime/Moryx.Runtime.csproj
@@ -6,6 +6,7 @@
     <Description>Server side component types and implementations for MORYX applications</Description>
     <CreatePackage>true</CreatePackage>
     <PackageTags>MORYX;Runtime;Server</PackageTags>
+	<IsPackable>true</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Moryx/Moryx.csproj
+++ b/src/Moryx/Moryx.csproj
@@ -7,6 +7,7 @@
     <Description>Core package of the MORYX ecosystem. It defines the necessary types for MORYX compatibility as well as commonly required tools.</Description>
     <CreatePackage>true</CreatePackage>
     <PackageTags>MORYX;Serialization;Configuration;Logging;Core;Modules;Workplans</PackageTags>
+	<IsPackable>true</IsPackable>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'net6.0'">

--- a/src/Tests/Moryx.Resources.Management.Tests/Mocks/ResourceWithGenericMethod.cs
+++ b/src/Tests/Moryx.Resources.Management.Tests/Mocks/ResourceWithGenericMethod.cs
@@ -37,24 +37,18 @@ namespace Moryx.Resources.Management.Tests
         public event EventHandler SomeEvent;
         public event EventHandler<ICapabilities> CapabilitiesChanged;
 
-        public IList<TChannel> GenericMethod<TChannel>(string identifier)
-        {
-            throw new NotImplementedException();
-        }
+        public IList<TChannel> GenericMethod<TChannel>(string identifier) => throw new NotImplementedException();
 
-        public int MultiplyFoo(int factor)
-        {
-            throw new NotImplementedException();
-        }
+        public int MultiplyFoo(int factor) => throw new NotImplementedException();
 
-        public int MultiplyFoo(int factor, ushort offset)
-        {
-            throw new NotImplementedException();
-        }
+        public int MultiplyFoo(int factor, ushort offset) => throw new NotImplementedException();
 
-        public void RaiseEvent()
-        {
-            throw new NotImplementedException();
-        }
+        public void RaiseEvent() => throw new NotImplementedException();
     }
+
+    public interface IGenericBaseResourceInterface : IResource { }
+
+    public class GenericBaseResource<T> : Resource, IGenericBaseResourceInterface { }
+
+    public class InheritingFromGenericResource : GenericBaseResource<object> { }
 }

--- a/src/Tests/Moryx.Resources.Management.Tests/TypeControllerTests.cs
+++ b/src/Tests/Moryx.Resources.Management.Tests/TypeControllerTests.cs
@@ -223,6 +223,20 @@ namespace Moryx.Resources.Management.Tests
         }
 
         [Test]
+        public void ProxyBuilderSkipsGenericBaseTypes()
+        {
+            // Arrange
+            var driver = new InheritingFromGenericResource { Id = 42, Name = "A non generic resource inheriting from a generic base type" };
+
+            // Act
+            var proxy = _typeController.GetProxy(driver);
+
+            // Assert
+            Assert.IsNotNull(proxy);
+            Assert.IsFalse(typeof(GenericBaseResource<object>).IsAssignableFrom(proxy.GetType()));
+        }
+
+        [Test]
         public void FacadeExceptionForGenericProxy()
         {
             // Arrange


### PR DESCRIPTION
When inheriting from a generic base type without adding additional interfaces, a resource can still have a generated proxy. However, in that case the proxy builder would assume the generic base type to be the best possible fit, which cannot be proxified.

Also, adds pre-set package file versions from major version.

__Note__: As described in #343 we currently don't plan to support generic resource proxies, this only prevents falsely assumed generic types