### PR TITLE
Add types to handle communication to devices

### DIFF
--- a/src/Moryx/Communication/Connection/ConnectionAttempt.cs
+++ b/src/Moryx/Communication/Connection/ConnectionAttempt.cs
@@ -1,0 +1,62 @@
+﻿using Moryx.Container;
+using Moryx.Tools.FunctionResult;
+using System;
+
+namespace Moryx.Communication.Connection
+{
+    /// <summary>
+    /// Specialized interface of <see cref="IDeviceCommunication"/>
+    /// </summary>
+    public interface IConnectionAttempt : IDeviceCommunication;
+
+    /// <summary>
+    /// Implements a common process of establishing connections of any kind
+    /// which is defined by the user.
+    /// </summary>
+    [Plugin(LifeCycle.Transient, [typeof(IConnectionAttempt)])]
+    public class ConnectionAttempt : DeviceCommunicationBase, IConnectionAttempt
+    {
+        /// <summary>
+        /// Retry in case a connection couldn't be established
+        /// </summary>
+        public bool RetryOnFailure { get; set; } = true;
+
+        /// <summary>
+        /// Reconnect timeout in milliseconds
+        /// </summary>
+        public int TimeoutInMs { get; set; } = 10000;
+
+        /// <summary>
+        /// Starts trying to connect a connection and checks its status.
+        /// </summary>
+        public override void Start(Func<FunctionResult> communicate)
+        {
+            if (_started)
+                return;
+
+            _execute = communicate
+                       ?? throw new ArgumentException(nameof(communicate));
+            _started = true;
+
+            Start();
+        }
+
+        private void Start()
+        {
+            var result = _execute!.Invoke();
+            if (result.Success)
+            {
+                RaiseExecutedEvent();
+            }
+            else
+            {
+                RaiseFailureEvent(result);
+                if (RetryOnFailure)
+                    _timerId = ParallelOperations.ScheduleExecution(
+                        Start,
+                         TimeoutInMs,
+                         0);
+            }
+        }
+    }
+}

--- a/src/Moryx/Communication/Connection/DeviceCommunicationBase.cs
+++ b/src/Moryx/Communication/Connection/DeviceCommunicationBase.cs
@@ -1,0 +1,64 @@
+﻿using Moryx.Container;
+using Moryx.Threading;
+using Moryx.Tools.FunctionResult;
+using System;
+
+namespace Moryx.Communication.Connection
+{
+
+    /// <summary>
+    /// Implements a common process of establishing connections of any kind
+    /// which is defined by the user.
+    /// It handles the need of executing frequent status checks when a connection
+    /// could be established or further connection attempts when not.
+    /// </summary>
+    public abstract class DeviceCommunicationBase : IDeviceCommunication
+    {
+        /// <inheritdoc/>
+        protected int _timerId;
+
+        /// <inheritdoc/>
+        protected bool _started = false;
+
+        /// <inheritdoc/>
+        protected Func<FunctionResult> _execute;
+
+        /// <inheritdoc />
+        public event EventHandler Executed;
+        /// <inheritdoc />
+        public event EventHandler<FunctionResult> Failed;
+
+        /// <summary>
+        /// <see cref="IParallelOperations"/> to enalbe derived types
+        /// to execute parallel operations
+        /// </summary>
+        public IParallelOperations ParallelOperations { get; set; }
+
+        /// <inheritdoc />
+        public abstract void Start(Func<FunctionResult> execute);
+
+        /// <inheritdoc />
+        public virtual void Stop()
+        {
+            ParallelOperations.StopExecution(_timerId);
+            _started = false;
+        }
+
+        /// <summary>
+        /// Raises the <see cref="Executed"/> event
+        /// </summary>
+        protected void RaiseExecutedEvent()
+        {
+            Executed?.Invoke(this, EventArgs.Empty);
+        }
+
+        /// <summary>
+        /// Raises the <see cref="Failed"/> event
+        /// </summary>
+        /// <param name="result">A <see cref="FunctionResult"/> to be evaluated by the caller</param>
+        protected void RaiseFailureEvent(FunctionResult result)
+        {
+            Failed?.Invoke(this, result);
+        }
+    }
+}

--- a/src/Moryx/Communication/Connection/IDeviceCommunication.cs
+++ b/src/Moryx/Communication/Connection/IDeviceCommunication.cs
@@ -1,0 +1,36 @@
+﻿using Moryx.Tools.FunctionResult;
+using System;
+
+namespace Moryx.Communication.Connection
+{
+    /// <summary>
+    /// General interface to model any kind of communication
+    /// to and with devices
+    /// </summary>
+    public interface IDeviceCommunication
+    {
+        /// <summary>
+        /// Starts communication
+        /// </summary>
+        /// <param name="communicate">The procedure that executes
+        /// this communication</param>
+        void Start(Func<FunctionResult> communicate);
+        
+        /// <summary>
+        /// Stops the communication
+        /// </summary>
+        void Stop();
+
+        /// <summary>
+        /// Event handler to be invoked when the communication
+        /// could be executed.
+        /// </summary>
+        event EventHandler Executed;
+
+        /// <summary>
+        /// Event handler to be invoked when there was any error
+        /// during communication
+        /// </summary>
+        event EventHandler<FunctionResult> Failed;
+    }
+}

--- a/src/Moryx/Communication/Connection/StatusCheck.cs
+++ b/src/Moryx/Communication/Connection/StatusCheck.cs
@@ -1,0 +1,62 @@
+﻿using Moryx.Container;
+using Moryx.Tools.FunctionResult;
+using System;
+
+namespace Moryx.Communication.Connection
+{
+    /// <summary>
+    /// Specialized interface of <see cref="IDeviceCommunication"/>
+    /// </summary>
+    public interface IStatusCheck : IDeviceCommunication;
+
+    /// <summary>
+    /// Implements a common process of executing status checks.
+    /// </summary>
+    [Plugin(LifeCycle.Transient, [typeof(IStatusCheck)])]
+    public class StatusCheck : DeviceCommunicationBase, IStatusCheck
+    {
+        /// <summary>
+        /// Interval in which the status check is executed
+        /// </summary>
+        public int IntervalInMs { get; set; } = 5000;
+
+        /// <summary>
+        /// Starts intervally checking the status
+        /// </summary>
+        public override void Start(Func<FunctionResult> execute)
+        {
+            if (_started)
+                return;
+
+            _execute = execute;
+            _started = true;
+
+            StartStatusCheck();
+        }
+
+        private void StartStatusCheck()
+        {
+            _timerId = ParallelOperations.ScheduleExecution(
+                CheckStatus,
+                IntervalInMs,
+                0);
+        }
+
+        private void CheckStatus()
+        {
+            if (_execute != null)
+            {
+                var result = _execute.Invoke();
+                if (result.Success)
+                {
+                    RaiseExecutedEvent();
+                    StartStatusCheck();
+                }
+                else
+                {
+                    RaiseFailureEvent(result);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
`IDeviceCommunication` defines the general interface of `Start`ing and `Stop`ing connections while it leaves the details of that up to the caller.

`ConnectionAttempt` and `StatusCheck` are implementations that provide the behaviour of continuous connection attempts and status checking as we found them to be reimplemented quite often.

