### PR TITLE
Fix the add order button hidden

### DIFF
--- a/src/Moryx.Orders.Web/src/app/components/operations/operations.component.scss
+++ b/src/Moryx.Orders.Web/src/app/components/operations/operations.component.scss
@@ -104,7 +104,7 @@ mat-grid-list {
 }
 
 .operation-create-fab-button {
-  position: fixed;
+  position: absolute;
   bottom: 16px;
   right: 16px;
   z-index: 1;


### PR DESCRIPTION
Problem:
	The `Add Order` button was hidden by the nav-bar when in
	operator view.
	The button's position was set as `fixed`, making it's position
	relative to the ViewPort.

Solution:
	Making the button's position `absolute` to position the button
	relative to it's parent element.
(cherry picked from commit 04a0ffb3aa6db349531ae885817194dd9d38c96d)

