### PR TITLE
Replace npm install with npm ci

### DIFF
--- a/src/Moryx.ControlSystem.ProcessEngine.Web/Moryx.ControlSystem.ProcessEngine.Web.csproj
+++ b/src/Moryx.ControlSystem.ProcessEngine.Web/Moryx.ControlSystem.ProcessEngine.Web.csproj
@@ -2,7 +2,7 @@
 
   <Target Name="BuildUI" Condition="('$(Configuration)'!='Debug' Or !Exists('wwwroot\main.js')) And ('$(NoBuild)' != 'true') ">
     <Exec WorkingDirectory=".\" Command="npm config set strict-ssl false" />
-    <Exec WorkingDirectory=".\" Command="npm install --no-audit" />
+    <Exec WorkingDirectory=".\" Command="npm ci" />
     <Exec WorkingDirectory=".\" Command="npm run build:prod" />
     <Exec WorkingDirectory=".\" Command="npm config set strict-ssl true" />
   </Target>

--- a/src/Moryx.ControlSystem.WorkerSupport.Web/Moryx.ControlSystem.WorkerSupport.Web.csproj
+++ b/src/Moryx.ControlSystem.WorkerSupport.Web/Moryx.ControlSystem.WorkerSupport.Web.csproj
@@ -2,7 +2,7 @@
 
   <Target Name="BuildUI" Condition="('$(Configuration)'!='Debug' Or !Exists('wwwroot\main.js')) And ('$(NoBuild)' != 'true') ">
 	<Exec WorkingDirectory=".\" Command="npm config set strict-ssl false" />
-	<Exec WorkingDirectory=".\" Command="npm install --no-audit" />
+	<Exec WorkingDirectory=".\" Command="npm ci" />
 	<Exec WorkingDirectory=".\" Command="npm run build:prod" />
 	<Exec WorkingDirectory=".\" Command="npm config set strict-ssl true" />
   </Target>

--- a/src/Moryx.FactoryMonitor.Web/Moryx.FactoryMonitor.Web.csproj
+++ b/src/Moryx.FactoryMonitor.Web/Moryx.FactoryMonitor.Web.csproj
@@ -33,7 +33,7 @@
   </ItemGroup>
   <Target Name="BuildUI" Condition="('$(Configuration)'!='Debug' Or !Exists('wwwroot\main.js')) And ('$(NoBuild)' != 'true') ">
     <Exec WorkingDirectory=".\" Command="npm config set strict-ssl false" />
-    <Exec WorkingDirectory=".\" Command="npm install" />
+    <Exec WorkingDirectory=".\" Command="npm ci" />
     <Exec WorkingDirectory=".\" Command="npm run build:prod" />
     <Exec WorkingDirectory=".\" Command="npm config set strict-ssl true" />
   </Target>

--- a/src/Moryx.Launcher/Moryx.Launcher.csproj
+++ b/src/Moryx.Launcher/Moryx.Launcher.csproj
@@ -53,7 +53,7 @@
 
   <Target Name="BuildUI" Condition="('$(Configuration)'!='Debug' Or !Exists('wwwroot\js\dist\main.js')) And ('$(NoBuild)' != 'true') ">
     <Exec WorkingDirectory="./" Command="npm config set strict-ssl false"/>
-    <Exec WorkingDirectory="./" Command="npm install --no-audit"/>
+    <Exec WorkingDirectory="./" Command="npm ci"/>
     <Exec WorkingDirectory="./" Command="npm run build:css"/>
     <Exec WorkingDirectory="./" Command="npm run build:prod"/>
     <Exec WorkingDirectory="./" Command="npm run copy:componentsfiles"/>

--- a/src/Moryx.Media.Web/Moryx.Media.Web.csproj
+++ b/src/Moryx.Media.Web/Moryx.Media.Web.csproj
@@ -35,7 +35,7 @@
   </ItemGroup>
   <Target Name="BuildUI" Condition="('$(Configuration)'!='Debug' Or !Exists('wwwroot\main.js')) And ('$(NoBuild)' != 'true')">
     <Exec WorkingDirectory=".\" Command="npm config set strict-ssl false" />
-    <Exec WorkingDirectory=".\" Command="npm install" />
+    <Exec WorkingDirectory=".\" Command="npm ci" />
     <Exec WorkingDirectory=".\" Command="npm run build:prod" />
     <Exec WorkingDirectory=".\" Command="npm config set strict-ssl true" />
   </Target>

--- a/src/Moryx.Notifications.Web/Moryx.Notifications.Web.csproj
+++ b/src/Moryx.Notifications.Web/Moryx.Notifications.Web.csproj
@@ -2,7 +2,7 @@
 
   <Target Name="BuildUI" Condition="('$(Configuration)'!='Debug' Or !Exists('wwwroot\main.js')) And ('$(NoBuild)' != 'true') ">
 	<Exec WorkingDirectory=".\" Command="npm config set strict-ssl false" />
-	<Exec WorkingDirectory=".\" Command="npm install --no-audit" />
+	<Exec WorkingDirectory=".\" Command="npm ci" />
 	<Exec WorkingDirectory=".\" Command="npm run build:prod" />
 	<Exec WorkingDirectory=".\" Command="npm config set strict-ssl true" />
   </Target>

--- a/src/Moryx.Operators.Web/Moryx.Operators.Web.csproj
+++ b/src/Moryx.Operators.Web/Moryx.Operators.Web.csproj
@@ -36,7 +36,7 @@
   
   <Target Name="BuildUI" Condition="('$(Configuration)'!='Debug' Or !Exists('wwwroot\main.js')) And ('$(NoBuild)' != 'true') ">
     <Exec WorkingDirectory=".\" Command="npm config set strict-ssl false" />
-    <Exec WorkingDirectory=".\" Command="npm install" />
+    <Exec WorkingDirectory=".\" Command="npm ci" />
     <Exec WorkingDirectory=".\" Command="npm run build:prod" />
     <Exec WorkingDirectory=".\" Command="npm config set strict-ssl true" />
   </Target>

--- a/src/Moryx.Orders.Web/Moryx.Orders.Web.csproj
+++ b/src/Moryx.Orders.Web/Moryx.Orders.Web.csproj
@@ -2,7 +2,7 @@
 
   <Target Name="BuildUI" Condition="('$(Configuration)'!='Debug' Or !Exists('wwwroot\main.js')) And ('$(NoBuild)' != 'true') ">
 	<Exec WorkingDirectory=".\" Command="npm config set strict-ssl false" />
-	<Exec WorkingDirectory=".\" Command="npm install --no-audit" />
+	<Exec WorkingDirectory=".\" Command="npm ci" />
 	<Exec WorkingDirectory=".\" Command="npm run build:prod" />
 	<Exec WorkingDirectory=".\" Command="npm config set strict-ssl true" />
   </Target>

--- a/src/Moryx.Products.Web/Moryx.Products.Web.csproj
+++ b/src/Moryx.Products.Web/Moryx.Products.Web.csproj
@@ -33,7 +33,7 @@
   </ItemGroup>
   <Target Name="BuildUI" Condition="('$(Configuration)'!='Debug' Or !Exists('wwwroot\main.js')) And ('$(NoBuild)' != 'true') ">
     <Exec WorkingDirectory=".\" Command="npm config set strict-ssl false" />
-    <Exec WorkingDirectory=".\" Command="npm install" />
+    <Exec WorkingDirectory=".\" Command="npm ci" />
     <Exec WorkingDirectory=".\" Command="npm run build:prod" />
     <Exec WorkingDirectory=".\" Command="npm config set strict-ssl true" />
   </Target>

--- a/src/Moryx.Resources.Web/Moryx.Resources.Web.csproj
+++ b/src/Moryx.Resources.Web/Moryx.Resources.Web.csproj
@@ -35,7 +35,7 @@
   </ItemGroup>
   <Target Name="BuildUI" Condition="('$(Configuration)'!='Debug' Or !Exists('wwwroot\main.js')) And ('$(NoBuild)' != 'true') ">
     <Exec WorkingDirectory=".\" Command="npm config set strict-ssl false" />
-    <Exec WorkingDirectory=".\" Command="npm install" />
+    <Exec WorkingDirectory=".\" Command="npm ci" />
     <Exec WorkingDirectory=".\" Command="npm run build:prod" />
     <Exec WorkingDirectory=".\" Command="npm config set strict-ssl true" />
   </Target>

--- a/src/Moryx.Shifts.Web/Moryx.Shifts.Web.csproj
+++ b/src/Moryx.Shifts.Web/Moryx.Shifts.Web.csproj
@@ -43,7 +43,7 @@
 
   <Target Name="BuildUI" Condition="('$(Configuration)'!='Debug' Or !Exists('wwwroot\main.js')) And ('$(NoBuild)' != 'true') ">
     <Exec WorkingDirectory="./" Command="npm config set strict-ssl false"/>
-    <Exec WorkingDirectory="./" Command="npm install"/>
+    <Exec WorkingDirectory="./" Command="npm ci"/>
     <Exec WorkingDirectory="./" Command="npm run build:prod"/>
     <Exec WorkingDirectory="./" Command="npm config set strict-ssl true"/>
   </Target>

--- a/src/Moryx.Workplans.Web/Moryx.Workplans.Web.csproj
+++ b/src/Moryx.Workplans.Web/Moryx.Workplans.Web.csproj
@@ -36,7 +36,7 @@
   </ItemGroup>
   <Target Name="BuildUI" Condition="('$(Configuration)'!='Debug' Or !Exists('wwwroot\main.js')) And ('$(NoBuild)' != 'true') ">
     <Exec WorkingDirectory=".\" Command="npm config set strict-ssl false" />
-    <Exec WorkingDirectory=".\" Command="npm install" />
+    <Exec WorkingDirectory=".\" Command="npm ci" />
     <Exec WorkingDirectory=".\" Command="npm run build:prod" />
     <Exec WorkingDirectory=".\" Command="npm config set strict-ssl true" />
   </Target>


### PR DESCRIPTION
This change updates all MSBuild targets that previously used `npm install` to use `npm ci` instead.

Reason for change:
- Improves build performance in CI environments.
- Ensures strict compliance with `package-lock.json` for reproducible builds.
- Removes unnecessary audit checks (npm ci does not run audits).