### PR TITLE
Renamed the package Moryx.Asp.Extensions to Moryx.AspNetCore

### DIFF
--- a/MORYX-Framework.sln
+++ b/MORYX-Framework.sln
@@ -82,7 +82,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "CommandCenter", "CommandCen
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Moryx.CommandCenter.Web", "src\Moryx.CommandCenter.Web\Moryx.CommandCenter.Web.csproj", "{BD8D5AB2-0C9E-4C61-B158-FF132890DB3C}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Moryx.Asp.Extensions", "src\Moryx.Asp.Extensions\Moryx.Asp.Extensions.csproj", "{0FB22EF0-3C6F-4235-A50E-3A976AC261D3}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Moryx.AspNetCore", "src\Moryx.AspNetCore\Moryx.AspNetCore.csproj", "{0FB22EF0-3C6F-4235-A50E-3A976AC261D3}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Moryx.AbstractionLayer", "src\Moryx.AbstractionLayer\Moryx.AbstractionLayer.csproj", "{B1ABAAF9-811D-41C8-8C1F-37AEF687BDF1}"
 EndProject

--- a/docs/migrations/v8_to_v10.md
+++ b/docs/migrations/v8_to_v10.md
@@ -118,3 +118,7 @@ The API of `IResourceInitializer` was adjusted
 ## ConstraintContext during activity-handling
 
 The `IConstraintContext` interface was removed from `IProcess`. Instead a new wrapper was introduced `ActivityConstraintContext` which provides the Activity and the Process for better handling in `IConstraint` implementations.
+
+## Renamed Moryx.Asp.Extensions to Moryx.AspNetCore
+
+Renamed the package Moryx.Asp.Extensions to Moryx.AspNetCore and moved the classes to the respective namespace. This change was applied to match the Microsoft namespaces. In the past the project was used in MORYX <6 for C#-extensions on ASP.NET Components to initialize the Runtime environment and register endpoints inside the ServerModules. Since we use controllers based on the facades, these stuff was already removed.

--- a/src/Moryx.AbstractionLayer.Products.Endpoints/Moryx.AbstractionLayer.Products.Endpoints.csproj
+++ b/src/Moryx.AbstractionLayer.Products.Endpoints/Moryx.AbstractionLayer.Products.Endpoints.csproj
@@ -13,7 +13,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Moryx.AbstractionLayer\Moryx.AbstractionLayer.csproj" />
-	<ProjectReference Include="..\Moryx.Asp.Extensions\Moryx.Asp.Extensions.csproj" />
+	<ProjectReference Include="..\Moryx.AspNetCore\Moryx.AspNetCore.csproj" />
 	<ProjectReference Include="..\Moryx.Runtime\Moryx.Runtime.csproj" />
   </ItemGroup>
 

--- a/src/Moryx.AbstractionLayer.Products.Endpoints/ProductManagementController.cs
+++ b/src/Moryx.AbstractionLayer.Products.Endpoints/ProductManagementController.cs
@@ -9,8 +9,8 @@ using Moryx.Serialization;
 using System.Net;
 using Microsoft.AspNetCore.Authorization;
 using Moryx.AbstractionLayer.Products.Endpoints.Properties;
+using Moryx.AspNetCore;
 using Moryx.Configuration;
-using Moryx.Asp.Extensions;
 using Moryx.Runtime.Modules;
 
 namespace Moryx.AbstractionLayer.Products.Endpoints

--- a/src/Moryx.AbstractionLayer.Products.Endpoints/WorkplanController.cs
+++ b/src/Moryx.AbstractionLayer.Products.Endpoints/WorkplanController.cs
@@ -5,7 +5,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Moryx.AbstractionLayer.Products.Endpoints.Properties;
-using Moryx.Asp.Extensions;
+using Moryx.AspNetCore;
 using Moryx.Workplans;
 
 namespace Moryx.AbstractionLayer.Products.Endpoints

--- a/src/Moryx.AbstractionLayer.Resources.Endpoints/Moryx.AbstractionLayer.Resources.Endpoints.csproj
+++ b/src/Moryx.AbstractionLayer.Resources.Endpoints/Moryx.AbstractionLayer.Resources.Endpoints.csproj
@@ -14,7 +14,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Moryx.AbstractionLayer\Moryx.AbstractionLayer.csproj" />
-	<ProjectReference Include="..\Moryx.Asp.Extensions\Moryx.Asp.Extensions.csproj" />
+	<ProjectReference Include="..\Moryx.AspNetCore\Moryx.AspNetCore.csproj" />
 	<ProjectReference Include="..\Moryx.Runtime\Moryx.Runtime.csproj" />
   </ItemGroup>
 

--- a/src/Moryx.AbstractionLayer.Resources.Endpoints/ResourceManagementController.cs
+++ b/src/Moryx.AbstractionLayer.Resources.Endpoints/ResourceManagementController.cs
@@ -7,7 +7,6 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
-using Moryx.Asp.Extensions;
 using Moryx.Serialization;
 using Moryx.Tools;
 using Moryx.Runtime.Modules;
@@ -15,6 +14,7 @@ using Moryx.Configuration;
 using System.Runtime.Serialization;
 using System.ComponentModel.DataAnnotations;
 using Moryx.AbstractionLayer.Resources.Endpoints.Properties;
+using Moryx.AspNetCore;
 
 namespace Moryx.AbstractionLayer.Resources.Endpoints
 {

--- a/src/Moryx.AspNetCore/Moryx.AspNetCore.csproj
+++ b/src/Moryx.AspNetCore/Moryx.AspNetCore.csproj
@@ -3,9 +3,10 @@
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Description>Extensions for the Integration of MORYX in ASP.NET Core</Description>
+    <Description>Extensions for the integration of MORYX in ASP.NET Core</Description>
     <PackageTags>MORYX;ASP</PackageTags>
     <IsPackable>true</IsPackable>
+    <RootNamespace>Moryx.AspNetCore</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Moryx.AspNetCore/MoryxExceptionFilter.cs
+++ b/src/Moryx.AspNetCore/MoryxExceptionFilter.cs
@@ -5,7 +5,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
 
-namespace Moryx.Asp.Extensions
+namespace Moryx.AspNetCore
 {
     public class MoryxExceptionFilter : IExceptionFilter
     {

--- a/src/Moryx.AspNetCore/MoryxExceptionResponse.cs
+++ b/src/Moryx.AspNetCore/MoryxExceptionResponse.cs
@@ -1,7 +1,7 @@
 // Copyright (c) 2025, Phoenix Contact GmbH & Co. KG
 // Licensed under the Apache License, Version 2.0
 
-namespace Moryx.Asp.Extensions
+namespace Moryx.AspNetCore
 {
     public class MoryxExceptionResponse
     {

--- a/src/Moryx.ControlSystem.Jobs.Endpoints/JobManagementController.cs
+++ b/src/Moryx.ControlSystem.Jobs.Endpoints/JobManagementController.cs
@@ -4,10 +4,10 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Moryx.Asp.Extensions;
 using Moryx.ControlSystem.Jobs.Endpoints.Properties;
 using Newtonsoft.Json;
 using System.Threading.Channels;
+using Moryx.AspNetCore;
 using Newtonsoft.Json.Serialization;
 
 namespace Moryx.ControlSystem.Jobs.Endpoints

--- a/src/Moryx.ControlSystem.Jobs.Endpoints/Moryx.ControlSystem.Jobs.Endpoints.csproj
+++ b/src/Moryx.ControlSystem.Jobs.Endpoints/Moryx.ControlSystem.Jobs.Endpoints.csproj
@@ -12,7 +12,7 @@
 
 	<ItemGroup>
 	  <ProjectReference Include="..\Moryx.AbstractionLayer\Moryx.AbstractionLayer.csproj" />
-	  <ProjectReference Include="..\Moryx.Asp.Extensions\Moryx.Asp.Extensions.csproj" />
+	  <ProjectReference Include="..\Moryx.AspNetCore\Moryx.AspNetCore.csproj" />
 	  <ProjectReference Include="..\Moryx.ControlSystem\Moryx.ControlSystem.csproj" />
 	</ItemGroup>
 

--- a/src/Moryx.ControlSystem.Processes.Endpoints/Moryx.ControlSystem.Processes.Endpoints.csproj
+++ b/src/Moryx.ControlSystem.Processes.Endpoints/Moryx.ControlSystem.Processes.Endpoints.csproj
@@ -8,7 +8,7 @@
 
 	<ItemGroup>
 	  <ProjectReference Include="..\Moryx.AbstractionLayer\Moryx.AbstractionLayer.csproj" />
-	  <ProjectReference Include="..\Moryx.Asp.Extensions\Moryx.Asp.Extensions.csproj" />
+	  <ProjectReference Include="..\Moryx.AspNetCore\Moryx.AspNetCore.csproj" />
 	  <ProjectReference Include="..\Moryx.ControlSystem\Moryx.ControlSystem.csproj" />
 	  <ProjectReference Include="..\Moryx.Factory\Moryx.Factory.csproj" />
 	</ItemGroup>

--- a/src/Moryx.ControlSystem.Processes.Endpoints/ProcessEngineController.cs
+++ b/src/Moryx.ControlSystem.Processes.Endpoints/ProcessEngineController.cs
@@ -8,7 +8,7 @@ using Microsoft.AspNetCore.Mvc;
 using Moryx.AbstractionLayer.Processes;
 using Moryx.AbstractionLayer.Products;
 using Moryx.AbstractionLayer.Resources;
-using Moryx.Asp.Extensions;
+using Moryx.AspNetCore;
 using Moryx.ControlSystem.Jobs;
 using Moryx.ControlSystem.Processes.Endpoints.Extensions;
 using Moryx.ControlSystem.Processes.Endpoints.Models;

--- a/src/Moryx.FactoryMonitor.Endpoints/FactoryMonitorController.cs
+++ b/src/Moryx.FactoryMonitor.Endpoints/FactoryMonitorController.cs
@@ -10,13 +10,13 @@ using Moryx.ControlSystem.Processes;
 using Moryx.Factory;
 using Moryx.ControlSystem.Cells;
 using System.Threading.Channels;
-using Moryx.Asp.Extensions;
 using Microsoft.Extensions.Logging;
 using Moryx.Orders;
 using Moryx.AbstractionLayer.Capabilities;
 using System.Timers;
 using Moryx.FactoryMonitor.Endpoints.Models;
 using Moryx.AbstractionLayer.Processes;
+using Moryx.AspNetCore;
 using Moryx.FactoryMonitor.Endpoints.Properties;
 //old models in '.Model' namespace. Only ones still in use: TransoirtRoute- / PathModel & CellSettingsModel
 using Moryx.FactoryMonitor.Endpoints.Model;

--- a/src/Moryx.Media.Endpoints/MediaServerController.cs
+++ b/src/Moryx.Media.Endpoints/MediaServerController.cs
@@ -4,10 +4,10 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Moryx.Asp.Extensions;
 using Moryx.Media.Endpoints.Model;
 using Moryx.Media.Endpoints.Properties;
 using System.Net;
+using Moryx.AspNetCore;
 
 namespace Moryx.Media.Endpoints
 {

--- a/src/Moryx.Media.Endpoints/Moryx.Media.Endpoints.csproj
+++ b/src/Moryx.Media.Endpoints/Moryx.Media.Endpoints.csproj
@@ -7,7 +7,7 @@
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\Moryx.Asp.Extensions\Moryx.Asp.Extensions.csproj" />
+    <ProjectReference Include="..\Moryx.AspNetCore\Moryx.AspNetCore.csproj" />
     <ProjectReference Include="..\Moryx.Media\Moryx.Media.csproj" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Moryx.Notifications.Endpoints/Moryx.Notifications.Endpoints.csproj
+++ b/src/Moryx.Notifications.Endpoints/Moryx.Notifications.Endpoints.csproj
@@ -6,7 +6,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-	  <ProjectReference Include="..\Moryx.Asp.Extensions\Moryx.Asp.Extensions.csproj" />
+	  <ProjectReference Include="..\Moryx.AspNetCore\Moryx.AspNetCore.csproj" />
 	  <ProjectReference Include="..\Moryx.Notifications\Moryx.Notifications.csproj" />
 	</ItemGroup>
 

--- a/src/Moryx.Notifications.Endpoints/NotificationPublisherController.cs
+++ b/src/Moryx.Notifications.Endpoints/NotificationPublisherController.cs
@@ -4,7 +4,7 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Moryx.Asp.Extensions;
+using Moryx.AspNetCore;
 using Moryx.Notifications.Endpoints.Properties;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;

--- a/src/Moryx.Orders.Endpoints/Moryx.Orders.Endpoints.csproj
+++ b/src/Moryx.Orders.Endpoints/Moryx.Orders.Endpoints.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Moryx.Asp.Extensions\Moryx.Asp.Extensions.csproj" />
+    <ProjectReference Include="..\Moryx.AspNetCore\Moryx.AspNetCore.csproj" />
     <ProjectReference Include="..\Moryx.Orders\Moryx.Orders.csproj" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Moryx.Orders.Endpoints/OrderManagementController.cs
+++ b/src/Moryx.Orders.Endpoints/OrderManagementController.cs
@@ -5,13 +5,13 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Moryx.AbstractionLayer.Products;
-using Moryx.Asp.Extensions;
 using Moryx.Orders.Endpoints.Properties;
 using Moryx.Users;
 using Newtonsoft.Json.Serialization;
 using Newtonsoft.Json;
 using System.Net;
 using System.Threading.Channels;
+using Moryx.AspNetCore;
 using Moryx.Orders.Endpoints.Models;
 
 namespace Moryx.Orders.Endpoints

--- a/src/Moryx.Workplans.Web/Moryx.Workplans.Web.csproj
+++ b/src/Moryx.Workplans.Web/Moryx.Workplans.Web.csproj
@@ -18,7 +18,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Moryx.AbstractionLayer.Products.Endpoints\Moryx.AbstractionLayer.Products.Endpoints.csproj" />
-    <ProjectReference Include="..\Moryx.Asp.Extensions\Moryx.Asp.Extensions.csproj" />
+    <ProjectReference Include="..\Moryx.AspNetCore\Moryx.AspNetCore.csproj" />
     <ProjectReference Include="..\Moryx.Workplans\Moryx.Workplans.csproj" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Moryx.Workplans.Web/WorkplanEditingController.cs
+++ b/src/Moryx.Workplans.Web/WorkplanEditingController.cs
@@ -5,7 +5,7 @@ using System.Drawing;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Moryx.AbstractionLayer.Products.Endpoints;
-using Moryx.Asp.Extensions;
+using Moryx.AspNetCore;
 using Moryx.Serialization;
 using Moryx.Workplans.Web.Properties;
 

--- a/src/StartProject.Asp/StartProject.Asp.csproj
+++ b/src/StartProject.Asp/StartProject.Asp.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Moryx.Asp.Extensions\Moryx.Asp.Extensions.csproj" />
+    <ProjectReference Include="..\Moryx.AspNetCore\Moryx.AspNetCore.csproj" />
     <ProjectReference Include="..\Moryx.CommandCenter.Web\Moryx.CommandCenter.Web.csproj" />
     <ProjectReference Include="..\Moryx.ControlSystem.Jobs.Endpoints\Moryx.ControlSystem.Jobs.Endpoints.csproj" />
     <ProjectReference Include="..\Moryx.ControlSystem.MaterialManager\Moryx.ControlSystem.MaterialManager.csproj" />

--- a/src/Tests/Moryx.FactoryMonitor.Endpoints.Tests/FactoryMonitorController_CellOperationsTest.cs
+++ b/src/Tests/Moryx.FactoryMonitor.Endpoints.Tests/FactoryMonitorController_CellOperationsTest.cs
@@ -4,12 +4,12 @@
 using Microsoft.AspNetCore.Mvc;
 using Moq;
 using Moryx.AbstractionLayer.Resources;
-using Moryx.Asp.Extensions;
 using Moryx.Factory;
 using Moryx.FactoryMonitor.Endpoints.Model;
 using NUnit.Framework;
 using System;
 using System.Linq;
+using Moryx.AspNetCore;
 
 namespace Moryx.FactoryMonitor.Endpoints.Tests
 {


### PR DESCRIPTION
Renamed the package Moryx.Asp.Extensions to Moryx.AspNetCore and moved the classes to the respective namespace. This change was applied to match the Microsoft namespaces. In the past the project was used in MORYX <6 for C#-extensions on ASP.NET Components to initialize the Runtime environment and register endpoints inside the ServerModules. Since we use controllers based on the facades, these stuff was already removed.