### PR TITLE
Prevent `NullReferenceException` on entering `RetrySetupBlockedState`

### DIFF
--- a/src/Moryx.ControlSystem.ProcessEngine/Jobs/Setup/SetupJobData.cs
+++ b/src/Moryx.ControlSystem.ProcessEngine/Jobs/Setup/SetupJobData.cs
@@ -121,13 +121,13 @@ namespace Moryx.ControlSystem.ProcessEngine.Jobs.Setup
             var notification = new Notification(Strings.SetupJobData_RetryFailedNotification_Title,
                 string.Format(Strings.SetupJobData_RetryFailedNotification_Message, Recipe.Name), Severity.Error, true);
 
-            NotificationAdapter.Publish(this, notification);
+            NotificationAdapter?.Publish(this, notification);
         }
 
         internal void ClearNotification()
         {
             _retryCounter = 0;
-            NotificationAdapter.AcknowledgeAll(this);
+            NotificationAdapter?.AcknowledgeAll(this);
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
When loading a job from the database on starting the module it is first initialized with its state and then populated with the dependencies. Thus, the `OnEnter` method is called before the `NotificationAdapter` is available and causes the `NullReferenceException`

(cherry picked from commit 35ec1db0dd4fe533a36a310efd56a4753dd29e7c)
