### PR TITLE
Fix concurrency exception

### DIFF
--- a/src/Moryx.Identity.AccessManagement/Controllers/API/EntraIdAuthController.cs
+++ b/src/Moryx.Identity.AccessManagement/Controllers/API/EntraIdAuthController.cs
@@ -98,7 +98,8 @@ namespace Moryx.Identity.AccessManagement.Controllers
             }
 
             await _userManager.UpdateAsync(user);
-
+            // Refetch the user from db to avoid concurrency exception while generating a token
+            user = await _userManager.FindByIdAsync(user.Id);
             var jwtToken = await _tokenService.GenerateToken(user);
             HttpContext.Response.Cookies.SetJwtCookie(jwtToken, user);
 


### PR DESCRIPTION
In some cases the user was updated while the token was not generated. That leads to a concurrency exception.

(cherry picked from commit 1e62da366a5eeaea47cf1236dbbd04eae9b5b186)
