### PR TITLE
Added support for publishing notifications async

### DIFF
--- a/docs/migrations/v8_to_v10.md
+++ b/docs/migrations/v8_to_v10.md
@@ -400,7 +400,6 @@ All driver APIs have been reworked to use TPL async/await instead of callbacks f
 - `IRfidDriver`, `IScannerDriver`, `IPickByLightDriver` and `IWeightScaleDriver` were extended with commonly used methods, extendable by options and result objects
 - Added generic `ISingleInput{TOptions, TResult}` and `IContinuousInput{TOptions, TResult}` for general pattern of input devices
 
-
 ## Resource initialization
 
 The API of `IResourceInitializer` was adjusted
@@ -449,6 +448,10 @@ The API of `IResourceInitializer` was adjusted
 **`IProductStorage`**
 
 - API `LoadType` is using `IIdentity` instead of `ProductIdentity` but in MORYX 10.0, only `ProductIdentity` is supported.
+
+## Modules-Notifications
+
+NotificationAdapter supports async publishing now. `PublishAsync` will return `true` if the notification was published and processed, and `false` if it was not processed before acknowledgement.
 
 ## Modules-Orders
 

--- a/src/Moryx.Notifications/Adapter/INotificationAdapter.cs
+++ b/src/Moryx.Notifications/Adapter/INotificationAdapter.cs
@@ -24,6 +24,18 @@ namespace Moryx.Notifications
         void Publish(INotificationSender sender, Notification notification);
 
         /// <summary>
+        /// Publishes the given notification asynchronously. Will return true if the notification was published and processed,
+        /// false if it was not processed before acknowledgement.
+        /// </summary>
+        Task<bool> PublishAsync(INotificationSender sender, Notification notification, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Publishes the given notification asynchronously. Will return true if the notification was published and processed,
+        /// false if it was not processed before acknowledgement.
+        /// </summary>
+        Task<bool> PublishAsync(INotificationSender sender, Notification notification, object tag, CancellationToken cancellationToken = default);
+
+        /// <summary>
         /// Publishes the given notification
         /// </summary>
         void Publish(INotificationSender sender, Notification notification, object tag);


### PR DESCRIPTION
NotificationAdapter supports async publishing now. `PublishAsync` will return `true` if the notification was published and processed, and `false` if it was not processed before acknowledgement. It adds the ability to await the processing of the notification to get information (like texts) from the processed notification.

The implementation is a POC. For the 10.0.0 release, we could just add the methods to the INotificationAdapter interface as preparation and add feature implementation in 10.x. @1nf0rmagician does this make sense for you?