### PR TITLE
Changed ProductManagement to use IIdentity

### DIFF
--- a/docs/migrations/v8_to_v10.md
+++ b/docs/migrations/v8_to_v10.md
@@ -258,6 +258,14 @@ The API of `IResourceInitializer` was adjusted
 
 - Removed `productId` from `SaveRecipes` of `IProductStorage` and changed argument to `IReadOnlyList`
 
+**`IProductManagement`**
+
+- APIs (LoadType, Duplicate) are using `IIdentity` instead of `ProductIdentity` but in MORYX 10.0, only `ProductIdentity` is supported.
+
+**`IProductStorage`**
+
+- API `LoadType` is using `IIdentity` instead of `ProductIdentity` but in MORYX 10.0, only `ProductIdentity` is supported.
+
 ### Product importer
 
 - Introduced `ProductImporterAttribute` for harmonized registration of importers.

--- a/src/Moryx.AbstractionLayer/Products/IProductManagement.cs
+++ b/src/Moryx.AbstractionLayer/Products/IProductManagement.cs
@@ -28,7 +28,7 @@ namespace Moryx.AbstractionLayer.Products
         /// Load product type by identity
         /// </summary>
         /// <exception cref="ProductNotFoundException">Thrown when the product with the given id doesn't exist.</exception>
-        ProductType LoadType(ProductIdentity identity);
+        ProductType LoadType(IIdentity identity);
 
         /// <summary>
         /// Event raised when a product type changed
@@ -39,7 +39,7 @@ namespace Moryx.AbstractionLayer.Products
         /// Duplicate a product under a new identity
         /// </summary>
         /// <exception cref="IdentityConflictException">Thrown when the new identity causes conflicts</exception>
-        ProductType Duplicate(ProductType template, ProductIdentity newIdentity);
+        ProductType Duplicate(ProductType template, IIdentity newIdentity);
 
         /// <summary>
         /// Save a product type

--- a/src/Moryx.Products.Management/Components/IProductManager.cs
+++ b/src/Moryx.Products.Management/Components/IProductManager.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0
 
 using System.Linq.Expressions;
+using Moryx.AbstractionLayer.Identity;
 using Moryx.AbstractionLayer.Products;
 using Moryx.Modules;
 
@@ -35,7 +36,7 @@ namespace Moryx.Products.Management
         /// <summary>
         /// Load product by identity
         /// </summary>
-        ProductType LoadType(ProductIdentity identity);
+        ProductType LoadType(IIdentity identity);
 
         /// <summary>
         /// Create a new product for the given group type
@@ -55,7 +56,7 @@ namespace Moryx.Products.Management
         /// <summary>
         /// Create revision of this product with provided revision number
         /// </summary>
-        ProductType Duplicate(ProductType source, ProductIdentity identity);
+        ProductType Duplicate(ProductType source, IIdentity identity);
 
         /// <summary>
         /// Import the given file as a product to the database

--- a/src/Moryx.Products.Management/Components/IProductStorage.cs
+++ b/src/Moryx.Products.Management/Components/IProductStorage.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0
 
 using System.Linq.Expressions;
+using Moryx.AbstractionLayer.Identity;
 using Moryx.AbstractionLayer.Products;
 using Moryx.AbstractionLayer.Recipes;
 using Moryx.Modules;
@@ -26,7 +27,7 @@ namespace Moryx.Products.Management
         /// <summary>
         /// Load product by identity. This method supports loading a products latest revision
         /// </summary>
-        ProductType LoadType(ProductIdentity identity);
+        ProductType LoadType(IIdentity identity);
 
         /// <summary>
         /// Save a type to the storage

--- a/src/Moryx.Products.Management/Facades/ProductManagementFacade.cs
+++ b/src/Moryx.Products.Management/Facades/ProductManagementFacade.cs
@@ -94,7 +94,7 @@ namespace Moryx.Products.Management
             return type;
         }
 
-        public ProductType LoadType(ProductIdentity identity)
+        public ProductType LoadType(IIdentity identity)
         {
             ValidateHealthState();
             return ProductManager.LoadType(identity);
@@ -106,7 +106,7 @@ namespace Moryx.Products.Management
         }
         public event EventHandler<ProductType> TypeChanged;
 
-        public ProductType Duplicate(ProductType template, ProductIdentity newIdentity)
+        public ProductType Duplicate(ProductType template, IIdentity newIdentity)
         {
             ValidateHealthState();
             return ProductManager.Duplicate(template, newIdentity);

--- a/src/Moryx.Products.Management/Implementation/ProductManager.cs
+++ b/src/Moryx.Products.Management/Implementation/ProductManager.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Concurrent;
 using System.Linq.Expressions;
+using Moryx.AbstractionLayer.Identity;
 using Moryx.AbstractionLayer.Products;
 using Moryx.AbstractionLayer.Recipes;
 using Moryx.Container;
@@ -62,7 +63,7 @@ namespace Moryx.Products.Management
             return Storage.LoadType(id);
         }
 
-        public ProductType LoadType(ProductIdentity identity)
+        public ProductType LoadType(IIdentity identity)
         {
             return Storage.LoadType(identity);
         }
@@ -85,12 +86,17 @@ namespace Moryx.Products.Management
             return wrapper.Constructor();
         }
 
-        public ProductType Duplicate(ProductType template, ProductIdentity newIdentity)
+        public ProductType Duplicate(ProductType template, IIdentity newIdentity)
         {
+            if (newIdentity is not ProductIdentity newProductIdentity)
+            {
+                throw new NotSupportedException($"Identity of type {newIdentity.GetType()} is not supported. Only {nameof(ProductIdentity)} is supported.");
+            }
+
             // Fetch existing products for identity validation
             var existing = LoadTypes(new ProductQuery { Identifier = newIdentity.Identifier });
             // Check if the same revision already exists
-            if (existing.Any(e => ((ProductIdentity)e.Identity).Revision == newIdentity.Revision))
+            if (existing.Any(e => ((ProductIdentity)e.Identity).Revision == newProductIdentity.Revision))
                 throw new IdentityConflictException();
             // If there are any products for this identifier, the source object must be one of them
             if (existing.Any() && template.Identity.Identifier != newIdentity.Identifier)

--- a/src/Moryx.Products.Management/Implementation/Storage/ProductStorage.cs
+++ b/src/Moryx.Products.Management/Implementation/Storage/ProductStorage.cs
@@ -16,6 +16,7 @@ using static Moryx.Products.Management.ProductExpressionHelpers;
 using Moryx.Logging;
 using Moryx.Products.Management.Implementation.Storage;
 using Microsoft.Extensions.Logging;
+using Moryx.AbstractionLayer.Identity;
 using Moryx.Products.Management.Model;
 
 namespace Moryx.Products.Management
@@ -436,12 +437,17 @@ namespace Moryx.Products.Management
         }
 
         /// <inheritdoc />
-        public ProductType LoadType(ProductIdentity identity)
+        public ProductType LoadType(IIdentity identity)
         {
+            if (identity is not ProductIdentity productIdentity)
+            {
+                throw new NotSupportedException($"Identity of type {identity.GetType()} is not supported. Only {nameof(ProductIdentity)} is supported.");
+            }
+
             using var uow = Factory.Create();
             var productRepo = uow.GetRepository<IProductTypeRepository>();
 
-            var revision = identity.Revision;
+            var revision = productIdentity.Revision;
             // If the latest revision was requested, replace it with the highest current revision
             if (revision == ProductIdentity.LatestRevision)
             {
@@ -544,7 +550,7 @@ namespace Moryx.Products.Management
         {
             using var uow = Factory.Create();
             var productSaverContext = new ProductPartsSaverContext(uow);
-            var entity = SaveProduct(productSaverContext, modifiedInstance);
+            var entity = SaveType(productSaverContext, modifiedInstance);
 
             uow.SaveChanges();
             modifiedInstance.Id = entity.Id;
@@ -556,23 +562,28 @@ namespace Moryx.Products.Management
             return entity.Id;
         }
 
-        private ProductTypeEntity SaveProduct(ProductPartsSaverContext saverContext, ProductType modifiedProductType)
+        private ProductTypeEntity SaveType(ProductPartsSaverContext saverContext, ProductType modifiedProductType)
         {
+            var identity = modifiedProductType.Identity;
+            if (identity is not ProductIdentity productIdentity)
+            {
+                throw new NotSupportedException($"Identity of type {identity.GetType()} is not supported. Only {nameof(ProductIdentity)} is supported.");
+            }
+
             var strategy = _typeInformation[modifiedProductType.ProductTypeName()].Strategy
                 ?? throw new InvalidOperationException($"Cannot save product of type {modifiedProductType.GetType().FullName}. No {nameof(IProductTypeStrategy)} is configured for this type in the {nameof(ModuleConfig)}");
 
             //TODO use uow directly instead of repo if that is possible
             // Get or create entity
             var repo = saverContext.GetRepository<IProductTypeRepository>();
-            var identity = (ProductIdentity)modifiedProductType.Identity;
             ProductTypeEntity typeEntity;
             var entities = repo.Linq
-                .Where(p => p.Identifier == identity.Identifier && p.Revision == identity.Revision)
+                .Where(p => p.Identifier == productIdentity.Identifier && p.Revision == productIdentity.Revision)
                 .ToList();
             // If entity does not exist or was deleted, create a new one
             if (entities.All(p => p.Deleted != null))
             {
-                typeEntity = repo.Create(identity.Identifier, identity.Revision, modifiedProductType.Name, modifiedProductType.ProductTypeName());
+                typeEntity = repo.Create(productIdentity.Identifier, productIdentity.Revision, modifiedProductType.Name, modifiedProductType.ProductTypeName());
                 saverContext.UnitOfWork.LinkEntityToBusinessObject(modifiedProductType, typeEntity);
             }
             else
@@ -674,7 +685,7 @@ namespace Moryx.Products.Management
             }
 
             if (link.Product.Id == 0)
-                return SaveProduct(saverContext, link.Product);
+                return SaveType(saverContext, link.Product);
 
             return saverContext.UnitOfWork.GetEntity<ProductTypeEntity>(link.Product);
         }


### PR DESCRIPTION
This prepares the API for #911 - using IIdentity in ProductManagement instead of ProductIdentity.

Hint: Only preparation of API, implementation must follow in 10.x

FYI @dacky179 