### PR TITLE
Revert "Change order of activation of the notification facade"

### DIFF
--- a/src/Moryx.Resources.Management/ModuleController/ModuleController.cs
+++ b/src/Moryx.Resources.Management/ModuleController/ModuleController.cs
@@ -68,8 +68,6 @@ namespace Moryx.Resources.Management
         /// </summary>
         protected override void OnStart()
         {
-            ActivateFacade(_notificationSourceFacade);
-
             // Start type controller for resource and proxy creation
             Container.Resolve<IResourceTypeController>().Start();
 
@@ -82,6 +80,7 @@ namespace Moryx.Resources.Management
 
             // Activate external facade to register events
             ActivateFacade(_resourceTypeTreeFacade);
+            ActivateFacade(_notificationSourceFacade);
             ActivateFacade(_resourceManagementFacade);
   
         }
@@ -92,12 +91,11 @@ namespace Moryx.Resources.Management
         protected override void OnStop()
         {
             // Tear down facades
+            DeactivateFacade(_notificationSourceFacade);
             DeactivateFacade(_resourceManagementFacade);
             DeactivateFacade(_resourceTypeTreeFacade);
             var resourceManager = Container.Resolve<IResourceManager>();
             resourceManager.Stop();
-
-            DeactivateFacade(_notificationSourceFacade);
         }
 
         private readonly ResourceManagementFacade _resourceManagementFacade = new ResourceManagementFacade();


### PR DESCRIPTION
Revert "Change order of activation of the notification facade. Facade… must be ready before resources are starting to allow publish notification during OnStart()."

This reverts commit 4cbf1b010ec21576e82a99158e7f34d9e93fdd75.

These changes have no effects on the notification publishing mechanism. The internal component NotificationAdapter is handling the notifications, no matter when the facade gets activated. 

On `future` - the sync must also be executed when the facade gets activated later in `NotificationPublisher`

Discussed with @dacky179 