### PR TITLE
Fix conditional Import and ItemGroup in Directory.Build.props

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,4 @@
-<Project>
-  <Import Project=".build\Common.props" Condition="'$(IsPackable)' == 'true'" />
-  
+<Project>  
   <PropertyGroup>
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
@@ -17,10 +15,5 @@
 
 		<LangVersion>latest</LangVersion>
 	</PropertyGroup>
-
-	<!-- Package refereces for all projects if IsPackable=true -->
-	<ItemGroup Condition="'$(IsPackable)' == 'true'">
-		<PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
-	</ItemGroup>
 
 </Project>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,6 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
 
+  <Import Project=".build\Common.props" Condition="'$(IsPackable)' == 'true'" />
+
+  <!-- Package refereces for all projects if IsPackable=true -->
+  <ItemGroup Condition="'$(IsPackable)' == 'true'">
+    <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
+  </ItemGroup>
+  
 	<ItemGroup>
 		<!-- Asp.Net Core Framework dependency -->
 		<FrameworkReference Update="Microsoft.AspNetCore.App" Version="$(dotnetVersion)" />


### PR DESCRIPTION
In the MSBuild evaluation order the Directory.Build.props is being evaluated before the project sets <IsPackable>true</IsPackable>, so the condition is false at import time and Common.props never gets loaded or the package reference set.

