### PR TITLE
Fix invalidation of  refresh tokens

### DIFF
--- a/src/Moryx.Identity.AccessManagement/Identity/TokenService.cs
+++ b/src/Moryx.Identity.AccessManagement/Identity/TokenService.cs
@@ -224,11 +224,8 @@ namespace Moryx.Identity.AccessManagement
         public async Task InvalidateRefreshTokens(MoryxUser user)
         {
             var refreshTokens = await _dbContext.RefreshTokens.Where(token => token.UserId == user.Id).ToListAsync();
-            foreach (var refreshToken in refreshTokens)
-            {
-                _dbContext.RefreshTokens.Remove(refreshToken);
-                await _dbContext.SaveChangesAsync();
-            }
+            _dbContext.RefreshTokens.RemoveRange(refreshTokens);
+            await _dbContext.SaveChangesAsync();
         }
 
         /// <inheritdoc/>


### PR DESCRIPTION
With thousands of tokens, invalidating or deleting the refresh tokens in the database is very slow due to the for loop and leads to problems in production. Therefore RemoveRange was used instead.

(cherry picked from commit 784c0aa5c54fbe975c07004979e8c2872caca073)
