### PR TITLE
Fix new order with document throws exception

### DIFF
--- a/src/Moryx.Orders.Management/Implementation/Assignment/DocumentAssignStep.cs
+++ b/src/Moryx.Orders.Management/Implementation/Assignment/DocumentAssignStep.cs
@@ -105,7 +105,7 @@ namespace Moryx.Orders.Management.Assignment
             fileName += ext;
 
             // use FileMode.Create to not corrupt file caused by remaining bytes of a existing file (that was longer)
-            using (var fs = new FileStream(fileName, FileMode.Create, FileAccess.Write))
+            using (var fs = new FileStream(fileName, FileMode.Create, FileAccess.Write, FileShare.Read))
             {
                 await stream.CopyToAsync(fs);
             }


### PR DESCRIPTION
### Summary
#### Issue:
There was an exception thrown about file access conflict when trying to store documents. The issue is that the FileStream is created without specifying file sharing options, which means no other process can access the file while it's being written. This can cause problems with antivirus scanners, file explorers, or concurrent operations.

<img width="498" height="1094" alt="image-2026-01-07-09-30-15-362" src="https://github.com/user-attachments/assets/e85ad113-7bb9-4e35-a935-e63a7342af0d" />

#### Solution:
Added the file share option to allow the file to be read by concurrent operations.
