### PR TITLE
Port: Fix border issue with Angular Material inputs

### DIFF
--- a/src/Moryx.Launcher/wwwroot/css/app.css
+++ b/src/Moryx.Launcher/wwwroot/css/app.css
@@ -2,6 +2,7 @@
 @tailwind components;
 @tailwind utilities;
 
+.mat-mdc-form-field.mat-mdc-form-field.mat-mdc-form-field.mat-mdc-form-field.mat-mdc-form-field .mdc-notched-outline__notch { border-right-style: hidden; }
 
 @layer components {
     .active {


### PR DESCRIPTION
### Background
After upgrading to Angular 19, the `mat-form-field` outline border was rendered incorrectly. The issue was caused by global CSS interfering with MDC's `mdc-notched-outline__notch`.


### Solution
Applied a CSS workaround globally via `wwwroot/app.css` to fix the visual conflict.
It affects all Angular Material inputs using the MDC outline