### PR TITLE
Removed resource initialiers from ModuleConfig

### DIFF
--- a/src/Moryx.AbstractionLayer/Resources/IResourceManagement.cs
+++ b/src/Moryx.AbstractionLayer/Resources/IResourceManagement.cs
@@ -63,7 +63,7 @@ namespace Moryx.AbstractionLayer.Resources
             where TResource : class, IResource;
 
         /// <summary>
-        /// Get all resources inluding the private ones of this type that match the predicate
+        /// Get all resources including the private ones of this type that match the predicate
         /// </summary>
         IEnumerable<TResource> GetAllResources<TResource>(Func<TResource, bool> predicate)
             where TResource : class, IResource;
@@ -89,8 +89,6 @@ namespace Moryx.AbstractionLayer.Resources
         /// Create and initialize a resource
         /// </summary>
         bool Delete(long id);
-
-
 
         /// <summary>
         /// Event raised when a resource was added at runtime

--- a/src/Moryx.Resources.Management/ModuleController/ModuleConfig.cs
+++ b/src/Moryx.Resources.Management/ModuleController/ModuleConfig.cs
@@ -1,12 +1,8 @@
-// Copyright (c) 2023, Phoenix Contact GmbH & Co. KG
+// Copyright (c) 2025, Phoenix Contact GmbH & Co. KG
 // Licensed under the Apache License, Version 2.0
 
-using System.Collections.Generic;
-using System.ComponentModel;
 using System.Runtime.Serialization;
-using Moryx.AbstractionLayer.Resources;
 using Moryx.Configuration;
-using Moryx.Serialization;
 
 namespace Moryx.Resources.Management
 {
@@ -16,11 +12,6 @@ namespace Moryx.Resources.Management
     [DataContract]
     public class ModuleConfig : ConfigBase
     {
-        /// <summary>
-        /// If database is empty, this resource will be created by default.
-        /// </summary>
-        [DataMember, Description("Configuration of possible resource initializer")]
-        [PluginConfigs(typeof(IResourceInitializer), true)]
-        public List<ResourceInitializerConfig> Initializers { get; set; }
+
     }
 }

--- a/src/Moryx.Resources.Management/ModuleController/ModuleConsole.cs
+++ b/src/Moryx.Resources.Management/ModuleController/ModuleConsole.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, Phoenix Contact GmbH & Co. KG
+// Copyright (c) 2025, Phoenix Contact GmbH & Co. KG
 // Licensed under the Apache License, Version 2.0
 
 using System;
@@ -18,11 +18,6 @@ namespace Moryx.Resources.Management
         /// Factory to create the resource initializer
         /// </summary>
         public IResourceInitializerFactory InitializerFactory { get; set; }
-
-        /// <summary>
-        /// Config to load all configured initializer
-        /// </summary>
-        public ModuleConfig ModuleConfig { get; set; }
 
         /// <summary>
         /// Resource manager to execute initializer
@@ -50,6 +45,5 @@ namespace Moryx.Resources.Management
 
             return "Success";
         }
-
     }
 }


### PR DESCRIPTION
The configured resource initializers are not used in the module config anymore. It makes no sense to configure them.

Ideas for next major: 
- Preconfigure initializer an execute by console
- More important: Execute resource initializer from facade #246
