### PR TITLE
Fix nullable porperties serialization exception in `EntryConvert`

### DIFF
--- a/src/Moryx/Serialization/EntryConvert/EntryConvert.cs
+++ b/src/Moryx/Serialization/EntryConvert/EntryConvert.cs
@@ -127,7 +127,12 @@ namespace Moryx.Serialization
             else if (entryValue.Possible != null && entryValue.Possible.Length >= 1)
                 entryValue.Default = entryValue.Possible[0];
             else if (property.PropertyType.IsValueType)
-                entryValue.Default = Activator.CreateInstance(property.PropertyType).ToString();
+            {
+                var underlyingType = Nullable.GetUnderlyingType(property.PropertyType);
+                entryValue.Default = underlyingType != null
+                    ? Activator.CreateInstance(underlyingType).ToString()
+                    : Activator.CreateInstance(property.PropertyType).ToString();
+            }
 
             // Value types should have the default value as current value
             if (ValueOrStringType(property.PropertyType))

--- a/src/Tests/Moryx.Tests/Serialization/DummyClass.cs
+++ b/src/Tests/Moryx.Tests/Serialization/DummyClass.cs
@@ -53,4 +53,9 @@ namespace Moryx.Tests
         ValueA,
         ValueB
     }
+
+    public class NullablePropertiesClass
+    {
+        public int? Value { get; set; } = 0;
+    }
 }

--- a/src/Tests/Moryx.Tests/Serialization/SerializationTests.cs
+++ b/src/Tests/Moryx.Tests/Serialization/SerializationTests.cs
@@ -847,6 +847,14 @@ namespace Moryx.Tests
             Assert.AreEqual("VGhpcyBpcyBhIHRlc3Q=", entry.SubEntries[0].Value.Current);
         }
 
+        [Test(Description = "Testing nullable properties")]
+        public void NullableProperty()
+        {
+            var nullablePropertiesObject = new NullablePropertiesClass();
+
+            Assert.DoesNotThrow(() => EntryConvert.EncodeObject(nullablePropertiesObject));
+        }
+
         [Test(Description = "Decodes to a MemoryStream and creates a new stream")]
         public void MemoryStreamDecode()
         {


### PR DESCRIPTION
Issue:
Nullable primitive type throws exception on serialization.

Solution:
Now `EntryConvertGenerator.TransformType()` returns `EntryValueType.Exception` if propertyType parameter is nullable primitive type.

[Port for release/6 #558 ]

