### PR TITLE
Resource changes are now exposed by the IResourceManagement-facade

### DIFF
--- a/src/Moryx.AbstractionLayer/Resources/IResourceManagement.cs
+++ b/src/Moryx.AbstractionLayer/Resources/IResourceManagement.cs
@@ -153,6 +153,12 @@ namespace Moryx.AbstractionLayer.Resources
         event EventHandler<IResource> ResourceRemoved;
 
         /// <summary>
+        /// Raised when a resource reports a change (via Resource.RaiseResourceChanged)
+        /// or is changed via the ResourceManagement facade (e.g. Modify).
+        /// </summary>
+        event EventHandler<IResource> ResourceChanged;
+
+        /// <summary>
         /// Raised when the capabilities have changed.
         /// </summary>
         event EventHandler<ICapabilities> CapabilitiesChanged;

--- a/src/Moryx.Resources.Management/Facades/ResourceManagementFacade.cs
+++ b/src/Moryx.Resources.Management/Facades/ResourceManagementFacade.cs
@@ -27,6 +27,7 @@ namespace Moryx.Resources.Management
             ResourceManager.ResourceAdded += OnResourceAdded;
             ResourceManager.CapabilitiesChanged += OnCapabilitiesChanged;
             ResourceManager.ResourceRemoved += OnResourceRemoved;
+            ResourceManager.ResourceChanged += OnResourceChanged;
         }
 
         /// <seealso cref="IFacadeControl"/>
@@ -35,6 +36,7 @@ namespace Moryx.Resources.Management
             ResourceManager.ResourceAdded -= OnResourceAdded;
             ResourceManager.CapabilitiesChanged -= OnCapabilitiesChanged;
             ResourceManager.ResourceRemoved -= OnResourceRemoved;
+            ResourceManager.ResourceChanged -= OnResourceChanged;
         }
 
         private void OnCapabilitiesChanged(object sender, ICapabilities args)
@@ -42,14 +44,19 @@ namespace Moryx.Resources.Management
             CapabilitiesChanged?.Invoke(((IResource)sender).Proxify(TypeController), args);
         }
 
-        private void OnResourceAdded(object sender, IResource publicResource)
+        private void OnResourceAdded(object sender, IResource resource)
         {
-            ResourceAdded?.Invoke(this, publicResource.Proxify(TypeController));
+            ResourceAdded?.Invoke(this, resource.Proxify(TypeController));
         }
 
-        private void OnResourceRemoved(object sender, IResource publicResource)
+        private void OnResourceChanged(object sender, IResource resource)
         {
-            ResourceRemoved?.Invoke(this, publicResource.Proxify(TypeController));
+            ResourceChanged?.Invoke(this, resource.Proxify(TypeController));
+        }
+
+        private void OnResourceRemoved(object sender, IResource resource)
+        {
+            ResourceRemoved?.Invoke(this, resource.Proxify(TypeController));
         }
 
         #region IResourceManagement
@@ -181,6 +188,8 @@ namespace Moryx.Resources.Management
         public event EventHandler<IResource> ResourceAdded;
 
         public event EventHandler<IResource> ResourceRemoved;
+
+        public event EventHandler<IResource> ResourceChanged;
 
         public event EventHandler<ICapabilities> CapabilitiesChanged;
     }

--- a/src/Moryx.Resources.Management/Resources/IResourceManager.cs
+++ b/src/Moryx.Resources.Management/Resources/IResourceManager.cs
@@ -32,6 +32,11 @@ namespace Moryx.AbstractionLayer.Resources
         event EventHandler<IResource> ResourceRemoved;
 
         /// <summary>
+        /// Raised when a resource was changed during runtime (properties, collections or references)
+        /// </summary>
+        event EventHandler<IResource> ResourceChanged;
+
+        /// <summary>
         /// Raised when the capabilities have changed.
         /// </summary>
         event EventHandler<ICapabilities> CapabilitiesChanged;

--- a/src/Tests/Moryx.Resources.Management.Tests/ResourceManagerTests.cs
+++ b/src/Tests/Moryx.Resources.Management.Tests/ResourceManagerTests.cs
@@ -218,6 +218,45 @@ namespace Moryx.Resources.Management.Tests
             Assert.That(entity.Name, Is.EqualTo(testResource.Name));
         }
 
+        [Test(Description = "Should notify facade listeners when resource Changed")]
+        public void RaiseResourceChangesOnChangedResource()
+        {
+            // Arrange
+            var testResource = _graph.Instantiate<PublicResourceMock>();
+            int notifications = 0;
+            _resourceManager.ResourceChanged += (sender, resource) =>
+            {
+                notifications = +1;
+            };
+            _resourceManager.Save(testResource);
+
+            // Act
+            testResource.Name = "Hello World";
+            testResource.RaiseChanged();
+
+            // Assert
+            Assert.That(notifications, Is.EqualTo(1));
+        }
+
+        [Test(Description = "Should not notify facade listeners when new resource added")]
+        public void DontRaiseResourceChangesOnAdded()
+        {
+            // Arrange
+            var testResource = _graph.Instantiate<PublicResourceMock>();
+            int notifications = 0;
+            _resourceManager.ResourceChanged += (sender, resource) =>
+            {
+                notifications = +1;
+            };
+
+            // Act
+            _resourceManager.Save(testResource);
+
+            // Assert
+            Assert.That(notifications, Is.EqualTo(0));
+        }
+
+
         [Test(Description = "Adds a resource while the ResourceManager was initialized but not started")]
         public void AddResourceWhileInitializedDoesNotStartResource()
         {


### PR DESCRIPTION
Changes to collection or Resource.Changed event are now published via the facade `IResourceManagement.ResourceChanged` event

picked from #661 because it will introduce an additional interface in 8.x which will be removed in 10 again, but only if done before release. Therefore I added this change directly to 10.