### PR TITLE
Fixed default sqlite db-path on non-windows systems

### DIFF
--- a/src/Moryx.Model.Sqlite/SqliteDatabaseConfig.cs
+++ b/src/Moryx.Model.Sqlite/SqliteDatabaseConfig.cs
@@ -6,6 +6,7 @@ using System.ComponentModel;
 using System.Runtime.Serialization;
 using Microsoft.Data.Sqlite;
 using System;
+using System.IO;
 
 namespace Moryx.Model.Sqlite
 {
@@ -24,14 +25,22 @@ namespace Moryx.Model.Sqlite
             ConfiguratorTypename = typeof(SqliteModelConfigurator).AssemblyQualifiedName;
         }
     }
-
-
+    
     /// <summary>
     /// Database connection settings for the Sqlite databases
     /// </summary>
     public class SqliteDatabaseConnectionSettings : DatabaseConnectionSettings
     {
         private string _database;
+
+        /// <summary>
+        /// Default constructor of <see cref="SqliteDatabaseConnectionSettings"/>
+        /// </summary>
+        public SqliteDatabaseConnectionSettings()
+        {
+            var defaultDbPath = Path.Combine(".", "db", "<DatabaseName>.db");
+            ConnectionString = $"Data Source={defaultDbPath};Mode=ReadWrite;";
+        }
 
         /// <inheritdoc />
         [DataMember]
@@ -47,7 +56,7 @@ namespace Moryx.Model.Sqlite
         }
 
         /// <inheritdoc />
-        [DataMember, Required, DefaultValue("Data Source=.\\db\\<DatabaseName>.db;Mode=ReadWrite;")]
+        [DataMember, Required]
         public override string ConnectionString { get; set; }
 
         /// <inheritdoc />

--- a/src/Moryx.Runtime.Endpoints/Databases/Endpoint/DatabaseController.cs
+++ b/src/Moryx.Runtime.Endpoints/Databases/Endpoint/DatabaseController.cs
@@ -323,10 +323,7 @@ namespace Moryx.Runtime.Endpoints.Databases.Endpoint
         private static DatabaseConfigOptionModel[] GetConfigurators()
         {
             var configuratorTypes = ReflectionTool
-                .GetPublicClasses(typeof(IModelConfigurator), delegate (Type type)
-                {
-                    return type != typeof(NullModelConfigurator);
-                }).ToList();
+                .GetPublicClasses(typeof(IModelConfigurator), type => type != typeof(NullModelConfigurator)).ToList();
 
             var result = configuratorTypes
                 .Select(type => new DatabaseConfigOptionModel

--- a/src/StartProject.Asp/Config/Moryx.Products.Model.ProductsContext.DbConfig.json
+++ b/src/StartProject.Asp/Config/Moryx.Products.Model.ProductsContext.DbConfig.json
@@ -1,8 +1,0 @@
-{
-  "ConfigState": "Generated",
-  "Host": "localhost",
-  "Port": 5432,
-  "Database": "Framework6_ProductsContext",
-  "Username": "postgres",
-  "Password": "postgres"
-}

--- a/src/StartProject.Asp/Config/Moryx.Resources.Model.ResourcesContext.DbConfig.json
+++ b/src/StartProject.Asp/Config/Moryx.Resources.Model.ResourcesContext.DbConfig.json
@@ -1,8 +1,0 @@
-{
-  "ConfigState": "Generated",
-  "Host": "localhost",
-  "Port": 5432,
-  "Database": "Framework6_ResourcesContext",
-  "Username": "postgres",
-  "Password": "postgres"
-}

--- a/src/StartProject.Asp/Config/Moryx.TestTools.Test.Model.TestModelContext.DbConfig.json
+++ b/src/StartProject.Asp/Config/Moryx.TestTools.Test.Model.TestModelContext.DbConfig.json
@@ -1,8 +1,0 @@
-{
-  "ConfigState": "Generated",
-  "Host": "localhost",
-  "Port": 5432,
-  "Database": "Framework6_TestModelContext",
-  "Username": "postgres",
-  "Password": "postgres"
-}


### PR DESCRIPTION
The path of the sqlite-database could not be set by `DefaultValueAttribute` because path depends on the system. 

--> Tested on Mac