### PR TITLE
Fix angular.json in Moryx.Operators.Web and Moryx.Shifts.Web

### DIFF
--- a/src/Moryx.Operators.Web/angular.json
+++ b/src/Moryx.Operators.Web/angular.json
@@ -18,7 +18,8 @@
           "builder": "@angular-devkit/build-angular:application",
           "options": {
             "outputPath": {
-              "base": "wwwroot"
+              "base": "wwwroot/",
+              "browser": ""
             },
             "index": "src/index.html",
             "polyfills": [

--- a/src/Moryx.Shifts.Web/angular.json
+++ b/src/Moryx.Shifts.Web/angular.json
@@ -17,7 +17,10 @@
         "build": {
           "builder": "@angular-devkit/build-angular:application",
           "options": {
-            "outputPath": "wwwroot",
+            "outputPath": {
+              "base": "wwwroot/",
+              "browser": ""
+            },
             "index": "src/index.html",
             "polyfills": ["zone.js"],
             "tsConfig": "tsconfig.app.json",

--- a/src/StartProject.Asp/StartProject.Asp.csproj
+++ b/src/StartProject.Asp/StartProject.Asp.csproj
@@ -15,16 +15,24 @@
     <ProjectReference Include="..\Moryx.Analytics.Web\Moryx.Analytics.Web.csproj" />
     <ProjectReference Include="..\Moryx.Asp.Extensions\Moryx.Asp.Extensions.csproj" />
     <ProjectReference Include="..\Moryx.CommandCenter.Web\Moryx.CommandCenter.Web.csproj" />
+    <ProjectReference Include="..\Moryx.ControlSystem.Jobs.Endpoints\Moryx.ControlSystem.Jobs.Endpoints.csproj" />
+    <ProjectReference Include="..\Moryx.ControlSystem.MaterialManager\Moryx.ControlSystem.MaterialManager.csproj" />
     <ProjectReference Include="..\Moryx.ControlSystem.ProcessEngine.Web\Moryx.ControlSystem.ProcessEngine.Web.csproj" />
     <ProjectReference Include="..\Moryx.ControlSystem.ProcessEngine\Moryx.ControlSystem.ProcessEngine.csproj" />
     <ProjectReference Include="..\Moryx.ControlSystem.Processes.Endpoints\Moryx.ControlSystem.Processes.Endpoints.csproj" />
+    <ProjectReference Include="..\Moryx.ControlSystem.SetupProvider\Moryx.ControlSystem.SetupProvider.csproj" />
+    <ProjectReference Include="..\Moryx.ControlSystem.VisualInstructions.Endpoints\Moryx.ControlSystem.VisualInstructions.Endpoints.csproj" />
+    <ProjectReference Include="..\Moryx.ControlSystem.WorkerSupport.Web\Moryx.ControlSystem.WorkerSupport.Web.csproj" />
+    <ProjectReference Include="..\Moryx.ControlSystem.WorkerSupport\Moryx.ControlSystem.WorkerSupport.csproj" />
     <ProjectReference Include="..\Moryx.Drivers.Mqtt\Moryx.Drivers.Mqtt.csproj" />
+    <ProjectReference Include="..\Moryx.Drivers.OpcUa\Moryx.Drivers.OpcUa.csproj" />
+    <ProjectReference Include="..\Moryx.Drivers.Simulation\Moryx.Drivers.Simulation.csproj" />
+    <ProjectReference Include="..\Moryx.FactoryMonitor.Endpoints\Moryx.FactoryMonitor.Endpoints.csproj" />
     <ProjectReference Include="..\Moryx.FactoryMonitor.Web\Moryx.FactoryMonitor.Web.csproj" />
     <ProjectReference Include="..\Moryx.Launcher\Moryx.Launcher.csproj" />
     <ProjectReference Include="..\Moryx.Media.Endpoints\Moryx.Media.Endpoints.csproj" />
     <ProjectReference Include="..\Moryx.Media.Server\Moryx.Media.Server.csproj" />
     <ProjectReference Include="..\Moryx.Media.Web\Moryx.Media.Web.csproj" />
-    <ProjectReference Include="..\Moryx.Model.Sqlite\Moryx.Model.Sqlite.csproj" />
     <ProjectReference Include="..\Moryx.Model\Moryx.Model.csproj" />
     <ProjectReference Include="..\Moryx.Notifications.Endpoints\Moryx.Notifications.Endpoints.csproj" />
     <ProjectReference Include="..\Moryx.Notifications.Publisher\Moryx.Notifications.Publisher.csproj" />
@@ -32,16 +40,17 @@
     <ProjectReference Include="..\Moryx.Operators.Endpoints\Moryx.Operators.Endpoints.csproj" />
     <ProjectReference Include="..\Moryx.Operators.Management\Moryx.Operators.Management.csproj" />
     <ProjectReference Include="..\Moryx.Operators.Web\Moryx.Operators.Web.csproj" />
+    <ProjectReference Include="..\Moryx.Orders.Endpoints\Moryx.Orders.Endpoints.csproj" />
+    <ProjectReference Include="..\Moryx.Orders.Management\Moryx.Orders.Management.csproj" />
     <ProjectReference Include="..\Moryx.Orders.Web\Moryx.Orders.Web.csproj" />
     <ProjectReference Include="..\Moryx.Products.Web\Moryx.Products.Web.csproj" />
+    <ProjectReference Include="..\Moryx.Resources.AssemblyInstruction\Moryx.Resources.AssemblyInstruction.csproj" />
     <ProjectReference Include="..\Moryx.Resources.Web\Moryx.Resources.Web.csproj" />
     <ProjectReference Include="..\Moryx.Runtime.Endpoints\Moryx.Runtime.Endpoints.csproj" />
     <ProjectReference Include="..\Moryx.Runtime.Kernel\Moryx.Runtime.Kernel.csproj" />
     <ProjectReference Include="..\Moryx.Shifts.Endpoints\Moryx.Shifts.Endpoints.csproj" />
     <ProjectReference Include="..\Moryx.Shifts.Management\Moryx.Shifts.Management.csproj" />
     <ProjectReference Include="..\Moryx.Shifts.Web\Moryx.Shifts.Web.csproj" />
-    <ProjectReference Include="..\Moryx.TestModule\Moryx.TestModule.csproj" />
-    <ProjectReference Include="..\Moryx.DependentTestModule\Moryx.DependentTestModule.csproj" />
 
     <ProjectReference Include="..\Moryx.AbstractionLayer.Products.Endpoints\Moryx.AbstractionLayer.Products.Endpoints.csproj" />
     <ProjectReference Include="..\Moryx.Products.Management\Moryx.Products.Management.csproj" />
@@ -49,6 +58,7 @@
     <ProjectReference Include="..\Moryx.Products.Samples\Moryx.Products.Samples.csproj" />
     <ProjectReference Include="..\Moryx.Resources.Management\Moryx.Resources.Management.csproj" />
     <ProjectReference Include="..\Moryx.Resources.Samples\Moryx.Resources.Samples.csproj" />
+    <ProjectReference Include="..\Moryx.Simulation.Simulator\Moryx.Simulation.Simulator.csproj" />
     <ProjectReference Include="..\Moryx.Workplans.Editing\Moryx.Workplans.Editing.csproj" />
     <ProjectReference Include="..\Moryx.Workplans.Web\Moryx.Workplans.Web.csproj" />
   </ItemGroup>


### PR DESCRIPTION
### Summary

The angular.json file of operators and shifts were missing an entry that disabled the build artifacts to be put into a `browser` subfolder under wwwroot.
This folder was not properly packed and references by the module causing white screens within the launcher.
Also fixes missing startproject references

### Checklist for Submitter

- [x] I have tested these changes locally
- [x] I have updated documentation as needed
- [x] I have added or updated tests as appropriate
- [x] I have used clear and descriptive commit messages

### Review

**Typical tasks**

- [ ] Merge request is well described
- [ ] Critical sections are *documented in code*
- [ ] *Tests* are extended
- [ ] *Documentation* is created / updated
- [ ] Running in test environment
- [ ] Ports to other maintained versions are created

**Clean code**

- [x] *All* unused references are removed
- [x] Clean code rules are respected with passion (naming, ...)
- [x] Avoid *copy and pasted* code snippets
