### PR TITLE
Refactored TCP KeepAlive configuration of TcpClientConnection and TcpListenerConnection

### DIFF
--- a/docs/articles/framework/BinaryConnection.md
+++ b/docs/articles/framework/BinaryConnection.md
@@ -109,8 +109,28 @@ Finally all you have to do is create a connection instance with the IBinaryConne
 
 ### Configuration
 
-- To open a server-socket and start listening on incoming connections the user has to use the TcpListenerConfig
-- To start a client-connection the user has to use the TcpClientConfig
+- To open a server-socket and start listening on incoming connections the user has to use the `TcpListenerConfig`
+- To start a client-connection the user has to use the `TcpClientConfig`
+
+### KeepAlive
+
+TCP Keep-Alive is a mechanism that allows a TCP connection to detect whether the remote peer is still reachable, even when no application data is being exchanged.
+When enabled, the TCP stack periodically sends small “keepalive” probe packets on otherwise idle connections. If the remote side fails to acknowledge a configured number of probes, the connection is considered dead and will be closed by the operating system.
+The keepalive mechanism uses three parameters:
+
+| Parameter | Description |
+|------------|-------------|
+| **KeepAliveTime** | The idle time (in seconds) before the first keepalive probe is sent. If no data is transmitted for this duration, the first probe is sent to verify that the peer is still reachable. |
+| **KeepAliveInterval** | The delay (in seconds) between subsequent keepalive probes when no acknowledgment is received. This determines how often probes are retried after the initial one. |
+| **KeepAliveRetryCount** | The number of unanswered keepalive probes before the connection is considered lost and automatically closed by the TCP stack. |
+
+Default values vary by platform (typically around 2 hours idle, 75 s interval, and 8–10 probes).
+
+| Platform    | KeepAliveTime      | KeepAliveInterval | KeepAliveRetryCount | Total Time Until Disconnect                 |
+| ----------- | ------------------ | ----------------- | ------------------- | ------------------------------------------- |
+| Windows     | 7 200 s (2 hours)  | 1 s               | 10                  | ≈ 7 209 s (≈ 2 hours 9 seconds)             |
+| Linux**     | 7 200 s (2 hours)  | 75 s              | 9                   | ≈ 7 875 s (≈ 2 hours 11 minutes 15 seconds) |
+| macOS / BSD | 7 200 s (2 hours)  | 75 s              | 8                   | ≈ 7 800 s (≈ 2 hours 10 minutes)            |
 
 ### Server Mode
 
@@ -169,10 +189,6 @@ The following table illustrates differences between Little-Endian and Big-Endian
 
 ### .NET Conversion-Methods
 
-<<<<<<< HEAD:docs/articles/Core/BinaryConnection.md
-The .Net-Framework offers serveral Helper Methods and Classes and should be used for the conversion of data before sending it via network. To make sure, that multibyte values have the right byte order before being converted in to a byte-stream use [.HostToNetworkOrder](https://msdn.microsoft.com/de-de/library/653kcke1%28v=vs.110%29.aspx) For incoming data [IpAddress.NetworkToHostOrder](https://msdn.microsoft.com/de-de/library/system.net.ipaddress.networktohostorder%28v=vs.100%29.aspx) maybe used.
-=======
-The .Net-Framework offers several Helper Methods and Classes and should be used for the conversion of data before sending it via network. To make sure, that multi byte values have the right byte order before being converted in to a byte-stream use [Ipaddress.HostToNetworkOrder](https://msdn.microsoft.com/de-de/library/653kcke1%28v=vs.110%29.aspx) For incoming data [IpAddress.NetworkToHostOrder](https://msdn.microsoft.com/de-de/library/system.net.ipaddress.networktohostorder%28v=vs.100%29.aspx) maybe used.
->>>>>>> origin/future:docs/articles/framework/BinaryConnection.md
+The .NET offers several Helper Methods and Classes and should be used for the conversion of data before sending it via network. To make sure, that multi byte values have the right byte order before being converted in to a byte-stream use [Ipaddress.HostToNetworkOrder](https://msdn.microsoft.com/de-de/library/653kcke1%28v=vs.110%29.aspx) For incoming data [IpAddress.NetworkToHostOrder](https://msdn.microsoft.com/de-de/library/system.net.ipaddress.networktohostorder%28v=vs.100%29.aspx) maybe used.
 
 To create Byte-Arrays the .Net-class [BitConverter](https://msdn.microsoft.com/en-us/library/vstudio/system.bitconverter%28v=vs.100%29.aspx) may be used after the multi byte values have been converted into the right order.

--- a/src/Moryx/Communication/Sockets/Client/TcpClientConfig.cs
+++ b/src/Moryx/Communication/Sockets/Client/TcpClientConfig.cs
@@ -15,55 +15,35 @@ namespace Moryx.Communication.Sockets
         /// <summary>
         /// Gets the name of the plugin.
         /// </summary>
-        /// <value>
-        /// The name of the plugin.
-        /// </value>
         public override string PluginName => nameof(TcpClientConnection);
 
         /// <summary>
         /// Gets or sets the ip address.
         /// </summary>
-        /// <value>
-        /// The ip address.
-        /// </value>
         [DataMember]
         [Description("The IP-Address for this device")]
         public string IpAddress { get; set; }
 
         /// <summary>
-        /// Gets or sets the port.
+        /// The port for this socket
         /// </summary>
-        /// <value>
-        /// The port.
-        /// </value>
-        [DataMember]
-        [Description("The TCP-Port for this Device")]
-        [DefaultValue(5002)]
+        [DataMember, DefaultValue(5002)]
+        [Description("The port for this socket")]
         public int Port { get; set; }
 
         /// <summary>
-        /// Gets or sets the connect retry wait time in ms.
+        /// Time to wait between attempts to open a connection in ms.
         /// </summary>
-        /// <value>
-        /// The connect retry wait ms.
-        /// </value>
         [DataMember]
         [Description("Time to wait between attempts to open a connection in ms.")]
         [DefaultValue(500)]
         public int RetryWaitMs { get; set; }
 
         /// <summary>
-        /// Time in milliseconds to check if connection is still open. Disable with -1
+        /// The TCP KeepAlive configuration
         /// </summary>
-        [DataMember, DefaultValue(5000)]
-        [Description("Time in milliseconds to check if connection is still open. Disable with -1")]
-        public int MonitoringIntervalMs { get; set; }
-
-        /// <summary>
-        /// Timeout for a monitoring call
-        /// </summary>
-        [DataMember, DefaultValue(500)]
-        [Description("Timeout for a monitoring call")]
-        public int MonitoringTimeoutMs { get; set; }
+        [DataMember]
+        [Description("The TCP KeepAlive configuration")]
+        public TcpKeepAliveConfig KeepAliveConfig { get; set; }
     }
 }

--- a/src/Moryx/Communication/Sockets/Server/PortMap.cs
+++ b/src/Moryx/Communication/Sockets/Server/PortMap.cs
@@ -1,0 +1,77 @@
+// Copyright (c) 2025, Phoenix Contact GmbH & Co. KG
+// Licensed under the Apache License, Version 2.0
+
+using System.Net;
+
+namespace Moryx.Communication.Sockets;
+
+/// <summary>
+/// Mapping of ports and protocols to make sure we don't mix protocols on ports
+/// </summary>
+internal class PortMap
+{
+    /// <summary>
+    /// Application global map of ports
+    /// </summary>
+    private static readonly List<PortMap> _registrations = [];
+
+    /// <summary>
+    /// IP Address of the registration
+    /// </summary>
+    private readonly IPAddress _address;
+
+    /// <summary>
+    /// Port of the registration
+    /// </summary>
+    private readonly int _port;
+
+    /// <summary>
+    /// Protocol interpreter registered at this address
+    /// </summary>
+    private readonly IMessageInterpreter _interpreter;
+
+    public PortMap(IPAddress address, int port, IMessageInterpreter interpreter)
+    {
+        _address = address;
+        _port = port;
+        _interpreter = interpreter;
+    }
+
+    /// <summary>
+    /// Try to register a message interpreter on a given port
+    /// </summary>
+    /// <param name="address">Ip address to listen on</param>
+    /// <param name="port">Port to use</param>
+    /// <param name="protocol">Interpreter of the protocol</param>
+    /// <returns>True if registration was successful, otherwise false</returns>
+    public static bool Register(IPAddress address, int port, IMessageInterpreter protocol)
+    {
+        lock (_registrations)
+        {
+            IEnumerable<PortMap> addressRelevant;
+            if (IsAny(address))
+                // If this is a registration for all IPAddresses, we need to compare against all entries
+                addressRelevant = _registrations;
+            else
+                // Find all registrations on the same or all addresses
+                addressRelevant = _registrations.Where(r => IsAny(r._address) | r._address.Equals(address));
+
+            // Within relevant addresses find an entry with the same port
+            var match = addressRelevant.FirstOrDefault(m => m._port == port);
+            if (match != null && !match._interpreter.Equals(protocol))
+                return false; // Conflict
+
+            // Create a registration
+            _registrations.Add(new PortMap(address, port, protocol));
+            return true;
+        }
+    }
+
+    /// <summary>
+    /// Check if a given IPAddress represents IPv4 or IPv6 any
+    /// </summary>
+    private static bool IsAny(IPAddress address)
+    {
+        return address.Equals(IPAddress.Any) | address.Equals(IPAddress.IPv6Any);
+    }
+}

--- a/src/Moryx/Communication/Sockets/Server/States/ServerStateBase.cs
+++ b/src/Moryx/Communication/Sockets/Server/States/ServerStateBase.cs
@@ -59,6 +59,5 @@ namespace Moryx.Communication.Sockets
 
         [StateDefinition(typeof(ServerReconnectingState))]
         protected const int StateReconnecting = 40;
-
     }
 }

--- a/src/Moryx/Communication/Sockets/Server/TcpListenerConfig.cs
+++ b/src/Moryx/Communication/Sockets/Server/TcpListenerConfig.cs
@@ -7,47 +7,42 @@ using System.Runtime.Serialization;
 namespace Moryx.Communication.Sockets
 {
     /// <summary>
-    /// Config for TCPListeners
+    /// Config for <see cref="TcpListenerConnection"/>
     /// </summary>
     [DataContract]
     public class TcpListenerConfig : BinaryConnectionConfig
     {
-        /// 
+        /// <summary>
+        /// Gets the name of the plugin.
+        /// </summary>
         public override string PluginName => nameof(TcpListenerConnection);
 
         /// <summary>
         /// Gets or sets the ip address. Usually this is IPAddress.Any which (for IPv4) is "0.0.0.0"
         /// </summary>
         [DataMember, DefaultValue("0.0.0.0")]
-        [Description("The IP-Address for this device")]
+        [Description("The IP-Address for this socket")]
         public string IpAddress { get; set; }
 
         /// <summary>
-        /// TCP Port of the connection
+        /// The port for this socket
         /// </summary>
         [DataMember, DefaultValue(5002)]
-        [Description("The TCP-Port for this Device")]
+        [Description("The port for this socket")]
         public int Port { get; set; }
 
         /// <summary>
-        /// Flag if incoming connections must be validated before assigning them, even if this is the only listener
+        /// Validate incoming messages before assigning the connection, even if this is the only listener.
         /// </summary>
         [DataMember]
         [Description("Validate incoming messages before assigning the connection, even if this is the only listener.")]
         public bool ValidateBeforeAssignment { get; set; }
 
         /// <summary>
-        /// Time in milliseconds to check if connection is still open. Disable with -1
+        /// The TCP KeepAlive configuration
         /// </summary>
-        [DataMember, DefaultValue(5000)]
-        [Description("Time in milliseconds to check if connection is still open. Disable with -1")]
-        public int MonitoringIntervalMs { get; set; }
-
-        /// <summary>
-        /// Timeout for a monitoring call
-        /// </summary>
-        [DataMember, DefaultValue(500)]
-        [Description("Timeout for a monitoring call")]
-        public int MonitoringTimeoutMs { get; set; }
+        [DataMember]
+        [Description("The TCP KeepAlive configuration")]
+        public TcpKeepAliveConfig KeepAliveConfig { get; set; }
     }
 }

--- a/src/Moryx/Communication/Sockets/Server/TcpPortListener.cs
+++ b/src/Moryx/Communication/Sockets/Server/TcpPortListener.cs
@@ -32,11 +32,6 @@ namespace Moryx.Communication.Sockets
         public int Port { get; }
 
         /// <summary>
-        /// Number of connected listeners on port
-        /// </summary>
-        public int ConnectionCount => _listeners.Count;
-
-        /// <summary>
         /// Protocol used on this port
         /// </summary>
         private IMessageInterpreter _protocolInterpreter;
@@ -61,16 +56,13 @@ namespace Moryx.Communication.Sockets
         /// </summary>
         private bool _listening;
 
-        ///
         public void Register(TcpListenerConnection listener)
         {
             lock (_listeners)
             {
                 // Steal objects from the first listener
-                if (_protocolInterpreter == null)
-                    _protocolInterpreter = listener.Validator.Interpreter;
-                if (_logger == null)
-                    _logger = listener.Logger;
+                _protocolInterpreter ??= listener.Validator.Interpreter;
+                _logger ??= listener.Logger;
 
                 _listeners.Add(listener);
 
@@ -78,7 +70,6 @@ namespace Moryx.Communication.Sockets
             }
         }
 
-        /// 
         public bool TryUnregister(TcpListenerConnection listener)
         {
             lock (_listeners)
@@ -87,15 +78,13 @@ namespace Moryx.Communication.Sockets
             }
         }
 
-        /// 
         private void StartListening()
         {
             if (_listening)
                 return;
 
             // Start tcp listener and accept clients
-            if (_tcpListener == null)
-                _tcpListener = new TcpListener(new IPEndPoint(Address, Port));
+            _tcpListener ??= new TcpListener(new IPEndPoint(Address, Port));
             _tcpListener.Start();
             _tcpListener.BeginAcceptTcpClient(ClientConnected, null);
             _listening = true;

--- a/src/Moryx/Communication/Sockets/Server/TcpServer.cs
+++ b/src/Moryx/Communication/Sockets/Server/TcpServer.cs
@@ -1,81 +1,8 @@
 // Copyright (c) 2025, Phoenix Contact GmbH & Co. KG
 // Licensed under the Apache License, Version 2.0
 
-using System.Net;
-
 namespace Moryx.Communication.Sockets
 {
-    /// <summary>
-    /// Mapping of ports and protocols to make sure we don't mix protocols on ports
-    /// </summary>
-    internal class PortMap
-    {
-        /// <summary>
-        /// Application global map of ports
-        /// </summary>
-        private static readonly List<PortMap> Registrations = [];
-
-        /// <summary>
-        /// IP Address of the registration
-        /// </summary>
-        public IPAddress Address { get; }
-
-        /// <summary>
-        /// Port of the registration
-        /// </summary>
-        public int Port { get; }
-
-        /// <summary>
-        /// Protocol interpreter registered at this address
-        /// </summary>
-        public IMessageInterpreter Interpreter { get; }
-
-        public PortMap(IPAddress address, int port, IMessageInterpreter interpreter)
-        {
-            Address = address;
-            Port = port;
-            Interpreter = interpreter;
-        }
-
-        /// <summary>
-        /// Try to register a message interpreter on a given port
-        /// </summary>
-        /// <param name="address">Ip address to listen on</param>
-        /// <param name="port">Port to use</param>
-        /// <param name="protocol">Interpreter of the protocol</param>
-        /// <returns>True if registration was successful, otherwise false</returns>
-        public static bool Register(IPAddress address, int port, IMessageInterpreter protocol)
-        {
-            lock (Registrations)
-            {
-                IEnumerable<PortMap> addressRelevant;
-                if (IsAny(address))
-                    // If this is a registration for all IPAddresses, we need to compare against all entries
-                    addressRelevant = Registrations;
-                else
-                    // Find all registrations on the same or all addresses
-                    addressRelevant = Registrations.Where(r => IsAny(r.Address) | r.Address.Equals(address));
-
-                // Within relevant addresses find an entry with the same port
-                var match = addressRelevant.FirstOrDefault(m => m.Port == port);
-                if (match != null && !match.Interpreter.Equals(protocol))
-                    return false; // Conflict
-
-                // Create a registration
-                Registrations.Add(new PortMap(address, port, protocol));
-                return true;
-            }
-        }
-
-        /// <summary>
-        /// Check if a given IPAddress represents IPv4 or IPv6 any
-        /// </summary>
-        private static bool IsAny(IPAddress address)
-        {
-            return address.Equals(IPAddress.Any) | address.Equals(IPAddress.IPv6Any);
-        }
-    }
-
     /// <summary>
     /// Central server for all listener connections
     /// </summary>
@@ -84,18 +11,18 @@ namespace Moryx.Communication.Sockets
         /// <summary>
         /// Lazy ThreadSafe instance of the tcp server
         /// </summary>
-        private static readonly Lazy<TcpServer> LazyInstance =
+        private static readonly Lazy<TcpServer> _lazyInstance =
             new(() => new TcpServer(), LazyThreadSafetyMode.ExecutionAndPublication);
 
         /// <summary>
         /// Singleton instance of the server
         /// </summary>
-        public static TcpServer Instance => LazyInstance.Value;
+        public static TcpServer Instance => _lazyInstance.Value;
 
         /// <summary>
         /// List of all running listeners
         /// </summary>
-        private readonly IList<TcpPortListener> _listeners = new List<TcpPortListener>();
+        private readonly List<TcpPortListener> _listeners = [];
 
         /// <summary>
         /// Register for a specific port

--- a/src/Moryx/Communication/Sockets/TcpKeepAliveConfig.cs
+++ b/src/Moryx/Communication/Sockets/TcpKeepAliveConfig.cs
@@ -1,0 +1,50 @@
+// Copyright (c) 2025, Phoenix Contact GmbH & Co. KG
+// Licensed under the Apache License, Version 2.0
+
+using System.ComponentModel;
+using System.Runtime.Serialization;
+
+namespace Moryx.Communication.Sockets;
+
+/// <summary>
+/// Configuration for the TCP Keep-Alive.
+/// TCP Keep-Alive is a mechanism that allows a TCP connection to detect whether the remote peer is still reachable, even when no application data is being exchanged.
+/// </summary>
+[DataContract]
+public class TcpKeepAliveConfig
+{
+    /// <summary>
+    /// Use keep-alive on this socket. OS defaults are used when override is inactive.
+    /// </summary>
+    [DataMember]
+    [Description("Use keep-alive on this socket. OS defaults are used when override is inactive.")]
+    public bool UseKeepAlive { get; set; }
+
+    /// <summary>
+    /// Override operating system defaults with this configuration.
+    /// </summary>
+    [DataMember]
+    [Description("Override operating system defaults with this configuation.")]
+    public bool OverrideOsDefaults { get; set; }
+
+    /// <summary>
+    /// The number of seconds a TCP connection will wait for a keepalive response before sending another keepalive probe.
+    /// </summary>
+    [DataMember, DefaultValue(75)]
+    [Description("The number of seconds a TCP connection will wait for a keepalive response before sending another keepalive probe.")]
+    public int KeepAliveInterval { get; set; }
+
+    /// <summary>
+    /// The number of seconds a TCP connection will remain alive/idle before keepalive probes are sent to the remote.
+    /// </summary>
+    [DataMember, DefaultValue(7200)]
+    [Description("The number of seconds a TCP connection will remain alive/idle before keepalive probes are sent to the remote.")]
+    public int KeepAliveTime { get; set; }
+
+    /// <summary>
+    /// The number of TCP keep alive probes that will be sent before the connection is terminated.
+    /// </summary>
+    [DataMember, DefaultValue(9)]
+    [Description("The number of TCP keep alive probes that will be sent before the connection is terminated.")]
+    public int KeepAliveRetryCount { get; set; }
+}

--- a/src/Tests/Moryx.Communication.Sockets.IntegrationTests/CommunicationSocketsTestsBase.cs
+++ b/src/Tests/Moryx.Communication.Sockets.IntegrationTests/CommunicationSocketsTestsBase.cs
@@ -90,7 +90,7 @@ namespace Moryx.Communication.Sockets.IntegrationTests
                     return;
 
                 c.Connection.Dispose();
-                // Client should be disconnected 
+                // Client should be disconnected
                 WaitForConnectionState(_clients.IndexOf(c), new TimeSpan(0, 0, 0, 10), BinaryConnectionState.Disconnected);
                 c.Connection = null;
             }
@@ -142,7 +142,7 @@ namespace Moryx.Communication.Sockets.IntegrationTests
 
             server.Connection.Start();
 
-            // Server should be listening 
+            // Server should be listening
             Assert.That(server.Connection.CurrentState, Is.EqualTo(BinaryConnectionState.AttemptingConnection),
                 $"server is not in the state '{BinaryConnectionState.AttemptingConnection:G}'. CurrentState: {server.Connection.CurrentState:G}");
 
@@ -182,7 +182,7 @@ namespace Moryx.Communication.Sockets.IntegrationTests
 
             _clients[clientIdx].Connection.Start();
 
-            // In some tests the client shall be connected at this point and in some tests it shall not be connected, 
+            // In some tests the client shall be connected at this point and in some tests it shall not be connected,
             // so check the connection-state somewhere else...
 
             return clientIdx;
@@ -265,7 +265,7 @@ namespace Moryx.Communication.Sockets.IntegrationTests
         /// <param name="counter">How often the element array shall be copied</param>
         /// <param name="element">The source payload</param>
         /// <returns>The created payload</returns>
-        protected static byte[] CreatePayload(int counter, byte[] element)
+        private static byte[] CreatePayload(int counter, byte[] element)
         {
             var result = new byte[element.Length * counter];
             for (var i = 0; i < counter; i++)
@@ -310,15 +310,21 @@ namespace Moryx.Communication.Sockets.IntegrationTests
         /// <param name="port">The port.</param>
         /// <param name="connectRetryWaitMs">The connect retry wait ms.</param>
         /// <returns>The client configuration</returns>
-        protected static TcpClientConfig CreateClientConfig(IPAddress adress, int port, int connectRetryWaitMs)
+        private static TcpClientConfig CreateClientConfig(IPAddress adress, int port, int connectRetryWaitMs)
         {
             return new TcpClientConfig
             {
                 IpAddress = adress.ToString(),
                 Port = port,
                 RetryWaitMs = connectRetryWaitMs,
-                MonitoringIntervalMs = 100,
-                MonitoringTimeoutMs = 500
+                KeepAliveConfig = new TcpKeepAliveConfig
+                {
+                    UseKeepAlive = true,
+                    OverrideOsDefaults = true,
+                    KeepAliveInterval = 1,
+                    KeepAliveTime = 1,
+                    KeepAliveRetryCount = 2
+                }
             };
         }
 
@@ -328,14 +334,20 @@ namespace Moryx.Communication.Sockets.IntegrationTests
         /// <param name="adress">The adress.</param>
         /// <param name="port">The port.</param>
         /// <returns>The listener configuration</returns>
-        protected static TcpListenerConfig CreateServerConfig(IPAddress adress, int port)
+        private static TcpListenerConfig CreateServerConfig(IPAddress adress, int port)
         {
             return new TcpListenerConfig
             {
                 IpAddress = adress.ToString(),
                 Port = port,
-                MonitoringIntervalMs = 100,
-                MonitoringTimeoutMs = 500
+                KeepAliveConfig = new TcpKeepAliveConfig
+                {
+                    UseKeepAlive = true,
+                    OverrideOsDefaults = true,
+                    KeepAliveInterval = 1,
+                    KeepAliveTime = 1,
+                    KeepAliveRetryCount = 2
+                }
             };
         }
     }


### PR DESCRIPTION
Refactored TCP KeepAlive configuration of TcpClientConnection and TcpListenerConnection. Introduced a separate config for the keepalive and allow enable/disable and configure all properties of the keepalive.

+ clean code in Moryx.Communication.Sockets namespace