### PR TITLE
Add default redirect to properties in product details route

### DIFF
--- a/src/Moryx.Products.Web/src/app/app.routes.ts
+++ b/src/Moryx.Products.Web/src/app/app.routes.ts
@@ -11,34 +11,35 @@ import { SearchResultComponent } from "./components/search-result/search-result.
 import { ImporterGuard } from "./guards/importer.guard";
 
 export const routes: Routes = [
-    {
-        path: 'details/:id',
-        component: ProductsDetailsViewComponent,
+  {
+    path: 'details/:id',
+    component: ProductsDetailsViewComponent,
+    children: [
+      { path: '', redirectTo: 'properties', pathMatch: 'full' },
+      { path: 'properties', component: ProductPropertiesComponent },
+      { path: 'references', component: ProductReferencesComponent },
+      {
+        path: 'parts/:partName/:partId',
+        component: ProductPartsComponent,
+      },
+      {
+        path: 'recipes',
+        component: ProductRecipesComponent,
         children: [
-          { path: 'properties', component: ProductPropertiesComponent },
-          { path: 'references', component: ProductReferencesComponent },
-          {
-            path: 'parts/:partName/:partId',
-            component: ProductPartsComponent,
-          },
-          {
-            path: 'recipes',
-            component: ProductRecipesComponent,
-            children: [
-              { path: '', component: DefaultViewComponent, pathMatch: 'full' },
+          { path: '', component: DefaultViewComponent, pathMatch: 'full' },
               {
                 path: ':recipeId',
                 component: ProductRecipesDetailsComponent,
               },
-            ],
-          },
         ],
       },
-      { path: '', component: DefaultViewComponent, pathMatch: 'full' },
-      {
-        path: 'import/:importer',
-        component: ProductsImporterComponent,
-        canActivate: [ImporterGuard]
-      },
+    ],
+  },
+  { path: '', component: DefaultViewComponent, pathMatch: 'full' },
+  {
+    path: 'import/:importer',
+    component: ProductsImporterComponent,
+    canActivate: [ImporterGuard]
+  },
       {path: 'search', component: SearchResultComponent}
 ]


### PR DESCRIPTION
### Summary
Added a default child route redirect for `details/:id` to `properties`.

### Changes
- Updated routing configuration so that navigating to `/details/:id` without a child path will automatically redirect to `/details/:id/properties`.

### Reason
Previously, when switching to another product from parts or recipes, the route would keep the old child path or result in an empty state, requiring a second click to show the properties tab.
With this change, `/details/:id` now consistently redirects to the properties tab, matching expected navigation behavior.