### PR TITLE
ModelSetupExecutor must use BaseDbContextType for Setups

### DIFF
--- a/src/Moryx.Model/DbContextManager.cs
+++ b/src/Moryx.Model/DbContextManager.cs
@@ -169,9 +169,7 @@ namespace Moryx.Model
             if (configuredContext == null)
                 throw new InvalidOperationException($"Context {contextType.FullName} not configured!");
 
-            var specificContextType = configuredContext.SpecificDbContextType;
-
-            var setupExecutorType = typeof(ModelSetupExecutor<>).MakeGenericType(specificContextType);
+            var setupExecutorType = typeof(ModelSetupExecutor<>).MakeGenericType(configuredContext.BaseDbContextType);
             return (IModelSetupExecutor)Activator.CreateInstance(setupExecutorType, this);
         }
 


### PR DESCRIPTION
Model setups for base-context were not found anymore. Setups are defined for the base-context-type