### PR TITLE
Fix conflicting job states after restart

### DIFF
--- a/src/Moryx.ControlSystem.ProcessEngine/Jobs/Implementation/JobManager.cs
+++ b/src/Moryx.ControlSystem.ProcessEngine/Jobs/Implementation/JobManager.cs
@@ -77,6 +77,11 @@ namespace Moryx.ControlSystem.ProcessEngine.Jobs
         public void Stop()
         {
             _running = false;
+            // wait until all events are processed 
+            while (_taskQueue.PendingElements > 0)
+            {
+                Thread.Sleep(1);
+            }
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
Problem:
The JobManager detaches the JobChanged event. That causes that the Stop execution proceeds and the Stop of Joblist overcomes the changed events.

Solution:
Yield for every job to stop before continuing. 

(cherry picked from commit 3e44339be332e5feb167e4d283dc283f695c9f9f)