### PR TITLE
Fixed `NullReferenceException` if no Launcher config was supplied

### DIFF
--- a/src/Moryx.Launcher/ShellNavigator.cs
+++ b/src/Moryx.Launcher/ShellNavigator.cs
@@ -144,7 +144,7 @@ namespace Moryx.Launcher
             if (launcherConfig.ConfigState == ConfigState.Generated)
             {
                 launcherConfig.ConfigState = ConfigState.Valid;
-                configManager.SaveConfiguration(_launcherConfig);
+                configManager.SaveConfiguration(launcherConfig);
             }
 
             return launcherConfig;

--- a/src/Moryx.Runtime.Kernel/Configuration/ConfigManager.cs
+++ b/src/Moryx.Runtime.Kernel/Configuration/ConfigManager.cs
@@ -84,6 +84,8 @@ namespace Moryx.Runtime.Kernel
         /// <param name="name">Name of the configuration</param>
         public void SaveConfiguration(ConfigBase configuration, string name, bool liveUpdate)
         {
+            ArgumentNullException.ThrowIfNull(configuration);
+
             var configType = configuration.GetType();
 
             lock (ConfigCache)

--- a/src/Moryx/Configuration/ConfigManagerExtensions.cs
+++ b/src/Moryx/Configuration/ConfigManagerExtensions.cs
@@ -81,6 +81,7 @@ namespace Moryx.Configuration
         /// <param name="configuration">Object to save</param>
         public static void SaveConfiguration(this IConfigManager configManager, ConfigBase configuration)
         {
+            ArgumentNullException.ThrowIfNull(configuration);
             configManager.SaveConfiguration(configuration, configuration.GetType().FullName, false);
         }
 
@@ -92,6 +93,7 @@ namespace Moryx.Configuration
         /// <param name="liveUpdate">Flag if config should be updated on the currently used object reference</param>
         public static void SaveConfiguration(this IConfigManager configManager, ConfigBase configuration, bool liveUpdate)
         {
+            ArgumentNullException.ThrowIfNull(configuration);
             configManager.SaveConfiguration(configuration, configuration.GetType().FullName, liveUpdate);
         }
 


### PR DESCRIPTION
### Summary
Issue was caused by typo in `ShellNavigator.GetConfiguration`. Also adds null checks for conbfiguration to provide a better error experience.

