### PR TITLE
`EntryPrototype.Identifier` supports `CREATED{any}`

### DIFF
--- a/src/Moryx/Serialization/EntryConvert/EntryConvert.cs
+++ b/src/Moryx/Serialization/EntryConvert/EntryConvert.cs
@@ -659,7 +659,7 @@ namespace Moryx.Serialization
             }
 
             // Add new entries to the collection
-            foreach (var subEntry in rootEntry.SubEntries.Where(se => se.Identifier == Entry.CreatedIdentifier))
+            foreach (var subEntry in rootEntry.SubEntries.Where(se => se.Identifier.ToLower().StartsWith(Entry.CreatedIdentifier.ToLower())))
             {
                 object item;
                 // All value types

--- a/src/Tests/Moryx.Tests/Serialization/SerializationTests.cs
+++ b/src/Tests/Moryx.Tests/Serialization/SerializationTests.cs
@@ -66,6 +66,60 @@ namespace Moryx.Tests
         }
 
         [Test]
+        public void ShouldCreateInstanceArray_WithIdentifier_ThatStart_With_CREATED()
+        {
+            // Arrange
+            var @object = new ArrayDummy
+            {
+                Array = new[] { 2, 3, 4, 5, 6 },
+                Keys = new[] { "Number: 1", "Number: 2", "Number: 3", "Number: 4", "Number: 5" }
+            };
+            var encoded = EntryConvert.EncodeObject(@object);
+
+            for (var i = 0; i < 5; i++)
+            {
+                var entry = encoded.SubEntries[0].SubEntries[i];
+                entry.Identifier = Entry.CreatedIdentifier + i;
+            }
+
+            // Act
+            var dummy = EntryConvert.CreateInstance<ArrayDummy>(encoded);
+
+            // Assert
+            for (var i = 1; i <= 5; i++)
+            {
+                Assert.AreEqual(i + 1, dummy.Array[i - 1]);
+            }
+        }
+
+        [Test]
+        public void ShouldNotCreateInstanceArray_WithIdentifier_ThatEnd_With_CREATED()
+        {
+            // Arrange
+            var @object = new ArrayDummy
+            {
+                Array = new[] { 2, 3, 4, 5, 6 },
+                Keys = new[] { "Number: 1", "Number: 2", "Number: 3", "Number: 4", "Number: 5" }
+            };
+            var encoded = EntryConvert.EncodeObject(@object);
+
+            for (var i = 0; i < 5; i++)
+            {
+                var entry = encoded.SubEntries[0].SubEntries[i];
+                entry.Identifier = i + Entry.CreatedIdentifier;
+            }
+
+            // Act
+            var dummy = EntryConvert.CreateInstance<ArrayDummy>(encoded);
+
+            // Assert
+            for (var i = 1; i <= 5; i++)
+            {
+                Assert.AreNotEqual(i + 1, dummy.Array[i - 1]);
+            }
+        }
+
+        [Test]
         public void CreateInstanceWithArray()
         {
             // Arrange


### PR DESCRIPTION
Previously the identifier of entry prototype was  only checking for exact id==`CREATED` match which would break in certain scenario for example if the UI doesn't set the id as `CREATED` any other variation would fail.

Instead or `identifier=='CREATED'` now we check if the identifier contains any variation of  id `CREATED` since the UI now sets the identifier as `CREATED1`,`CREATED2`. The current solution is more flexible.