### PR TITLE
Fix pagination for notifications in `Moryx.CommandCenter.Web`

### DIFF
--- a/src/Moryx.CommandCenter.Web/src/modules/container/Notifications.tsx
+++ b/src/Moryx.CommandCenter.Web/src/modules/container/Notifications.tsx
@@ -7,7 +7,9 @@ import Table from "@mui/material/Table";
 import TableBody from "@mui/material/TableBody";
 import TableCell from "@mui/material/TableCell";
 import TableContainer from "@mui/material/TableContainer";
+import TableFooter from "@mui/material/TableFooter";
 import TableHead from "@mui/material/TableHead";
+import TablePagination from "@mui/material/TablePagination";
 import TableRow from "@mui/material/TableRow";
 import * as React from "react";
 import NotificationModel from "../models/NotificationModel";
@@ -17,15 +19,51 @@ interface NotificationsPropModel {
     messages: NotificationModel[];
 }
 
-export class Notifications extends React.Component<NotificationsPropModel> {
+interface NotificationPaginationState {
+    page: number;
+    rowsPerPage: number;
+}
+
+const defaultPageIndex: number = 0;
+const defaultRowsPerPage: number = 25;
+
+export class Notifications extends React.Component<NotificationsPropModel, NotificationPaginationState> {
 
     constructor(props: NotificationsPropModel) {
         super(props);
-
+        this.state = {
+            page: defaultPageIndex,
+            rowsPerPage: defaultRowsPerPage
+        };
     }
 
     public render() {
         const messages = this.props.messages;
+        const { page, rowsPerPage } = this.state;
+
+        const paginatedMessages = messages.slice(
+            page * rowsPerPage,
+            page * rowsPerPage + rowsPerPage
+        );
+
+        const handlePageChange = (_event: unknown, newPage: number): void => {
+            this.setState({ page: newPage });
+        };
+
+        const getCurrentPage = (currentPageIndex: number, totalPageNum: number): number => {
+            return currentPageIndex > totalPageNum - 1 ? totalPageNum - 1 : currentPageIndex;
+        };
+
+        const handleChangeRowsPerPage = (
+            event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
+        ): void => {
+            const newRowsPerPage = parseInt(event.target.value, 10);
+            this.setState({
+                rowsPerPage: newRowsPerPage,
+                page: getCurrentPage(this.state.page, Math.ceil(messages.length / newRowsPerPage))
+            });
+        };
+
         return (
             <TableContainer>
                 <Table
@@ -40,9 +78,8 @@ export class Notifications extends React.Component<NotificationsPropModel> {
                         </TableRow>
                     </TableHead>
                     <TableBody>
-                        { (messages.length > 0)
-                            ? (messages.map((message, idx) => (
-
+                        { (paginatedMessages.length > 0)
+                            ? (paginatedMessages.map((message, idx) => (
                                 <NotificationRow message={message}/>
                             )))
                             : <TableRow>
@@ -50,9 +87,18 @@ export class Notifications extends React.Component<NotificationsPropModel> {
                             </TableRow>
                         }
                     </TableBody>
+                    <TableFooter>
+                        <TablePagination
+                            count={messages.length}
+                            page={page}
+                            onPageChange={handlePageChange}
+                            rowsPerPage={rowsPerPage}
+                            onRowsPerPageChange={handleChangeRowsPerPage}
+                            rowsPerPageOptions={[25, 50, 100]}
+                        />
+                    </TableFooter>
                 </Table >
             </TableContainer >
         );
-
     }
 }


### PR DESCRIPTION
Notifications are no longer infinitely added below one another. 
Added Material-UI `TablePagination` to the table in `Notifications.tsx`. 
Changing `rowsPerPage` only updates the current page if it exceeds the max page number.

<img width="1167" height="795" alt="image" src="https://github.com/user-attachments/assets/9855bff2-7358-47a4-83ae-b56e99410334" />
<img width="1160" height="1040" alt="image" src="https://github.com/user-attachments/assets/08609ef3-61a0-4cb8-85e6-0cbee1113295" />
<img width="1164" height="701" alt="Screenshot 2025-08-07 152355" src="https://github.com/user-attachments/assets/f501bad1-15d9-4647-b856-a0977a810f8b" />

