### PR TITLE
FIX: Allow numbers in TextBindingResolver

### DIFF
--- a/src/Moryx/Bindings/TextBindingResolverFactory.cs
+++ b/src/Moryx/Bindings/TextBindingResolverFactory.cs
@@ -14,7 +14,7 @@ namespace Moryx.Bindings
         /// Regex for binding.
         /// It matches strings of type "Product.Id" or "Recipe".
         /// </summary>
-        private const string BindingRegex = @"\{(?<binding>[A-Z][a-z][0-9]+(\.?[A-Z]\w+(?:\[\w+\])?)*)(?<hasFormat>:(?<format>\w+))?\}";
+        private const string BindingRegex = @"\{(?<binding>([A-Za-z_][A-Za-z0-9_]*)(\[\d+\])?(\.([A-Za-z_][A-Za-z0-9_]*)(\[\d+\])?)*)?(?<hasFormat>:(?<format>\w+))?\}";
 
         /// <summary>
         /// Create resolver for this instruction


### PR DESCRIPTION
In cases where propertynames contain a number, e.g. "Comment1", they will be excluded from the resolver. This should fix the problem.

<img width="963" height="546" alt="image" src="https://github.com/user-attachments/assets/6ab5da0a-d355-4d6c-b4c3-9d18b4b9be03" />
