### PR TITLE
Removed the encapsulation of ActionResult on return

### DIFF
--- a/src/Moryx.AbstractionLayer.Resources.Endpoints/ResourceManagementController.cs
+++ b/src/Moryx.AbstractionLayer.Resources.Endpoints/ResourceManagementController.cs
@@ -365,7 +365,7 @@ namespace Moryx.AbstractionLayer.Resources.Endpoints
                 throw;
             }            
 
-            return Ok(GetDetails(id));
+            return GetDetails(id);
         }
 
         [HttpDelete]


### PR DESCRIPTION
This caused titles of resources to be unnamed upon saving