### PR TITLE
Support async Methods in EntryConvert

### DIFF
--- a/docs/migrations/v8_to_v10.md
+++ b/docs/migrations/v8_to_v10.md
@@ -170,3 +170,8 @@ Features:
 * Support unsubscribing from Topics, by removing or changing the resource
 * Support changing the broker without restarting the Resource Management, by a) providing a Reconnect method and b) handling changes to the relevant properties
 * Support diagnostic tracing of message contents, before and after deserialization
+
+## EntryConvert
+
+- Supports async invocation of methods now by `InvokeMethodAsync`. Synchronous methods are executed synchronously.
+- The synchronous `InvokeMethod` does now support async methods too. They are executed synchronously.

--- a/src/Moryx.Runtime.Endpoints/Modules/Endpoint/ModulesController.cs
+++ b/src/Moryx.Runtime.Endpoints/Modules/Endpoint/ModulesController.cs
@@ -235,7 +235,7 @@ namespace Moryx.Runtime.Endpoints.Modules.Endpoint
 
         [HttpPost("{moduleName}/console")]
         [Authorize(Policy = RuntimePermissions.ModulesCanInvoke)]
-        public ActionResult<Entry> InvokeMethod([FromRoute] string moduleName, [FromBody] MethodEntry method)
+        public async Task<ActionResult<Entry>> InvokeMethod([FromRoute] string moduleName, [FromBody] MethodEntry method)
         {
             ArgumentNullException.ThrowIfNull(method);
 
@@ -245,8 +245,20 @@ namespace Moryx.Runtime.Endpoints.Modules.Endpoint
 
             try
             {
-                return EntryConvert.InvokeMethod(serverModule.Console, method,
-                    CreateEditorSerializeSerialization(serverModule));
+                if (method.IsAsync)
+                {
+                    return await EntryConvert.InvokeMethodAsync(serverModule.Console, method,
+                        CreateEditorSerializeSerialization(serverModule));
+                }
+                else
+                {
+                    // ReSharper disable once MethodHasAsyncOverload
+                    EntryConvert.InvokeMethod(serverModule.Console, method,
+                        CreateEditorSerializeSerialization(serverModule));
+
+                    return null;
+                }
+
             }
             catch (Exception e)
             {

--- a/src/Moryx.TestModule/ModuleController/ModuleConsole.cs
+++ b/src/Moryx.TestModule/ModuleController/ModuleConsole.cs
@@ -97,5 +97,11 @@ namespace Moryx.TestModule
             var jsonTest = Container.Resolve<JsonTest>();
             jsonTest.Start();
         }
+
+        [EntrySerialize, Description("Executes the async method")]
+        public Task<string> AsyncTest()
+        {
+            return Task.FromResult("Test");
+        }
     }
 }

--- a/src/Moryx/Serialization/EntryConvert/MethodEntry.cs
+++ b/src/Moryx/Serialization/EntryConvert/MethodEntry.cs
@@ -40,6 +40,12 @@ namespace Moryx.Serialization
         [DataMember]
         public Entry Parameters { get; set; }
 
+        /// <summary>
+        /// True if the method is awaitable by <see cref="Task"/>
+        /// </summary>
+        [DataMember]
+        public bool IsAsync { get; set; }
+
         /// <see cref="ICloneable"/>
         public object Clone()
         {
@@ -56,7 +62,8 @@ namespace Moryx.Serialization
             {
                 Name = Name,
                 DisplayName = DisplayName,
-                Description = Description
+                Description = Description,
+                IsAsync =  IsAsync
             };
 
             if (deep)

--- a/src/Tests/Moryx.Tests/Serialization/EntrySerializeDummies.cs
+++ b/src/Tests/Moryx.Tests/Serialization/EntrySerializeDummies.cs
@@ -1,6 +1,7 @@
 // Copyright (c) 2025, Phoenix Contact GmbH & Co. KG
 // Licensed under the Apache License, Version 2.0
 
+using System.Threading.Tasks;
 using Moryx.Serialization;
 
 namespace Moryx.Tests
@@ -129,18 +130,45 @@ namespace Moryx.Tests
     public class EntrySerialize_Methods : EntrySerialize_InheritedBase
     {
         [EntrySerialize]
-        public void InvocablePublic() { }
+        public void InvocablePublic()
+        {
+
+        }
 
         [EntrySerialize]
-        public void InvocablePublic(int intValue, string stringValue1, string stringValue2 = "testing value") { }
+        public void InvocablePublic(int intValue, string stringValue1, string stringValue2 = "testing value")
+        {
+
+        }
 
         [EntrySerialize]
-        internal void InvocableInternal() { }
+        internal void InvocableInternal()
+        {
+
+        }
 
         [EntrySerialize]
-        protected void NonInvocableProtected() { }
+        protected void NonInvocableProtected()
+        {
+
+        }
 
         [EntrySerialize]
-        private void NonInvocablePrivate() { }
+        private void NonInvocablePrivate()
+        {
+
+        }
+
+        [EntrySerialize]
+        public Task AsyncWithoutResult()
+        {
+            return Task.CompletedTask;
+        }
+
+        [EntrySerialize]
+        public Task<string> AsyncWithStringResult()
+        {
+            return Task.FromResult("Test");
+        }
     }
 }


### PR DESCRIPTION
- Supports async invocation of methods now by `InvokeMethodAsync`. Synchronous methods are executed synchronously.
- The synchronous `InvokeMethod` does now support async methods too. They are executed synchronously.

After merge of #833 we can think about removing synchronous API, it is mostly used in async context (controllers).