### PR TITLE
After upgrading to Angular 19, progress bars in both `operations` and `begin-dialog` components were no longs visible.

### DIFF
--- a/src/Moryx.Orders.Web/src/app/components/operations/operations.component.html
+++ b/src/Moryx.Orders.Web/src/app/components/operations/operations.component.html
@@ -137,9 +137,35 @@
                     {{ TranslationConstants.OPERATIONS.AMOUNT | translate }}:
                     {{ operation.model.totalAmount }}
                   </div>
-                  <div>
-                    {{ TranslationConstants.OPERATIONS.SUCCESS | translate }}:
-                    {{ operation.model.successCount }}
+
+                  <div class="flex-row-center operation-progress">
+                    <div class="multi-progress-container">
+                      <div
+                        class="bar success"
+                        [style.flex-basis.%]="operation.progressSuccessPercent"
+                        matTooltip="{{ TranslationConstants.OPERATIONS.SUCCESS | translate }}: {{ operation.progressSuccessPercent | number: '1.1-1' }}%">
+                      </div>
+                      <div
+                        class="bar scrap"
+                        [style.flex-basis.%]="operation.progressScrapPercent"
+                        matTooltip="{{ TranslationConstants.OPERATIONS.SCRAP | translate }}: {{ operation.progressScrapPercent | number: '1.1-1' }}%">
+                      </div>
+                      <div
+                        class="bar running"
+                        [style.flex-basis.%]="operation.progressRunningPercent"
+                        matTooltip="{{ TranslationConstants.OPERATIONS.RUNNING | translate }}: {{ operation.progressRunningPercent | number: '1.1-1' }}%">
+                      </div>
+                      <div
+                        class="bar pending"
+                        [style.flex-basis.%]="operation.progressPendingPercent"
+                        matTooltip="{{ TranslationConstants.OPERATIONS.PENDING | translate }}: {{ operation.progressPendingPercent | number: '1.1-1' }}%">
+                      </div>
+                      <div
+                        class="bar residual"
+                        [style.flex-basis.%]="operation.progressResidualPercent"
+                        matTooltip="{{ TranslationConstants.OPERATIONS.RESIDUAL | translate }}: {{ operation.progressResidualPercent | number: '1.1-1' }}%">
+                      </div>
+                  </div>
                   </div>
                   <div>
                     {{ TranslationConstants.OPERATIONS.RUNNING | translate }}:

--- a/src/Moryx.Orders.Web/src/app/components/operations/operations.component.ts
+++ b/src/Moryx.Orders.Web/src/app/components/operations/operations.component.ts
@@ -32,7 +32,6 @@ import { MatButtonModule } from '@angular/material/button';
 import { MatBadgeModule } from '@angular/material/badge';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MatTooltipModule } from '@angular/material/tooltip';
-import { MatTooltip } from '@angular/material/tooltip';
 
 @Component({
   selector: 'app-operations',
@@ -53,8 +52,7 @@ import { MatTooltip } from '@angular/material/tooltip';
     EmptyStateComponent,
     MatProgressSpinnerModule,
     MatTooltipModule,
-    MatSidenavModule,
-    MatTooltip
+    MatSidenavModule
   ],
   standalone:true
 })


### PR DESCRIPTION
Root cause:
- The progress bars relied on `mat-progress-bar` elements being stacked and styled with `width`.
- The underlying cause could be related to Angular Material's internal CSS changes

Fix Summary:
- Rebuilt progress bar using a custom `flexbox` layout with colored `div` segments instead of multiple `mat-progress-bar` elements
- Added `matTooltip` to show localized segment label and percentage on hover
- Ensured consistent visual behavior and color usage across `operations` and `begin-dialog` components
- Implemented multi-language support for all tooltip labels
