### PR TITLE
Fixed transitive npgsql vulnerabilities in npgsql < v8.0.3

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,54 +1,54 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
 
-	<Import Project=".build\Common.props" Condition="'$(IsPackable)' == 'true'" />
+  <Import Project=".build\Common.props" Condition="'$(IsPackable)' == 'true'" />
 
-	<PropertyGroup>
-		<dotnetVersion>8.0.0</dotnetVersion>
-		<efCoreVersion>8.0.0</efCoreVersion>
+  <PropertyGroup>
+    <dotnetVersion>8.0.0</dotnetVersion>
+    <efCoreVersion>8.0.4</efCoreVersion>
 
-		<LangVersion>latest</LangVersion>
-	</PropertyGroup>
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
 
-	<!-- Package refereces for all projects if IsPackable=true -->
-	<ItemGroup Condition="'$(IsPackable)' == 'true'">
-		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-	</ItemGroup>
+  <!-- Package refereces for all projects if IsPackable=true -->
+  <ItemGroup Condition="'$(IsPackable)' == 'true'">
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
+  </ItemGroup>
 
-	<!-- Package versions for package references across all projects -->
-	<ItemGroup>
-		<!--3rd party dependencies-->
-		<PackageReference Update="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-		<PackageReference Update="Moq" Version="4.20.69" />
-		<PackageReference Update="NUnit" Version="3.14.0" />
-		<PackageReference Update="NUnit3TestAdapter" Version="4.5.0" />
-		<PackageReference Update="coverlet.collector" Version="6.0.0" >
-      		<PrivateAssets>all</PrivateAssets>
-      		<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-  		</PackageReference>
+  <!-- Package versions for package references across all projects -->
+  <ItemGroup>
+    <!--3rd party dependencies-->
+    <PackageReference Update="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Update="Moq" Version="4.20.69" />
+    <PackageReference Update="NUnit" Version="3.14.0" />
+    <PackageReference Update="NUnit3TestAdapter" Version="4.5.0" />
+    <PackageReference Update="coverlet.collector" Version="6.0.0" >
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
 
-		<PackageReference Update="Newtonsoft.Json" Version="13.0.3" />
-		<PackageReference Update="CommandLineParser" Version="2.9.1" />
+    <PackageReference Update="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Update="CommandLineParser" Version="2.9.1" />
 
-		<FrameworkReference Update="Microsoft.AspNetCore.App" Version="$(dotnetVersion)"/>
-		<PackageReference Update="Microsoft.Extensions.Logging" Version="$(dotnetVersion)" />
-		<PackageReference Update="Microsoft.Extensions.Configuration.Json" Version="$(dotnetVersion)" />
-		<PackageReference Update="Microsoft.Extensions.Configuration.FileExtensions" Version="$(dotnetVersion)" />
-		<PackageReference Update="Microsoft.Data.Sqlite" Version="$(dotnetVersion)" />
+    <FrameworkReference Update="Microsoft.AspNetCore.App" Version="$(dotnetVersion)"/>
+    <PackageReference Update="Microsoft.Extensions.Logging" Version="$(dotnetVersion)" />
+    <PackageReference Update="Microsoft.Extensions.Configuration.Json" Version="$(dotnetVersion)" />
+    <PackageReference Update="Microsoft.Extensions.Configuration.FileExtensions" Version="$(dotnetVersion)" />
+    <PackageReference Update="Microsoft.Data.Sqlite" Version="$(dotnetVersion)" />
 
-		<PackageReference Update="Microsoft.EntityFrameworkCore" Version="$(efCoreVersion)" />
-		<PackageReference Update="Microsoft.EntityFrameworkCore.Design" Version="$(efCoreVersion)" />
-		<PackageReference Update="Microsoft.EntityFrameworkCore.Proxies" Version="$(efCoreVersion)" />
-		<PackageReference Update="Microsoft.EntityFrameworkCore.Relational" Version="$(efCoreVersion)" />
-		<PackageReference Update="Microsoft.EntityFrameworkCore.InMemory" Version="$(efCoreVersion)" />
-		<PackageReference Update="Microsoft.EntityFrameworkCore.Sqlite" Version="$(efCoreVersion)" />
-		<PackageReference Update="Npgsql.EntityFrameworkCore.PostgreSQL" Version="$(efCoreVersion)" />
+    <PackageReference Update="Microsoft.EntityFrameworkCore" Version="$(efCoreVersion)" />
+    <PackageReference Update="Microsoft.EntityFrameworkCore.Design" Version="$(efCoreVersion)" />
+    <PackageReference Update="Microsoft.EntityFrameworkCore.Proxies" Version="$(efCoreVersion)" />
+    <PackageReference Update="Microsoft.EntityFrameworkCore.Relational" Version="$(efCoreVersion)" />
+    <PackageReference Update="Microsoft.EntityFrameworkCore.InMemory" Version="$(efCoreVersion)" />
+    <PackageReference Update="Microsoft.EntityFrameworkCore.Sqlite" Version="$(efCoreVersion)" />
+    <PackageReference Update="Npgsql.EntityFrameworkCore.PostgreSQL" Version="$(efCoreVersion)" />
 
-		<PackageReference Update="System.IO.Ports" Version="$(dotnetVersion)" />
-		<PackageReference Update="System.ComponentModel.Annotations" Version="5.0.0" />
+    <PackageReference Update="System.IO.Ports" Version="$(dotnetVersion)" />
+    <PackageReference Update="System.ComponentModel.Annotations" Version="5.0.0" />
 
-		<PackageReference Update="Castle.Windsor" Version="6.0.0" />
+    <PackageReference Update="Castle.Windsor" Version="6.0.0" />
 
-	</ItemGroup>
+  </ItemGroup>
 
 </Project>


### PR DESCRIPTION
The npgsql dependency does have open vulnerabilities

Affecting [npgsql](https://security.snyk.io/package/nuget/npgsql) package, versions [,4.0.14)[4.1.0,4.1.13)[5.0.0,5.0.18)[6.0.0-preview2,6.0.11)[7.0.0-preview.1,7.0.7)[8.0.0-preview.1,8.0.3)

Source: https://security.snyk.io/vuln/SNYK-DOTNET-NPGSQL-6825563

I updated the minimum efCore version to 8.0.4 to fix this issue.

Sorry for the amount of changes in the file but someone has destroyed the intendation. (Tabs instead of spaces)