### PR TITLE
Prevent the driver from crashing when saving with invalid `OpcUaServerUrl`

### DIFF
--- a/src/Moryx.Drivers.OpcUa/ApplicationConfigurationFactory.cs
+++ b/src/Moryx.Drivers.OpcUa/ApplicationConfigurationFactory.cs
@@ -1,0 +1,79 @@
+// Copyright (c) 2025, Phoenix Contact GmbH & Co. KG
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Opc.Ua;
+using Opc.Ua.Configuration;
+
+namespace Moryx.Drivers.OpcUa;
+public class ApplicationConfigurationFactory
+{
+    private ILogger _logger;
+
+    public string ApplicationName { get; set; } = "";
+
+    public virtual async Task<ApplicationConfiguration> Create(ILogger logger, string configPath = null)
+    {
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        var application = new ApplicationInstance
+        {
+            ApplicationName = ApplicationName,
+            ApplicationType = ApplicationType.Client,
+            ConfigSectionName = "Moryx.OpcUa.Client",
+        };
+
+        ApplicationConfiguration config;
+        var defaultPath = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "Config\\Opc.Ua.Default.Config.xml"));
+        var filePath = string.IsNullOrEmpty(configPath) ? defaultPath : configPath;
+        try
+        {
+            config = await application.LoadApplicationConfiguration(filePath, false);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError("{Message}", ex.Message);
+            return null;
+        }
+
+        ApplicationName = config.ApplicationName;
+        // check the application certificate
+        var haveAppCertificate = await application.CheckApplicationInstanceCertificate(false, 0);
+        if (!haveAppCertificate)
+        {
+            throw new Exception("Application instance certificate invalid!");
+        }
+        else
+        {
+            config.ApplicationUri = X509Utils.GetApplicationUriFromCertificate(config.SecurityConfiguration.ApplicationCertificate.Certificate);
+            config.CertificateValidator.CertificateValidation += CertificateValidatorCertificateValidation;
+        }
+        return config;
+    }
+
+    private void CertificateValidatorCertificateValidation(CertificateValidator validator, CertificateValidationEventArgs e)
+    {
+        _logger.Log(LogLevel.Error, "{StatusCode}", e.Error.StatusCode);
+        if (e.Error.StatusCode == StatusCodes.BadCertificateUntrusted)
+        {
+            if (validator.AutoAcceptUntrustedCertificates)
+            {
+                e.Accept = true;
+                if (validator.AutoAcceptUntrustedCertificates)
+                {
+                    _logger.Log(LogLevel.Information, "Accepted Certificate: {Subject}",
+                    e.Certificate.Subject);
+                }
+                else
+                {
+                    _logger.Log(LogLevel.Information, "Rejected Certificate: {Subject}",
+                    e.Certificate.Subject);
+                }
+            }
+        }
+    }
+}

--- a/src/Tests/Moryx.Drivers.OpcUa.Tests/DriverPropertiesTests.cs
+++ b/src/Tests/Moryx.Drivers.OpcUa.Tests/DriverPropertiesTests.cs
@@ -1,0 +1,40 @@
+// Copyright (c) 2025, Phoenix Contact GmbH & Co. KG
+
+using Microsoft.Extensions.Logging;
+using Moq;
+using Moryx.AbstractionLayer.Drivers.Message;
+using Moryx.Drivers.OpcUa.DriverStates;
+using Moryx.Modules;
+using NUnit.Framework;
+using Opc.Ua;
+using Opc.Ua.Client;
+
+namespace Moryx.Drivers.OpcUa.Tests;
+
+[TestFixture]
+public class DriverPropertiesTests : OpcUaTestBase
+{
+    [SetUp]
+    public void Setup()
+    {
+        BasicSetup();
+        var appConfigFactoryMock = new Mock<ApplicationConfigurationFactory>();
+        appConfigFactoryMock
+            .Setup(f => f.Create(It.IsAny<ILogger>(), It.IsAny<string>()))
+            .Returns(Task.FromResult(new ApplicationConfiguration { ApplicationName = "TestApp" }));
+
+        _driver.ApplicationConfigurationFactory = appConfigFactoryMock.Object;
+    }
+
+    [Test(Description = "Use Aliases for node Ids")]
+    public void DriverDoesntCrashWithInvalidServerUrl()
+    {
+        //Arrange
+        _driver.OpcUaServerUrl = "";
+
+        TestDelegate action = () => _driver.TryConnect(true).GetAwaiter().GetResult();
+
+        //Assert
+        Assert.DoesNotThrow(action);
+    }
+}


### PR DESCRIPTION
(cherry picked from commit 9d7f0d05b8bcc4c6ad628dd18cd0b6c4311c72f6)
