### PR TITLE
Return errors with `ReadNodeAsString`

### DIFF
--- a/src/Moryx.Drivers.OpcUa/DataValueResult.cs
+++ b/src/Moryx.Drivers.OpcUa/DataValueResult.cs
@@ -1,0 +1,24 @@
+// Copyright (c) 2025, Phoenix Contact GmbH & Co. KG
+
+using System;
+using Opc.Ua;
+using Moryx.Tools.FunctionResult;
+
+namespace Moryx.Drivers.OpcUa;
+
+internal class DataValueResult : FunctionResult<DataValue>
+{
+    public DataValueResult(DataValue dataValue) : base(dataValue)
+    {
+    }
+
+    public DataValueResult(FunctionResultError error) : base(error)
+    {
+    }
+
+    internal static DataValueResult WithError(string message)
+        => new(new FunctionResultError(message));
+
+    internal static DataValueResult WithError(Exception exception)
+        => new(new FunctionResultError(exception));
+}

--- a/src/Moryx.Drivers.OpcUa/DriverStates/DriverOpcUaState.cs
+++ b/src/Moryx.Drivers.OpcUa/DriverStates/DriverOpcUaState.cs
@@ -1,8 +1,10 @@
 // Copyright (c) 2025, Phoenix Contact GmbH & Co. KG
 // Licensed under the Apache License, Version 2.0
 
+using System;
 using Moryx.AbstractionLayer.Drivers;
 using Moryx.StateMachines;
+using Moryx.Tools.FunctionResult;
 using Opc.Ua;
 using Opc.Ua.Client;
 
@@ -58,7 +60,7 @@ internal abstract class DriverOpcUaState(OpcUaDriver context, StateBase.StateMap
         Context.SaveSubscriptionToBeAdded(node);
     }
 
-    internal virtual DataValue ReadValue(string identifier)
+    internal virtual DataValueResult ReadValue(string identifier)
     {
         throw new InvalidOperationException();
     }

--- a/src/Moryx.Drivers.OpcUa/DriverStates/RunningState.cs
+++ b/src/Moryx.Drivers.OpcUa/DriverStates/RunningState.cs
@@ -20,7 +20,7 @@ internal class RunningState(OpcUaDriver context, StateMachines.StateBase.StateMa
         return Context.GetNode(identifier);
     }
 
-    internal override DataValue ReadValue(string identifier)
+    internal override DataValueResult ReadValue(string identifier)
     {
         return Context.OnReadValueOfNode(identifier);
     }


### PR DESCRIPTION
Previously, when attempting to read a node as a string using the
`ReadNodeAsString` method, errors were logged but not returned to the
caller. That made it difficult for the user understand what went wrong.

Now the method either returns the string value or an error, allowing the
user to directly take appropriate action instead of browsing logs first.

(cherry picked from commit 40b7d4523b228f91f1e7839e1845a7f9cdf50471)
