### PR TITLE
Fix unreliable unit tests

### DIFF
--- a/src/Tests/Moryx.Orders.Management.Tests/Integration/ProductionTests.cs
+++ b/src/Tests/Moryx.Orders.Management.Tests/Integration/ProductionTests.cs
@@ -47,7 +47,7 @@ namespace Moryx.Orders.Management.Tests
             _orderModel = new UnitOfWorkFactory<OrdersContext>(new InMemoryDbContextManager(Guid.NewGuid().ToString()));
 
             var logger = new ModuleLogger("Dummy", new NullLoggerFactory());
-            var parallelOperations = new ParallelOperations(new ModuleLogger("Dummy", new NullLoggerFactory()));
+            var parallelOperations = new ParallelOperations(logger);
 
             var userMock = new Mock<User>();
             userMock.SetupGet(u => u.Identifier).Returns("1234");
@@ -79,6 +79,7 @@ namespace Moryx.Orders.Management.Tests
                 JobManagement = jobManagement,
                 OperationDataPool = _operationDataPool,
                 ParallelOperations = parallelOperations,
+                Logger = logger,
                 Dispatcher = dispatcher
             };
 

--- a/src/Tests/Moryx.Orders.Management.Tests/OperationDispatcher/SingleJobOperationDispatcherTests.cs
+++ b/src/Tests/Moryx.Orders.Management.Tests/OperationDispatcher/SingleJobOperationDispatcherTests.cs
@@ -5,12 +5,14 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
 using Moryx.AbstractionLayer.Recipes;
 using Moryx.ControlSystem.Jobs;
 using Moryx.ControlSystem.TestTools;
-using Moq;
-using NUnit.Framework;
+using Moryx.Logging;
 using Moryx.TestTools.UnitTest;
+using NUnit.Framework;
 
 namespace Moryx.Orders.Management.Tests
 {
@@ -56,6 +58,7 @@ namespace Moryx.Orders.Management.Tests
                 JobManagement = _jobManagementMock.Object,
                 OperationDataPool = _operationPoolMock.Object,
                 ParallelOperations = new NotSoParallelOps(),
+                Logger = new ModuleLogger("Dummy", new NullLoggerFactory()),
                 Dispatcher = _dispatcher
             };
 

--- a/src/Tests/Moryx.Runtime.Kernel.Tests/ModuleManagerTests.cs
+++ b/src/Tests/Moryx.Runtime.Kernel.Tests/ModuleManagerTests.cs
@@ -5,15 +5,15 @@ using System;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
 using Moryx.Configuration;
 using Moryx.Logging;
+using Moryx.Runtime.Kernel.Tests.Dummies;
 using Moryx.Runtime.Kernel.Tests.ModuleMocks;
 using Moryx.Runtime.Modules;
-using Moq;
 using Moryx.Tools;
 using NUnit.Framework;
-using Microsoft.Extensions.Logging.Abstractions;
-using Moryx.Runtime.Kernel.Tests.Dummies;
 
 namespace Moryx.Runtime.Kernel.Tests
 {
@@ -208,9 +208,9 @@ namespace Moryx.Runtime.Kernel.Tests
             // Act
             await moduleManager.StartModulesAsync();
 
-            // Assert
-            Thread.Sleep(3000); // Give the thread pool some time
+            WaitForTimeboxed(() => mockModule2.Invocations.Any(i => i.Method.Name == nameof(IServerModule.StartAsync)));
 
+            // Assert
             mockModule1.Verify(mock => mock.InitializeAsync(), Times.Exactly(2));
             mockModule1.Verify(mock => mock.StartAsync());
 
@@ -229,7 +229,7 @@ namespace Moryx.Runtime.Kernel.Tests
             // Act
             await moduleManager.StartModuleAsync(mockModule.Object);
 
-            Thread.Sleep(1);
+            WaitForTimeboxed(() => mockModule.Invocations.Any(i => i.Method.Name == nameof(IServerModule.StartAsync)));
 
             // Assert
             mockModule.Verify(mock => mock.InitializeAsync());
@@ -312,7 +312,7 @@ namespace Moryx.Runtime.Kernel.Tests
             var i = 0;
             while (!condition() && (i < maxSeconds))
             {
-                Thread.Sleep(100);
+                Thread.Sleep(1000);
                 i++;
             }
         }

--- a/src/Tests/Moryx.Simulation.Tests/SimulationActivitiesTests.cs
+++ b/src/Tests/Moryx.Simulation.Tests/SimulationActivitiesTests.cs
@@ -186,7 +186,7 @@ namespace Moryx.Simulation.Tests
         public void CompleteMovement_ActivityAlreadyStarted_ShouldNotCallReady()
         {
             // Arrange
-            _moduleConfig.MovingDuration = 1;
+            _moduleConfig.MovingDuration = 5;
             var processId = 42;
             var completedActivity = new AssemblyActivity();
             completedActivity.Result = new ActivityResult();
@@ -198,14 +198,13 @@ namespace Moryx.Simulation.Tests
                 .Returns([completedActivity, readyActivity]);
             _processMock.SetupGet(x => x.Id).Returns(processId);
             _processMock.Setup(x => x.GetActivity(ActivitySelectionType.LastOrDefault, It.IsAny<Func<Activity, bool>>()));
-
             _processControlMock.Setup(pc => pc.GetRunningProcesses()).Returns([_processMock.Object]);
             CreateActivity(readyActivity, _processMock.Object, [_anotherAssemblyCell]);
 
             // Act
-            _processSimulator.Start();
-            readyActivity.Tracing.Started = DateTime.Now;
-            Thread.Sleep(10);
+            _processSimulator.Start(); // Start movement for readyActivity
+            readyActivity.Tracing.Started = DateTime.Now; // Simulate that activity has started during movement
+            Thread.Sleep(10); // Wait for movement to complete
 
             // Assert
             _anotherAssemblyDriverMock.Verify(d => d.Ready(It.IsAny<Activity>()), Times.Never);


### PR DESCRIPTION
### Summary 
- Properly time simulation test for completed activity movement when the activity is already running
- Add missing logger in tests using the JobHandler
- Increase reliability of time sensitive tests of the `ModuleManager.Start` methods, by adding time-boxed waiting for longer periods

