### PR TITLE
Make TimerId of ScheduleExecution thread safe.

### DIFF
--- a/src/Moryx/Threading/ParallelOperations.cs
+++ b/src/Moryx/Threading/ParallelOperations.cs
@@ -128,11 +128,8 @@ namespace Moryx.Threading
         /// </summary>
         public int ScheduleExecution<T>(Action<T> operation, T userState, int delayMs, int periodMs, bool criticalOperation) where T : class
         {
-            int id;
-            lock (_runningTimers)
-            {
-                id = ++_lastTimerId;
-            }
+            // thread safe increment of timer id
+            int id = Interlocked.Increment(ref _lastTimerId);
             
             var timer = new Timer(new NonStackingTimerCallback(state =>
             {

--- a/src/Moryx/Threading/ParallelOperations.cs
+++ b/src/Moryx/Threading/ParallelOperations.cs
@@ -128,18 +128,26 @@ namespace Moryx.Threading
         /// </summary>
         public int ScheduleExecution<T>(Action<T> operation, T userState, int delayMs, int periodMs, bool criticalOperation) where T : class
         {
-            var id = ++_lastTimerId;
+            int id;
+            lock (_runningTimers)
+            {
+                id = ++_lastTimerId;
+            }
+            
             var timer = new Timer(new NonStackingTimerCallback(state =>
             {
                 try
                 {
                     operation((T)state);
-                    if (periodMs <= 0)
-                        StopExecution(id);
                 }
                 catch (Exception ex)
                 {
                     HandleException(ex, operation, criticalOperation);
+                }
+                finally
+                {
+                    if (periodMs <= 0)
+                        StopExecution(id);
                 }
             }), userState, delayMs, periodMs);
 


### PR DESCRIPTION
Handle problem that two threads getting the same timer id.
Make sure a non periodical execution is stopped even also on exceptions.
<img width="1243" height="62" alt="image" src="https://github.com/user-attachments/assets/1f45691d-2b86-48a1-bdd7-1b1780230029" />
