### PR TITLE
Renamed GetAllResources, Create, Modify and Read and added remarks

### DIFF
--- a/docs/migrations/v8_to_v10.md
+++ b/docs/migrations/v8_to_v10.md
@@ -22,6 +22,10 @@ The simulator module has also been renamed, and its namespace and package id hav
 - ResourceRelationType.CurrentExchangablePart -> ResourceRelationType.CurrentExchangeablePart
 - ResourceRelationType.PossibleExchangablePart -> ResourceRelationType.PossibleExchangeablePart
 - MqttDriver.BrokerURL -> MqttDriver.BrokerUrl
+- IResourceManagement.GetAllResources -> IResourceManagement.GetResourcesUnsafe
+- IResourceManagement.Create -> IResourceManagement.CreateUnsafe
+- IResourceManagement.Read -> IResourceManagement.ReadUnsafe
+- IResourceManagement.Modify -> IResourceManagement.ModifyUnsafe
 
 ## Reduction of interfaces
 

--- a/src/Moryx.AbstractionLayer/Resources/IResourceManagement.cs
+++ b/src/Moryx.AbstractionLayer/Resources/IResourceManagement.cs
@@ -63,25 +63,69 @@ namespace Moryx.AbstractionLayer.Resources
         /// <summary>
         /// Get all resources including the private ones of this type that match the predicate
         /// </summary>
-        IEnumerable<TResource> GetAllResources<TResource>(Func<TResource, bool> predicate)
+        /// <remarks>
+        /// This method returns the actual resource instances, not wrapped by proxy.
+        /// As a result, all internal members, including properties and
+        /// methods not exposed through interfaces, are accessible.
+        ///
+        /// This API is intended primarily for endpoint controllers that must export or
+        /// inspect the full internal state of a resource.
+        ///
+        /// Because the returned objects are the originals, the API consumer is responsible for keeping and watching the life-cycle.
+        /// Use with extreme caution. Do not keep the instances in memory for later usage.
+        /// </remarks>
+        IEnumerable<TResource> GetResourcesUnsafe<TResource>(Func<TResource, bool> predicate)
             where TResource : class, IResource;
 
         /// <summary>
         /// Create and initialize a resource
         /// </summary>
-        long Create(Type resourceType, Action<Resource> initializer);
+        /// <remarks>
+        /// The <param name="initializer"></param> action uses the actual resource instance, not wrapped by proxy.
+        /// As a result, all internal members, including properties and
+        /// methods not exposed through interfaces, are accessible.
+        ///
+        /// This API is intended primarily for endpoint controllers that must export or
+        /// inspect the full internal state of a resource.
+        ///
+        /// Because the returned objects are the originals, the API consumer is responsible for keeping and watching the life-cycle.
+        /// Use with extreme caution. Do not keep the instance in memory for later usage.
+        /// </remarks>
+        long CreateUnsafe(Type resourceType, Action<Resource> initializer);
 
         /// <summary>
         /// Read data from a resource
         /// </summary>
-        TResult Read<TResult>(long id, Func<Resource, TResult> accessor);
+        /// <remarks>
+        /// The <param name="accessor"></param> action uses the actual resource instance, not wrapped by proxy.
+        /// As a result, all internal members, including properties and
+        /// methods not exposed through interfaces, are accessible.
+        ///
+        /// This API is intended primarily for endpoint controllers that must export or
+        /// inspect the full internal state of a resource.
+        ///
+        /// Because the returned objects are the originals, the API consumer is responsible for keeping and watching the life-cycle.
+        /// Use with extreme caution. Do not keep the instance in memory for later usage.
+        /// </remarks>
+        TResult ReadUnsafe<TResult>(long id, Func<Resource, TResult> accessor);
 
         /// <summary>
-        /// Modify the resource. 
+        /// Modify the resource.
         /// </summary>
         /// <param name="id">Id of the resource</param>
         /// <param name="modifier">Modifier delegate, must return <value>true</value> in order to save changes</param>
-        void Modify(long id, Func<Resource, bool> modifier);
+        /// <remarks>
+        /// The <param name="modifier"></param> action uses the actual resource instance, not wrapped by proxy.
+        /// As a result, all internal members, including properties and
+        /// methods not exposed through interfaces, are accessible.
+        ///
+        /// This API is intended primarily for endpoint controllers that must export or
+        /// inspect the full internal state of a resource.
+        ///
+        /// Because the returned objects are the originals, the API consumer is responsible for keeping and watching the life-cycle.
+        /// Use with extreme caution. Do not keep the instance in memory for later usage.
+        /// </remarks>
+        void ModifyUnsafe(long id, Func<Resource, bool> modifier);
 
         /// <summary>
         /// Create and initialize a resource

--- a/src/Moryx.AbstractionLayer/Resources/ResourceFacadeExtensions.cs
+++ b/src/Moryx.AbstractionLayer/Resources/ResourceFacadeExtensions.cs
@@ -9,64 +9,92 @@ namespace Moryx.AbstractionLayer.Resources
     public static class ResourceFacadeExtensions
     {
         /// <summary>
-        /// Read data from a resource
+        /// Read data from a resource by the given resource-proxy
         /// </summary>
-        public static TResult Read<TResult>(this IResourceManagement facade, long resourceId, Func<Resource, TResult> accessor)
+        /// <param name="facade">Extended facade</param>
+        /// <param name="proxy">Resource proxy reference</param>
+        /// <param name="accessor">Accessor delegate for the resource</param>
+        /// <remarks>
+        /// The <param name="accessor"></param> action uses the actual resource instance, not wrapped by proxy.
+        /// As a result, all internal members, including properties and
+        /// methods not exposed through interfaces, are accessible.
+        ///
+        /// This API is intended primarily for endpoint controllers that must export or
+        /// inspect the full internal state of a resource.
+        ///
+        /// Because the returned objects are the originals, the API consumer is responsible for keeping and watching the life-cycle.
+        /// Use with extreme caution. Do not keep the instance in memory for later usage.
+        /// </remarks>
+        public static TResult ReadUnsafe<TResult>(this IResourceManagement facade, IResource proxy, Func<Resource, TResult> accessor)
         {
-            return facade.Read(resourceId, accessor);
+            return facade.ReadUnsafe(proxy.Id, accessor);
         }
 
         /// <summary>
-        /// Read data from a resource
+        /// Modify the resource by the given resource-proxy
         /// </summary>
-        public static TResult Read<TResult>(this IResourceManagement facade, IResource proxy, Func<Resource, TResult> accessor)
-        {
-            return facade.Read(proxy.Id, accessor);
-        }
-
-        /// <summary>
-        /// Modify the resource. 
-        /// </summary>
-        /// <param name="resourceId"></param>
+        /// <param name="facade">Extended facade</param>
+        /// <param name="proxy">Resource proxy reference</param>
         /// <param name="modifier">Modifier delegate, must return <value>true</value> in order to save changes</param>
-        /// <param name="facade"></param>
-        public static void Modify(this IResourceManagement facade, long resourceId, Func<Resource, bool> modifier)
+        /// <remarks>
+        /// The <param name="modifier"></param> action uses the actual resource instance, not wrapped by proxy.
+        /// As a result, all internal members, including properties and
+        /// methods not exposed through interfaces, are accessible.
+        ///
+        /// This API is intended primarily for endpoint controllers that must export or
+        /// inspect the full internal state of a resource.
+        ///
+        /// Because the returned objects are the originals, the API consumer is responsible for keeping and watching the life-cycle.
+        /// Use with extreme caution. Do not keep the instance in memory for later usage.
+        /// </remarks>
+        public static void ModifyUnsafe(this IResourceManagement facade, IResource proxy, Func<Resource, bool> modifier)
         {
-            facade.Modify(resourceId, modifier);
+            facade.ModifyUnsafe(proxy.Id, modifier);
         }
 
         /// <summary>
-        /// Modify the resource. 
+        /// Modify the resource.
         /// </summary>
-        /// <param name="proxy"></param>
+        /// <param name="facade">Extended facade</param>
+        /// <param name="proxy">Resource proxy reference</param>
         /// <param name="modifier">Modifier delegate, must return <value>true</value> in order to save changes</param>
-        /// <param name="facade"></param>
-        public static void Modify(this IResourceManagement facade, IResource proxy, Func<Resource, bool> modifier)
+        /// <param name="context">Additional context, used within the <param cref="modifier"/></param>
+        /// <remarks>
+        /// The <param name="modifier"></param> action uses the actual resource instance, not wrapped by proxy.
+        /// As a result, all internal members, including properties and
+        /// methods not exposed through interfaces, are accessible.
+        ///
+        /// This API is intended primarily for endpoint controllers that must export or
+        /// inspect the full internal state of a resource.
+        ///
+        /// Because the returned objects are the originals, the API consumer is responsible for keeping and watching the life-cycle.
+        /// Use with extreme caution. Do not keep the instance in memory for later usage.
+        /// </remarks>
+        public static void ModifyUnsafe<TContext>(this IResourceManagement facade, IResource proxy, Func<Resource, TContext, bool> modifier, TContext context)
         {
-            facade.Modify(proxy.Id, modifier);
+            facade.ModifyUnsafe(proxy.Id, resource => modifier(resource, context));
         }
 
         /// <summary>
-        /// Modify the resource. 
+        /// Create and initialize a resource with typed initializer
         /// </summary>
-        /// <param name="proxy"></param>
-        /// <param name="modifier">Modifier delegate, must return <value>true</value> in order to save changes</param>
-        /// <param name="facade"></param>
-        /// <param name="context"></param>
-        public static void Modify<TContext>(this IResourceManagement facade, IResource proxy, Func<Resource, TContext, bool> modifier, TContext context)
-        {
-            facade.Modify(proxy.Id, resource => modifier(resource, context));
-        }
-
-        /// <summary>
-        /// Create a resource with typed initializer 
-        /// </summary>
-        /// <param name="facade"></param>
-        /// <param name="initializer"></param>
-        public static long Create<TResource>(this IResourceManagement facade, Action<TResource> initializer)
+        /// <remarks>
+        /// The <param name="initializer"></param> action uses the actual resource instance, not wrapped by proxy.
+        /// As a result, all internal members, including properties and
+        /// methods not exposed through interfaces, are accessible.
+        ///
+        /// This API is intended primarily for endpoint controllers that must export or
+        /// inspect the full internal state of a resource.
+        ///
+        /// Because the returned objects are the originals, the API consumer is responsible for keeping and watching the life-cycle.
+        /// Use with extreme caution. Do not keep the instance in memory for later usage.
+        /// </remarks>
+        /// <param name="facade">Extended facade</param>
+        /// <param name="initializer">Initializer delegate for the resource</param>
+        public static long CreateUnsafe<TResource>(this IResourceManagement facade, Action<TResource> initializer)
             where TResource : Resource
         {
-            return facade.Create(typeof(TResource), r => initializer((TResource)r));
+            return facade.CreateUnsafe(typeof(TResource), r => initializer((TResource)r));
         }
     }
 }

--- a/src/Moryx.ControlSystem.Processes.Endpoints/ProcessEngineController.cs
+++ b/src/Moryx.ControlSystem.Processes.Endpoints/ProcessEngineController.cs
@@ -315,9 +315,9 @@ public class ProcessEngineController : ControllerBase
     {
         return HttpResponse(() =>
         {
-            var allPositions = _resourceManagement.GetAllResources<IProcessHolderPosition>(x => true);
+            var allPositions = _resourceManagement.GetResourcesUnsafe<IProcessHolderPosition>(x => true);
             var ungrouped = allPositions.GetUngroupedPostions();
-            var groups = _resourceManagement.GetAllResources<IProcessHolderGroup>(x => true);
+            var groups = _resourceManagement.GetResourcesUnsafe<IProcessHolderGroup>(x => true);
 
             return new ApiResponse<ProcessHolderGroupModel[]>([.. groups.ToDto(), .. ungrouped.ToDto()]);
         });

--- a/src/Moryx.ControlSystem.Processes.Endpoints/StreamServices/ProcessHolderGroupStream.cs
+++ b/src/Moryx.ControlSystem.Processes.Endpoints/StreamServices/ProcessHolderGroupStream.cs
@@ -30,8 +30,8 @@ internal class ProcessHolderGroupStream(
 
         //using this because resourceManagement.GetResources<T> is very restricted in the sense
         // that casting at line 55 doesn't work
-        var groups = resourceManagement.GetAllResources<IProcessHolderGroup>(_ => true);
-        var allPositions = resourceManagement.GetAllResources<IProcessHolderPosition>(_ => true);
+        var groups = resourceManagement.GetResourcesUnsafe<IProcessHolderGroup>(_ => true);
+        var allPositions = resourceManagement.GetResourcesUnsafe<IProcessHolderPosition>(_ => true);
 
         // Define event handling
         var groupChannel = Channel.CreateUnbounded<ProcessHolderGroupChangedEventArg>();

--- a/src/Moryx.ControlSystem.Simulator/Implementation/ProcessSimulator.cs
+++ b/src/Moryx.ControlSystem.Simulator/Implementation/ProcessSimulator.cs
@@ -46,7 +46,7 @@ namespace Moryx.ControlSystem.Simulator
 
         public void Start()
         {
-            _drivers = ResourceManagement.GetAllResources<ISimulationDriver>(x => true).ToList();
+            _drivers = ResourceManagement.GetResourcesUnsafe<ISimulationDriver>(x => true).ToList();
             foreach (var driver in _drivers)
             {
                 driver.SimulatedStateChanged += SimulationStateChanged;

--- a/src/Moryx.FactoryMonitor.Endpoints/Extensions/CellExtensions.cs
+++ b/src/Moryx.FactoryMonitor.Endpoints/Extensions/CellExtensions.cs
@@ -24,7 +24,7 @@ namespace Moryx.FactoryMonitor.Endpoints.Extensions
            Func<IMachineLocation, bool> cellFilter)
         {
 
-            var resourceChangedCellModel = resourceManager.Read(cell.Id, converter.ToResourceChangedModel);
+            var resourceChangedCellModel = resourceManager.ReadUnsafe(cell.Id, converter.ToResourceChangedModel);
 
             var machineLocation = resourceManager
                 .GetResources(cellFilter)
@@ -39,7 +39,7 @@ namespace Moryx.FactoryMonitor.Endpoints.Extensions
 
         public static long GetFactoryId(this ICell cell, IResourceManagement resourceManagement)
         {
-            var resource = resourceManagement.Read(cell, x => x.GetFactory());
+            var resource = resourceManagement.ReadUnsafe(cell, x => x.GetFactory());
             return resource?.Id ?? -1;
         }
 

--- a/src/Moryx.FactoryMonitor.Endpoints/Models/SimpleGraph.cs
+++ b/src/Moryx.FactoryMonitor.Endpoints/Models/SimpleGraph.cs
@@ -55,7 +55,7 @@ namespace Moryx.FactoryMonitor.Endpoints.Models
             Converter converter,
             Func<IMachineLocation, bool> filter)
         {
-            VisualizableItemModel result = resourceManager.Read(Id, e =>
+            VisualizableItemModel result = resourceManager.ReadUnsafe(Id, e =>
             {
                 if (e.GetDisplayableResourceLocation(logger) is not MachineLocation displayableItemLocation) return null;
 

--- a/src/Moryx.Resources.Management/Facades/ResourceManagementFacade.cs
+++ b/src/Moryx.Resources.Management/Facades/ResourceManagementFacade.cs
@@ -19,8 +19,6 @@ namespace Moryx.Resources.Management
 
         #endregion
 
-        #region IFacadeControl
-
         /// <seealso cref="IFacadeControl"/>
         public override void Activate()
         {
@@ -51,7 +49,6 @@ namespace Moryx.Resources.Management
         {
             ResourceRemoved?.Invoke(this, publicResource.Proxify(TypeController));
         }
-        #endregion
 
         #region IResourceManagement
         public TResource GetResource<TResource>() where TResource : class, IResource
@@ -110,8 +107,7 @@ namespace Moryx.Resources.Management
 
         #endregion
 
-        #region IResourceModification
-        public long Create(Type resourceType, Action<Resource> initializer)
+        public long CreateUnsafe(Type resourceType, Action<Resource> initializer)
         {
             ValidateHealthState();
 
@@ -121,14 +117,7 @@ namespace Moryx.Resources.Management
             return resource.Id;
         }
 
-        /// <summary>
-        /// 
-        /// </summary>
-        /// <typeparam name="TResult"></typeparam>
-        /// <param name="id"></param>
-        /// <param name="accessor"></param>
-        /// <returns>null, when a resource with this id doesn't exist</returns>
-        public TResult Read<TResult>(long id, Func<Resource, TResult> accessor)
+        public TResult ReadUnsafe<TResult>(long id, Func<Resource, TResult> accessor)
         {
             ValidateHealthState();
 
@@ -138,7 +127,7 @@ namespace Moryx.Resources.Management
             return result;
         }
 
-        public void Modify(long id, Func<Resource, bool> modifier)
+        public void ModifyUnsafe(long id, Func<Resource, bool> modifier)
         {
             ValidateHealthState();
 
@@ -162,21 +151,17 @@ namespace Moryx.Resources.Management
             return ResourceGraph.Destroy(resource);
         }
 
-        public IEnumerable<TResource> GetAllResources<TResource>(Func<TResource, bool> predicate)
+        public IEnumerable<TResource> GetResourcesUnsafe<TResource>(Func<TResource, bool> predicate)
              where TResource : class, IResource
         {
             ValidateHealthState();
             return ResourceGraph.GetResources(predicate);
         }
-        #endregion
 
-        /// <inheritdoc />
         public event EventHandler<IResource> ResourceAdded;
 
-        /// <inheritdoc />
         public event EventHandler<IResource> ResourceRemoved;
 
-        /// <inheritdoc />
         public event EventHandler<ICapabilities> CapabilitiesChanged;
     }
 

--- a/src/Tests/Moryx.FactoryMonitor.Endpoints.Tests/BaseTest.cs
+++ b/src/Tests/Moryx.FactoryMonitor.Endpoints.Tests/BaseTest.cs
@@ -80,7 +80,7 @@ namespace Moryx.FactoryMonitor.Endpoints.Tests
             _resourceManagementMock.Setup(rm =>
             rm.GetResource<IMachineLocation>(It.Is<Func<IMachineLocation, bool>>(f => f(_assemblyCellLocation))))
                 .Returns(_assemblyCellLocation);
-            _resourceManagementMock.Setup(rm => rm.Read(_assemblyCellLocation.Id, It.IsAny<Func<Resource, MachineLocation>>()))
+            _resourceManagementMock.Setup(rm => rm.ReadUnsafe(_assemblyCellLocation.Id, It.IsAny<Func<Resource, MachineLocation>>()))
                 .Returns(_assemblyCellLocation);
             //_solderingCell location 
             _solderingCellLocation = _graph.Instantiate<MachineLocation>();
@@ -91,7 +91,7 @@ namespace Moryx.FactoryMonitor.Endpoints.Tests
             _resourceManagementMock.Setup(rm =>
             rm.GetResource<IMachineLocation>(It.Is<Func<IMachineLocation, bool>>(f => f(_solderingCellLocation))))
                 .Returns(_solderingCellLocation);
-            _resourceManagementMock.Setup(rm => rm.Read(_solderingCellLocation.Id, It.IsAny<Func<Resource, MachineLocation>>()))
+            _resourceManagementMock.Setup(rm => rm.ReadUnsafe(_solderingCellLocation.Id, It.IsAny<Func<Resource, MachineLocation>>()))
                 .Returns(_solderingCellLocation);
 
             // resource management cells
@@ -101,17 +101,17 @@ namespace Moryx.FactoryMonitor.Endpoints.Tests
                 .Returns(GetLocations());
             _resourceManagementMock.Setup(rm => rm.GetResources(It.IsAny<Func<IMachineLocation, bool>>()))
                 .Returns(GetLocations());
-            _resourceManagementMock.Setup(rm => rm.Read(_assemblyCellId, It.IsAny<Func<Resource, Resource>>()))
+            _resourceManagementMock.Setup(rm => rm.ReadUnsafe(_assemblyCellId, It.IsAny<Func<Resource, Resource>>()))
                 .Returns(_assemblyCell);
-            _resourceManagementMock.Setup(rm => rm.Read(_assemblyCellId, It.IsAny<Func<Resource, ResourceChangedModel>>()))
+            _resourceManagementMock.Setup(rm => rm.ReadUnsafe(_assemblyCellId, It.IsAny<Func<Resource, ResourceChangedModel>>()))
                  .Returns(converter.ToResourceChangedModel(_assemblyCell));
-            _resourceManagementMock.Setup(rm => rm.Read(_solderingCellId, It.IsAny<Func<Resource, Resource>>()))
+            _resourceManagementMock.Setup(rm => rm.ReadUnsafe(_solderingCellId, It.IsAny<Func<Resource, Resource>>()))
                 .Returns(_solderingCell);
-            _resourceManagementMock.Setup(rm => rm.Read(_solderingCellId, It.IsAny<Func<Resource, ResourceChangedModel>>()))
+            _resourceManagementMock.Setup(rm => rm.ReadUnsafe(_solderingCellId, It.IsAny<Func<Resource, ResourceChangedModel>>()))
                  .Returns(converter.ToResourceChangedModel(_solderingCell));
-            _resourceManagementMock.Setup(rm => rm.Read(_manufactoringFactoryId, It.IsAny<Func<Resource, Resource>>()))
+            _resourceManagementMock.Setup(rm => rm.ReadUnsafe(_manufactoringFactoryId, It.IsAny<Func<Resource, Resource>>()))
                 .Returns(_manufactoringFactory);
-            _resourceManagementMock.Setup(rm => rm.Read(_manufactoringFactoryId, It.IsAny<Func<Resource, ResourceChangedModel>>()))
+            _resourceManagementMock.Setup(rm => rm.ReadUnsafe(_manufactoringFactoryId, It.IsAny<Func<Resource, ResourceChangedModel>>()))
                 .Returns(converter.ToResourceChangedModel(_manufactoringFactory));
             //process
             _processFacadeMock.SetupGet(pm => pm.RunningProcesses)

--- a/src/Tests/Moryx.FactoryMonitor.Endpoints.Tests/FactoryMonitorController_BackgroundTest.cs
+++ b/src/Tests/Moryx.FactoryMonitor.Endpoints.Tests/FactoryMonitorController_BackgroundTest.cs
@@ -18,7 +18,7 @@ namespace Moryx.FactoryMonitor.Endpoints.Tests
         {
             // Arange
             var newBackgroundUrl = @"https://media.istockphoto.com/id/849023956/photo/robot-assembly-line-in-car-factory.jpg?s=612x612&w=0&k=20&c=K39t_WpWlKB6I3iJco72kiscOxYdXl1ons-0VSf8yyo=";
-            _resourceManagementMock.Setup(rm => rm.Modify(_manufactoringFactoryId, It.IsAny<Func<Resource, bool>>()))
+            _resourceManagementMock.Setup(rm => rm.ModifyUnsafe(_manufactoringFactoryId, It.IsAny<Func<Resource, bool>>()))
                 .Callback(() =>
                 {
                     _manufactoringFactory.BackgroundUrl = newBackgroundUrl;
@@ -30,7 +30,7 @@ namespace Moryx.FactoryMonitor.Endpoints.Tests
             //Assert
             Assert.That(((OkResult)endPointResult).StatusCode, Is.EqualTo(200));
             Assert.That(_manufactoringFactory.BackgroundUrl, Is.EqualTo(newBackgroundUrl));
-            _resourceManagementMock.Verify(rm => rm.Modify(_manufactoringFactoryId, It.IsAny<Func<Resource, bool>>()), Times.Once);
+            _resourceManagementMock.Verify(rm => rm.ModifyUnsafe(_manufactoringFactoryId, It.IsAny<Func<Resource, bool>>()), Times.Once);
         }
 
     }

--- a/src/Tests/Moryx.FactoryMonitor.Endpoints.Tests/FactoryMonitorController_CellOperationsTest.cs
+++ b/src/Tests/Moryx.FactoryMonitor.Endpoints.Tests/FactoryMonitorController_CellOperationsTest.cs
@@ -58,7 +58,7 @@ namespace Moryx.FactoryMonitor.Endpoints.Tests
 
             //Assert
             Assert.That(((OkResult)endPointResult).StatusCode, Is.EqualTo(200));
-            _resourceManagementMock.Verify(rm => rm.Modify(_assemblyCellLocation.Id, It.IsAny<Func<Resource, bool>>()), Times.Once, "The Location resource was not updated!");
+            _resourceManagementMock.Verify(rm => rm.ModifyUnsafe(_assemblyCellLocation.Id, It.IsAny<Func<Resource, bool>>()), Times.Once, "The Location resource was not updated!");
         }
 
         [Test]

--- a/src/Tests/Moryx.FactoryMonitor.Endpoints.Tests/FactoryMonitorController_RouteTest.cs
+++ b/src/Tests/Moryx.FactoryMonitor.Endpoints.Tests/FactoryMonitorController_RouteTest.cs
@@ -21,11 +21,11 @@ namespace Moryx.FactoryMonitor.Endpoints.Tests
         {
             // Arange
             long expectedId = 10;
-            _resourceManagementMock.Setup(rm => rm.Read(_assemblyCellLocation.Id, It.IsAny<Func<Resource, Resource>>()))
+            _resourceManagementMock.Setup(rm => rm.ReadUnsafe(_assemblyCellLocation.Id, It.IsAny<Func<Resource, Resource>>()))
                 .Returns(new MachineLocation { Id = _assemblyCellLocation.Id });
-            _resourceManagementMock.Setup(rm => rm.Read(_solderingCellLocation.Id, It.IsAny<Func<Resource, Resource>>()))
+            _resourceManagementMock.Setup(rm => rm.ReadUnsafe(_solderingCellLocation.Id, It.IsAny<Func<Resource, Resource>>()))
                 .Returns(new MachineLocation { Id = _solderingCellLocation.Id });
-            _resourceManagementMock.Setup(rm => rm.Create(typeof(TransportPath), It.IsAny<Action<Resource>>()))
+            _resourceManagementMock.Setup(rm => rm.CreateUnsafe(typeof(TransportPath), It.IsAny<Action<Resource>>()))
                 .Returns(expectedId);
 
             //Act
@@ -33,7 +33,7 @@ namespace Moryx.FactoryMonitor.Endpoints.Tests
 
             //Assert
             Assert.That(((OkResult)endPointResult).StatusCode, Is.EqualTo(200));
-            _resourceManagementMock.Verify(rm => rm.Create(typeof(TransportPath), It.IsAny<Action<Resource>>()), Times.Once, "The resource was not created!");
+            _resourceManagementMock.Verify(rm => rm.CreateUnsafe(typeof(TransportPath), It.IsAny<Action<Resource>>()), Times.Once, "The resource was not created!");
         }
 
         [Test]
@@ -52,7 +52,7 @@ namespace Moryx.FactoryMonitor.Endpoints.Tests
 
             //Assert
             Assert.That(((OkResult)endPointResult).StatusCode, Is.EqualTo(200));
-            _resourceManagementMock.Verify(rm => rm.Modify(expectedId, It.IsAny<Func<Resource, bool>>()), Times.Once, "The resource was not updated!");
+            _resourceManagementMock.Verify(rm => rm.ModifyUnsafe(expectedId, It.IsAny<Func<Resource, bool>>()), Times.Once, "The resource was not updated!");
 
             _solderingCellLocation.Destinations.Clear();
         }

--- a/src/Tests/Moryx.Simulation.Tests/BaseTest.cs
+++ b/src/Tests/Moryx.Simulation.Tests/BaseTest.cs
@@ -62,7 +62,7 @@ namespace Moryx.Simulation.Tests
 
             //resource management
             _resourceManagementMock = new Mock<IResourceManagement>();
-            _resourceManagementMock.Setup(rm => rm.GetAllResources<ISimulationDriver>(It.IsAny<Func<ISimulationDriver, bool>>()))
+            _resourceManagementMock.Setup(rm => rm.GetResourcesUnsafe<ISimulationDriver>(It.IsAny<Func<ISimulationDriver, bool>>()))
                 .Returns([_assemblyCellDriver, _anotherAssemblyCellDriver]);
 
             //logger mock

--- a/src/Tests/Moryx.Simulation.Tests/SimulationActivitiesTests.cs
+++ b/src/Tests/Moryx.Simulation.Tests/SimulationActivitiesTests.cs
@@ -99,7 +99,7 @@ namespace Moryx.Simulation.Tests
             _anotherAssemblyCell.Driver = _anotherAssemblyDriverMock.Object;
 
             //resource management
-            _resourceManagementMock.Setup(rm => rm.GetAllResources(It.IsAny<Func<ISimulationDriver, bool>>()))
+            _resourceManagementMock.Setup(rm => rm.GetResourcesUnsafe(It.IsAny<Func<ISimulationDriver, bool>>()))
                 .Returns([_assemblyDriverMock.Object, _anotherAssemblyDriverMock.Object]);
 
             _processControlMock.SetupSequence(pc => pc.Targets(It.IsAny<IProcess>()))

--- a/src/Tests/Moryx.Simulation.Tests/SimulationDriverTests.cs
+++ b/src/Tests/Moryx.Simulation.Tests/SimulationDriverTests.cs
@@ -61,7 +61,7 @@ namespace Moryx.Simulation.Tests
             _assemblyCell.Driver = _simulationDriverTestMock.Object;
 
             //resource management
-            _resourceManagementMock.Setup(rm => rm.GetAllResources<ISimulationDriver>(It.IsAny<Func<ISimulationDriver, bool>>()))
+            _resourceManagementMock.Setup(rm => rm.GetResourcesUnsafe<ISimulationDriver>(It.IsAny<Func<ISimulationDriver, bool>>()))
                 .Returns([_simulationDriverTestMock.Object]);
 
             //start the simulator


### PR DESCRIPTION
As discussed here #783 and described in the ADR - the hint for working on non-proxies should be more explicit. 

Renamed GetAllResources/Create/Modify/Read and added *Unsafe to it. Added a descriptive remarks section to the methods and extensions:

<img width="748" height="334" alt="Screenshot 2025-11-20 at 10 54 00" src="https://github.com/user-attachments/assets/589d5b63-dc53-46d4-979a-c7aa9bc95ed7" />

@andreniggemann FYI