### PR TITLE
Fix CommandCenter CollectionEditor

### DIFF
--- a/src/Moryx.CommandCenter.Web/src/modules/components/ConfigEditor/CollectionEditor.tsx
+++ b/src/Moryx.CommandCenter.Web/src/modules/components/ConfigEditor/CollectionEditor.tsx
@@ -34,7 +34,7 @@ export default class CollectionEditor extends CollapsibleEntryEditorBase<Collect
     constructor(props: CollapsibleEntryEditorBasePropModel) {
         super(props);
         this.state = {
-            SelectedEntry: props.Entry.value.possible[0].key,
+            SelectedEntry: props.Entry.value.possible[0]?.key,
             ExpandedEntryNames: [],
             CreatedPrototypesCount: 0
         };


### PR DESCRIPTION
The collection editor uses the first possible value as the default selected entry. If there was none, it crashed and resulted in an empty page.

