### PR TITLE
Expose ResourceChanged notifications from ResourceManagement as a non-breaking facade extension

### DIFF
--- a/src/Moryx.AbstractionLayer/Resources/Attributes/ResourceSynchronizationAttribute.cs
+++ b/src/Moryx.AbstractionLayer/Resources/Attributes/ResourceSynchronizationAttribute.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) 2025, Phoenix Contact GmbH & Co. KG
+// Licensed under the Apache License, Version 2.0
+
+using System;
+
+namespace Moryx.AbstractionLayer.Resources.Attributes;
+
+/// <summary>
+/// Specifies the synchronization behavior for a resource's digital twin
+/// across multiple application instances.
+/// </summary>
+[AttributeUsage(AttributeTargets.Class, Inherited = false)]
+public class ResourceSynchronizationAttribute: Attribute
+{
+    /// <summary>
+    /// Defines the property serialization strategy for this resource.
+    /// </summary>
+    public SynchronizationMode Mode { get; set; }
+}
+
+/// <summary>
+/// Defines the property serialization strategy.
+/// </summary>
+public enum SynchronizationMode
+{
+    /// <summary>
+    /// The entire resource object, including all its properties, is serialized and synchronized.
+    /// </summary>
+    Full,
+
+    /// <summary>
+    /// Only properties explicitly marked with the [SynchronizableMember] attribute will be 
+    /// serialized and synchronized.
+    /// </summary>
+    Selective
+}

--- a/src/Moryx.AbstractionLayer/Resources/Attributes/SynchronizableMemberAttribute.cs
+++ b/src/Moryx.AbstractionLayer/Resources/Attributes/SynchronizableMemberAttribute.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) 2025, Phoenix Contact GmbH & Co. KG
+// Licensed under the Apache License, Version 2.0
+
+using System;
+
+namespace Moryx.AbstractionLayer.Resources.Attributes;
+
+/// <summary>
+/// Marks a property as included in the payload when its class
+/// is using 'Selective' synchronization mode.
+/// </summary>
+[AttributeUsage(AttributeTargets.Property)]
+public class SynchronizableMemberAttribute : Attribute
+{
+    
+}

--- a/src/Moryx.AbstractionLayer/Resources/IResourceManagementChanges.cs
+++ b/src/Moryx.AbstractionLayer/Resources/IResourceManagementChanges.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) 2025, Phoenix Contact GmbH & Co. KG
+// Licensed under the Apache License, Version 2.0
+
+using System;
+
+namespace Moryx.AbstractionLayer.Resources;
+
+// TODO: Combine with IResourceManagement in MORYX 10
+/// <summary>
+/// Resource management API used raise change events for resources
+/// </summary>
+public interface IResourceManagementChanges
+{
+    /// <summary>
+    /// Raised when a resource reports a change (via Resource.RaiseResourceChanged)
+    /// or is changed via the ResourceManagement facade (e.g. Modify).
+    /// </summary>
+    event EventHandler<IResource> ResourceChanged;
+}

--- a/src/Moryx.Resources.Management/Facades/ResourceManagementFacade.cs
+++ b/src/Moryx.Resources.Management/Facades/ResourceManagementFacade.cs
@@ -9,7 +9,7 @@ using Moryx.Runtime.Modules;
 
 namespace Moryx.Resources.Management
 {
-    internal class ResourceManagementFacade : FacadeBase, IResourceManagement
+    internal class ResourceManagementFacade : FacadeBase, IResourceManagement, IResourceManagementChanges
     {
         #region Dependency Injection
 
@@ -29,6 +29,7 @@ namespace Moryx.Resources.Management
             Manager.ResourceAdded += OnResourceAdded;
             Manager.CapabilitiesChanged += OnCapabilitiesChanged;
             Manager.ResourceRemoved += OnResourceRemoved;
+            Manager.ResourceChanged += OnResourceChanged;
         }
 
         /// <seealso cref="IFacadeControl"/>
@@ -37,6 +38,7 @@ namespace Moryx.Resources.Management
             Manager.ResourceAdded -= OnResourceAdded;
             Manager.CapabilitiesChanged -= OnCapabilitiesChanged;
             Manager.ResourceRemoved -= OnResourceRemoved;
+            Manager.ResourceChanged -= OnResourceChanged;
         }
 
         private void OnCapabilitiesChanged(object sender, ICapabilities args)
@@ -53,6 +55,12 @@ namespace Moryx.Resources.Management
         {
             ResourceRemoved?.Invoke(this, publicResource.Proxify(TypeController));
         }
+
+        private void OnResourceChanged(object sender, IResource resource)
+        {
+            ResourceChanged?.Invoke(this, resource.Proxify(TypeController));
+        }
+
         #endregion
 
         #region IResourceManagement
@@ -182,6 +190,9 @@ namespace Moryx.Resources.Management
 
         /// <inheritdoc />
         public event EventHandler<ICapabilities> CapabilitiesChanged;
+
+        /// <inheritdoc />
+        public event EventHandler<IResource> ResourceChanged;
     }
 
 }

--- a/src/Moryx.Resources.Management/ModuleController/ModuleController.cs
+++ b/src/Moryx.Resources.Management/ModuleController/ModuleController.cs
@@ -18,6 +18,7 @@ namespace Moryx.Resources.Management
     /// </summary>
     public class ModuleController : ServerModuleBase<ModuleConfig>,
         IFacadeContainer<IResourceManagement>,
+        IFacadeContainer<IResourceManagementChanges>,
         IFacadeContainer<IResourceTypeTree>,
         IFacadeContainer<INotificationSource>
     {
@@ -104,7 +105,7 @@ namespace Moryx.Resources.Management
         private readonly ResourceManagementFacade _resourceManagementFacade = new ResourceManagementFacade();
         private readonly ResourceTypeTreeFacade _resourceTypeTreeFacade = new ResourceTypeTreeFacade();
         IResourceManagement IFacadeContainer<IResourceManagement>.Facade => _resourceManagementFacade;
-
+        IResourceManagementChanges IFacadeContainer<IResourceManagementChanges>.Facade => _resourceManagementFacade;
         IResourceTypeTree IFacadeContainer<IResourceTypeTree>.Facade => _resourceTypeTreeFacade;
 
         private readonly NotificationSourceFacade _notificationSourceFacade = new NotificationSourceFacade(ModuleName);

--- a/src/Moryx.Resources.Management/Resources/IResourceManager.cs
+++ b/src/Moryx.Resources.Management/Resources/IResourceManager.cs
@@ -31,5 +31,10 @@ namespace Moryx.AbstractionLayer.Resources
         /// Raised when the capabilities have changed.
         /// </summary>
         event EventHandler<ICapabilities> CapabilitiesChanged;
+
+        /// <summary>
+        /// Raised when a resource was changed during runtime (properties, collections or references)
+        /// </summary>
+        event EventHandler<IResource> ResourceChanged;
     }
 }

--- a/src/Moryx.Resources.Management/Resources/ResourceManager.cs
+++ b/src/Moryx.Resources.Management/Resources/ResourceManager.cs
@@ -318,6 +318,8 @@ namespace Moryx.Resources.Management
         {
             lock (Graph.GetResource(resource.Id) ?? _fallbackLock)
             {
+                var isNew = resource.Id == 0;
+
                 using var uow = UowFactory.Create();
                 var newResources = new HashSet<Resource>();
 
@@ -350,6 +352,11 @@ namespace Moryx.Resources.Management
 
                 foreach (var instance in newResources)
                     AddResource(instance, true);
+
+                if (!isNew)
+                {
+                    RaiseResourceChanged(resource);
+                }
             }
         }
 
@@ -379,6 +386,7 @@ namespace Moryx.Resources.Management
                 foreach (var newResource in newResources)
                     AddResource(newResource, true);
             }
+            RaiseResourceChanged(instance);
         }
 
         public void ExecuteInitializer(IResourceInitializer initializer)
@@ -445,7 +453,7 @@ namespace Moryx.Resources.Management
 
         #region IResourceManagement
 
-
+        
         private void RaiseResourceAdded(IResource newResource)
         {
             ResourceAdded?.Invoke(this, newResource);
@@ -466,6 +474,13 @@ namespace Moryx.Resources.Management
             if (Graph.GetAll().Any(x => x.Id == ((IResource)originalSender).Id))
                 CapabilitiesChanged?.Invoke(originalSender, capabilities);
         }
+
+        private void RaiseResourceChanged(IResource updated)
+        {
+            ResourceChanged?.Invoke(this, updated);
+        }
+
+        public event EventHandler<IResource> ResourceChanged;
 
         #endregion
     }


### PR DESCRIPTION
This pull request contains the changes proposed in the [Issue 657](https://github.com/PHOENIXCONTACT/MORYX-Framework/issues/657)

- New interface `IResourceManagementChanges` added for the non-breaking
- Facade is exposed as both `IResourceManagement` and `IResourceManagementChanges`
- Changes to collection or `Resource.Changed` event are now published via the facade `IResourceManagementChanges.ResourceChanged`  event