### PR TITLE
StateClass now inherit the fields (constant State keys)  from the parent

### DIFF
--- a/src/Moryx/StateMachines/StateBase.cs
+++ b/src/Moryx/StateMachines/StateBase.cs
@@ -168,7 +168,7 @@ namespace Moryx.StateMachines
         /// </summary>
         internal static IEnumerable<FieldInfo> GetStateFields(Type stateBaseType)
         {
-            var stateFields = from field in stateBaseType.GetFields(BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.Public)
+            var stateFields = from field in stateBaseType.GetFields(BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.FlattenHierarchy)
                 where field.IsLiteral && !field.IsInitOnly &&
                       field.FieldType.IsAssignableFrom(typeof(int)) &&
                       field.GetCustomAttribute<StateDefinitionAttribute>() != null


### PR DESCRIPTION
This PR is a continuation of the #616 PR, previously when you inherited from an abstract state base class you lost all the constants protected fields  that define the different states `StateMap`. 

```c#
public abstract class MyGeneralStateBase : StateBase<MyContext> 
{
 [StateDefinition(typeof(StartState))]
 protected const int StateStart = 100;

 //constructor
  .....
}

public abstract class MySpecificStateBase :  MyGeneralStateBase 
 {
  // Here i need to redeclare it again
 [StateDefinition(typeof(StartState))]
 protected new const int StateStart = 100;

 [StateDefinition(typeof(StopState))]
 protected const int StateStop = 101;

 //constructor
  .....
}
``` 

Now all the constant fields of the parent are inherited and taking into account in the `StateMap` :

```c#
public abstract class MyStateBase : StateBase<MyContext> 
{
   [StateDefinition(typeof(StartState))]
   protected const int StateStart = 100;
}

public abstract MySpecificStateBase :  MyGeneralStateBase 
{
   [StateDefinition(typeof(StopState))]
   protected const int StateStop = 101;

   //constructor
    .....
}
``` 
