### PR TITLE
Port: Add automatic support for Inputs to the VisualInstructionParameters

### DIFF
--- a/docs/migrations/v8_to_v10.md
+++ b/docs/migrations/v8_to_v10.md
@@ -3,3 +3,7 @@
 ## Replaced result of visual instructions with dedicated result object
 
 In *Moryx.Factory* **6.3** and **8.1** we introduced the new result object and optional extended APIs. The result object solved issues caused by localization of the different results. With **Moryx 10** we remove all old APIs based on strings.
+
+## Replaced `IVisualInstructions` with `VisualInstructionParameters`
+The interface was only used in `VisualInstructionParameters` which can and is being used as a base class in most cases anyway.
+Hence, `IVisualInstructions` is removed in favor of a more extendable base class.

--- a/src/Moryx.Benchmarking/BenchmarkParameters.cs
+++ b/src/Moryx.Benchmarking/BenchmarkParameters.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2023, Phoenix Contact GmbH & Co. KG
+// Copyright (c) 2023, Phoenix Contact GmbH & Co. KG
 // Licensed under the Apache License, Version 2.0
 
 using Moryx.AbstractionLayer;
@@ -7,7 +7,7 @@ using Moryx.ControlSystem.VisualInstructions;
 
 namespace Moryx.Benchmarking
 {
-    public class BenchmarkParameters : Parameters, IVisualInstructions, IActivityTimeoutParameters
+    public class BenchmarkParameters : VisualInstructionParameters, IActivityTimeoutParameters
     {
         /// <summary>
         /// Step of the benchmark
@@ -15,31 +15,22 @@ namespace Moryx.Benchmarking
         public int Step { get; set; }
 
         /// <inheritdoc />
-        public VisualInstruction[] Instructions { get; set; } =
-        {
-            new VisualInstruction
-            {
-                Type = InstructionContentType.Text,
-                Content = "Please select the result for Step {0}:"
-            }
-        };
-
-        /// <inheritdoc />
         public int Timeout { get; set; }
+
+        /// <summary>
+        /// Creates new <see cref="BenchmarkParameters"/> with default instructions
+        /// </summary>
+        public BenchmarkParameters()
+        {
+            Instructions = ["Please select the result for Step {0}:".AsInstruction()];
+        }
 
         /// <inheritdoc />
         protected override void Populate(IProcess process, Parameters instance)
         {
             var parameters = (BenchmarkParameters) instance;
             parameters.Step = Step;
-            parameters.Instructions = new[]
-            {
-                new VisualInstruction
-                {
-                    Type = Instructions[0].Type,
-                    Content = string.Format(Instructions[0].Content, Step)
-                }
-            };
+            parameters.Instructions = [string.Format(Instructions[0].Content, Step).AsInstruction()];
         }
     }
 }

--- a/src/Moryx.ControlSystem/VisualInstructions/VisualInstruction.cs
+++ b/src/Moryx.ControlSystem/VisualInstructions/VisualInstruction.cs
@@ -49,16 +49,4 @@ namespace Moryx.ControlSystem.VisualInstructions
         [DataMember, EntrySerialize]
         public string Preview { get; set; }
     }
-
-    /// <summary>
-    /// Interface for classes that define instructions
-    /// </summary>
-    //TODO: remove  in MORYX 10, will be replaced by VisualInstructionParameters
-    public interface IVisualInstructions
-    {
-        /// <summary>
-        /// All instructions for this activity
-        /// </summary>
-        VisualInstruction[] Instructions { get; }
-    }
 }

--- a/src/Moryx.ControlSystem/VisualInstructions/VisualInstruction.cs
+++ b/src/Moryx.ControlSystem/VisualInstructions/VisualInstruction.cs
@@ -53,6 +53,7 @@ namespace Moryx.ControlSystem.VisualInstructions
     /// <summary>
     /// Interface for classes that define instructions
     /// </summary>
+    //TODO: remove  in MORYX 10, will be replaced by VisualInstructionParameters
     public interface IVisualInstructions
     {
         /// <summary>

--- a/src/Moryx.ControlSystem/VisualInstructions/VisualInstructionParameters.cs
+++ b/src/Moryx.ControlSystem/VisualInstructions/VisualInstructionParameters.cs
@@ -11,7 +11,7 @@ namespace Moryx.ControlSystem.VisualInstructions
     /// Provides parameters with visual instructions
     /// </summary>
     [DataContract]
-    public class VisualInstructionParameters : Parameters, IVisualInstructions
+    public class VisualInstructionParameters : Parameters
     {
         /// <summary>
         /// All instructions for this activity, if it used as a visual activity

--- a/src/Moryx.ControlSystem/VisualInstructions/VisualInstructionParameters.cs
+++ b/src/Moryx.ControlSystem/VisualInstructions/VisualInstructionParameters.cs
@@ -20,6 +20,11 @@ namespace Moryx.ControlSystem.VisualInstructions
         public VisualInstruction[] Instructions { get; set; }
 
         /// <summary>
+        /// Inputs for this activity.
+        /// </summary>
+        public object Inputs { get; set; }
+
+        /// <summary>
         /// Binder to resolve visual instruction bindings
         /// </summary>
         protected VisualInstructionBinder InstructionBinder { get; private set; }

--- a/src/Moryx.ControlSystem/VisualInstructions/VisualInstructorExtensions.cs
+++ b/src/Moryx.ControlSystem/VisualInstructions/VisualInstructorExtensions.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using System.Reflection.Metadata;
 using Moryx.AbstractionLayer;
 using Moryx.ControlSystem.Cells;
 
@@ -20,14 +19,13 @@ namespace Moryx.ControlSystem.VisualInstructions
         /// Only display these instructions
         /// Have to be cleared with the <see cref="IVisualInstructor.Clear"/> method
         /// </summary>
-        public static long Display(this IVisualInstructor instructor, string title, IVisualInstructions parameter)
+        public static long Display(this IVisualInstructor instructor, string title, VisualInstructionParameters parameter)
         {
             return instructor.Display(new ActiveInstruction
             {
                 Title = title,
                 Instructions = parameter.Instructions,
-                //TODO: remove the casting in MORYX 10
-                Inputs = (parameter as VisualInstructionParameters)?.Inputs,
+                Inputs = parameter.Inputs,
             });
         }
 
@@ -35,14 +33,13 @@ namespace Moryx.ControlSystem.VisualInstructions
         /// Only display these instructions
         /// Instruction will automatically cleared after the given time
         /// </summary>
-        public static void Display(this IVisualInstructor instructor, string title, IVisualInstructions parameter, int autoClearMs)
+        public static void Display(this IVisualInstructor instructor, string title, VisualInstructionParameters parameter, int autoClearMs)
         {
             instructor.Display(new ActiveInstruction
             {
                 Title = title,
                 Instructions = parameter.Instructions,
-                //TODO: remove the casting in MORYX 10
-                Inputs = (parameter as VisualInstructionParameters)?.Inputs,
+                Inputs = parameter.Inputs,
             }, autoClearMs);
         }
 
@@ -51,13 +48,12 @@ namespace Moryx.ControlSystem.VisualInstructions
         /// </summary>
         public static long Display(this IVisualInstructor instructor, string title, ActivityStart activityStart)
         {
-            var instructions = GetInstructions(activityStart);
+            var instructionParams = GetInstructionParameters(activityStart);
             return instructor.Display(new ActiveInstruction
             {
                 Title = title,
-                Instructions = instructions,
-                //TODO: remove the casting in MORYX 10
-                Inputs = (activityStart.Activity.Parameters as VisualInstructionParameters)?.Inputs,
+                Instructions = instructionParams.Instructions,
+                Inputs = instructionParams.Inputs,
             });
         }
 
@@ -123,15 +119,14 @@ namespace Moryx.ControlSystem.VisualInstructions
         /// Execute these instructions based on the given activity and report the result on completion
         /// Can (but must not) be cleared with the <see cref="IVisualInstructor.Clear"/> method
         /// </summary>
-        public static long Execute(this IVisualInstructor instructor, string title, IVisualInstructions parameter, IReadOnlyList<InstructionResult> results, Action<ActiveInstructionResponse> callback)
+        public static long Execute(this IVisualInstructor instructor, string title, VisualInstructionParameters parameter, IReadOnlyList<InstructionResult> results, Action<ActiveInstructionResponse> callback)
         {
             return instructor.Execute(new ActiveInstruction
             {
                 Title = title,
                 Instructions = parameter.Instructions,
                 Results = results,
-                //TODO: remove the casting in MORYX 10
-                Inputs = (parameter as VisualInstructionParameters)?.Inputs,
+                Inputs = parameter.Inputs,
             }, callback);
         }
 
@@ -140,7 +135,7 @@ namespace Moryx.ControlSystem.VisualInstructions
         /// Can (but must not) be cleared with the <see cref="IVisualInstructor.Clear"/> method
         /// </summary>
         /// <typeparam name="T">Type of enum used for possible instruction results</typeparam>
-        public static long Execute<T>(this IVisualInstructor instructor, string title, IVisualInstructions parameter, Action<T> callback) where T : Enum
+        public static long Execute<T>(this IVisualInstructor instructor, string title, VisualInstructionParameters parameter, Action<T> callback) where T : Enum
         {
             return instructor.Execute(
                 title,
@@ -154,14 +149,13 @@ namespace Moryx.ControlSystem.VisualInstructions
         /// </summary>
         public static long Execute(this IVisualInstructor instructor, string title, ActivityStart activityStart, IReadOnlyList<InstructionResult> results, Action<ActiveInstructionResponse> callback)
         {
-            var instructions = GetInstructions(activityStart);
+            var instructionParams = GetInstructionParameters(activityStart);
             return instructor.Execute(new ActiveInstruction
             {
                 Title = title,
-                Instructions = instructions,
+                Instructions = instructionParams.Instructions,
                 Results = results,
-                //TODO: remove the casting in MORYX 10
-                Inputs = (activityStart.Activity.Parameters as VisualInstructionParameters)?.Inputs,
+                Inputs = instructionParams.Inputs,
             }, callback);
         }
 
@@ -171,7 +165,7 @@ namespace Moryx.ControlSystem.VisualInstructions
         public static long Execute<TInput>(this IVisualInstructor instructor, string title, ActivityStart activityStart, TInput input, Action<int, TInput, ActivityStart> callback)
             where TInput : class
         {
-            var instructions = GetInstructions(activityStart);
+            var instructions = GetInstructionParameters(activityStart).Instructions;
             return Execute(instructor, title, activityStart, input, (result, populated, session) => callback(result, (TInput)populated, session), instructions);
         }
 
@@ -180,7 +174,7 @@ namespace Moryx.ControlSystem.VisualInstructions
         /// </summary>
         public static long Execute(this IVisualInstructor instructor, string title, ActivityStart activityStart, Action<int, ActivityStart> callback)
         {
-            var instructions = GetInstructions(activityStart);
+            var instructions = GetInstructionParameters(activityStart);
             return Execute(instructor, title, activityStart, callback, instructions);
         }
 
@@ -188,9 +182,18 @@ namespace Moryx.ControlSystem.VisualInstructions
         /// Executes an instruction based on a activity session (<see cref="ActivityStart"/>).
         /// Parameters can be set manually
         /// </summary>
-        public static long Execute(this IVisualInstructor instructor, string title, ActivityStart activityStart, Action<int, ActivityStart> callback, IVisualInstructions parameters)
+        public static long Execute(this IVisualInstructor instructor, string title, ActivityStart activityStart, Action<int, ActivityStart> callback, VisualInstructionParameters parameters)
         {
             return Execute(instructor, title, activityStart, callback, parameters.Instructions);
+        }
+
+        /// <summary>
+        /// Executes an instruction based on a activity session (<see cref="ActivityStart"/>).
+        /// Parameters can be set manually
+        /// </summary>
+        public static long Execute(this IVisualInstructor instructor, string title, ActivityStart activityStart, Action<int, object, ActivityStart> callback, VisualInstructionParameters parameters)
+        {
+            return Execute(instructor, title, activityStart, parameters.Inputs, callback, parameters.Instructions);
         }
 
         /// <summary>
@@ -217,33 +220,31 @@ namespace Moryx.ControlSystem.VisualInstructions
         private static long ExecuteWithEnum(this IVisualInstructor instructor, string title, ActivityStart activityStart, object inputs, Action<int, object, ActivityStart> callback, VisualInstruction[] parameters)
         {
             var activity = activityStart.Activity;
-
-            var attr = activity.GetType().GetCustomAttribute<ActivityResultsAttribute>();
-            if (attr == null)
+            var attr = activity.GetType().GetCustomAttribute<ActivityResultsAttribute>() ??
                 throw new ArgumentException($"Activity is not decorated with the {nameof(ActivityResultsAttribute)}");
 
             if (!attr.ResultEnum.IsEnum)
+            {
                 throw new ArgumentException("Result type is not an enum!");
-
-            var results = EnumInstructionResult.PossibleResults(attr.ResultEnum);
-            var resultObjects = EnumInstructionResult.PossibleInstructionResults(attr.ResultEnum);
+            }
 
             return instructor.Execute(new ActiveInstruction
             {
                 Title = title,
                 Instructions = parameters,
-                Results = results,
+                Results = EnumInstructionResult.PossibleResults(attr.ResultEnum),
                 Inputs = inputs
             }, instructionResponse => callback(EnumInstructionResult.ResultToEnumValue(attr.ResultEnum, instructionResponse.SelectedResult), instructionResponse.Inputs, activityStart));
         }
 
-        private static VisualInstruction[] GetInstructions(ActivityStart activity)
+        private static VisualInstructionParameters GetInstructionParameters(ActivityStart activity)
         {
-            var parameters = ((IActivity<IParameters>)activity.Activity).Parameters as IVisualInstructions;
-            if (parameters == null)
-                throw new ArgumentException($"Activity parameters are not of type {nameof(IVisualInstructions)}.");
+            if (((IActivity<IParameters>)activity.Activity).Parameters is not VisualInstructionParameters parameters)
+            {
+                throw new ArgumentException($"Activity parameters are not of type {nameof(VisualInstructionParameters)}.");
+            }
 
-            return parameters.Instructions;
+            return parameters;
         }
 
         /// <summary>

--- a/src/Moryx.ControlSystem/VisualInstructions/VisualInstructorExtensions.cs
+++ b/src/Moryx.ControlSystem/VisualInstructions/VisualInstructorExtensions.cs
@@ -1,10 +1,11 @@
-﻿// Copyright (c) 2024, Phoenix Contact GmbH & Co. KG
+// Copyright (c) 2024, Phoenix Contact GmbH & Co. KG
 // Licensed under the Apache License, Version 2.0
 
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using System.Reflection.Metadata;
 using Moryx.AbstractionLayer;
 using Moryx.ControlSystem.Cells;
 
@@ -24,7 +25,9 @@ namespace Moryx.ControlSystem.VisualInstructions
             return instructor.Display(new ActiveInstruction
             {
                 Title = title,
-                Instructions = parameter.Instructions
+                Instructions = parameter.Instructions,
+                //TODO: remove the casting in MORYX 10
+                Inputs = (parameter as VisualInstructionParameters)?.Inputs,
             });
         }
 
@@ -37,7 +40,9 @@ namespace Moryx.ControlSystem.VisualInstructions
             instructor.Display(new ActiveInstruction
             {
                 Title = title,
-                Instructions = parameter.Instructions
+                Instructions = parameter.Instructions,
+                //TODO: remove the casting in MORYX 10
+                Inputs = (parameter as VisualInstructionParameters)?.Inputs,
             }, autoClearMs);
         }
 
@@ -50,7 +55,9 @@ namespace Moryx.ControlSystem.VisualInstructions
             return instructor.Display(new ActiveInstruction
             {
                 Title = title,
-                Instructions = instructions
+                Instructions = instructions,
+                //TODO: remove the casting in MORYX 10
+                Inputs = (activityStart.Activity.Parameters as VisualInstructionParameters)?.Inputs,
             });
         }
 
@@ -122,7 +129,9 @@ namespace Moryx.ControlSystem.VisualInstructions
             {
                 Title = title,
                 Instructions = parameter.Instructions,
-                Results = results
+                Results = results,
+                //TODO: remove the casting in MORYX 10
+                Inputs = (parameter as VisualInstructionParameters)?.Inputs,
             }, callback);
         }
 
@@ -150,7 +159,9 @@ namespace Moryx.ControlSystem.VisualInstructions
             {
                 Title = title,
                 Instructions = instructions,
-                Results = results
+                Results = results,
+                //TODO: remove the casting in MORYX 10
+                Inputs = (activityStart.Activity.Parameters as VisualInstructionParameters)?.Inputs,
             }, callback);
         }
 


### PR DESCRIPTION
### Summary

The interface was only used in `VisualInstructionParameters` which can and is being used as a base class in most cases anyway.
Hence IVisualInstructions is removed in favor of a more extendable base class.


### Linked Issues

Ports: https://github.com/PHOENIXCONTACT/MORYX-Factory/pull/117

### Breaking Changes

- Replaces `IVisualInstructions` with `VisualInstructionParameters`

### Checklist for Submitter

- [x] I have tested these changes locally
- [x] I have updated documentation as needed
- [x] I have added or updated tests as appropriate
- [x] I have used clear and descriptive commit messages

### Review

**Typical tasks**

- [ ] Merge request is well described
- [ ] Critical sections are *documented in code*
- [ ] *Tests* are extended
- [ ] *Documentation* is created / updated
- [ ] Running in test environment
- [ ] Ports to other maintained versions are created

**Clean code**

- [x] *All* unused references are removed
- [x] Clean code rules are respected with passion (naming, ...)
- [x] Avoid *copy and pasted* code snippets
