### PR TITLE
Fixed StateMachine initialization API

### DIFF
--- a/docs/articles/framework/StateMachine.md
+++ b/docs/articles/framework/StateMachine.md
@@ -67,7 +67,7 @@ public class MyContext : IStateContext
 
     public void Initial()
     {
-        StateMachine.Initialize(this).With<MyStateBase>();
+        StateMachine.ForContext(this).With<MyStateBase>();
         //State is not Initial = A
         _currentValue = 0;
     }
@@ -219,12 +219,12 @@ The state machine will be initialized with the static helper class [StateMachine
 ````cs
 private void InitializeMachine()
 {
-    StateMachine.Initialize(this).With<MyStateBase>();
+    StateMachine.ForContext(this).With<MyStateBase>();
 }
 
 private async Task InitializeMachineAsync()
 {
-    await StateMachine.Initialize(this).WithAsync<MyAsyncStateBase>();
+    await StateMachine.ForAsyncContext(this).WithAsync<MyAsyncStateBase>();
 }
 ````
 
@@ -237,12 +237,27 @@ Additionally a `stateKey` can be given to the method.
 private void ReloadMachine()
 {
     // Get the key of current state
-    var key = _state.Key;
+    var currentStateKey = _state.Key;
 
     // ... save key to db or somewhere else
 
     // Reload the state with the saved key
-    StateMachine.Reload(this, key).With<MyStateBase>();
+    StateMachine.ForContext(this).With<MyStateBase>(currentStateKey);
+}
+````
+
+For async state machines:
+
+````cs
+private async Task ReloadMachineAsync()
+{
+    // Get the key of current state
+    var currentStateKey = _state.Key;
+
+    // ... save key to db or somewhere else
+
+    // Reload the state with the saved key
+    StateMachine.ForAsyncContext(this, key).WithAsync<MyAsyncStateBase>(currentStateKey);
 }
 ````
 

--- a/docs/migrations/v8_to_v10.md
+++ b/docs/migrations/v8_to_v10.md
@@ -32,6 +32,12 @@ Due to the reduction of unnecessary interfaces, `IState` was removed and `StateB
 The `StateMachine` class was extended by `WithAsync()` and `ForceAsync()`. The `AsyncStateBase` provides async all the way: `NextStateAsync()`, `OnEnterAsync()`, `OnExitAsync`.\
 **Upgrade hint:** Replace `StateBase<TContext>` by `SyncStateBase<TContext>`.
 
+The `StateMachine.Initialize` method was renamed to `StateMachine.ForContext` to better reflect its purpose. Additionally, a new method `ForAsyncContext` was introduced to create an asynchronous state machines.
+
+The `StateMachine.Reload` methods were merged into `StateMachine.With` which makes it possible to provide the initial state during initialization. Additionally, a new method `WithAsync` was introduced to create an asynchronous state machines including overload for providing an initial state.
+
+````cs
+
 The same convention was applied to `DriverState`. It was renamed to `SyncDriverState` and a new implementation `AsyncDriverState` was added with full async support.\
 **Upgrade hint:** Replace `DriverState<TContext>` by `SyncDriverState<TContext>`.
 
@@ -280,8 +286,6 @@ SET "Type" = 'Moryx.Resources.VisualInstructions.VisualInstructor'
 WHERE "Type" = 'Moryx.Resources.AssemblyInstruction.VisualInstructor';
 ````
 
-
-
 ### Replaced result of visual instructions with dedicated result object
 
 In *Moryx.Factory* **6.3** and **8.1** we introduced the new result object and optional extended APIs. The result object solved issues caused by localization of the different results. With **Moryx 10** we remove all old APIs based on strings.
@@ -397,7 +401,7 @@ New version:
 
 ### Namespaces
 
-- `Moryx.Model.*.Attributes` have been merged into `Moryx.Model.*` 
+- `Moryx.Model.*.Attributes` have been merged into `Moryx.Model.*`
 
 ## Other model adjustments
 

--- a/src/Moryx.ControlSystem.ProcessEngine/Jobs/Production/ProductionJobData.cs
+++ b/src/Moryx.ControlSystem.ProcessEngine/Jobs/Production/ProductionJobData.cs
@@ -57,7 +57,7 @@ internal sealed class ProductionJobData : JobDataBase, IProductionJobData
     /// <inheritdoc />
     public ProductionJobData(ProductionRecipe recipe, int amount) : base(recipe, amount)
     {
-        StateMachine.Initialize(this).With<ProductionJobStateBase>();
+        StateMachine.ForContext(this).With<ProductionJobStateBase>();
     }
 
     /// <inheritdoc />
@@ -65,7 +65,7 @@ internal sealed class ProductionJobData : JobDataBase, IProductionJobData
     {
         Started = entity.Created;
 
-        StateMachine.Reload(this, entity.State).With<ProductionJobStateBase>();
+        StateMachine.ForContext(this).With<ProductionJobStateBase>(entity.State);
     }
 
     /// <inheritdoc />

--- a/src/Moryx.ControlSystem.ProcessEngine/Jobs/Setup/SetupJobData.cs
+++ b/src/Moryx.ControlSystem.ProcessEngine/Jobs/Setup/SetupJobData.cs
@@ -71,12 +71,12 @@ internal sealed class SetupJobData : JobDataBase, ISetupJobData, INotificationSe
 
     public SetupJobData(IWorkplanRecipe recipe) : base(recipe, recipe.Workplan.Steps.Count())
     {
-        StateMachine.Initialize(this).With<SetupJobStateBase>();
+        StateMachine.ForContext(this).With<SetupJobStateBase>();
     }
 
     public SetupJobData(IWorkplanRecipe recipe, JobEntity entity) : base(recipe, entity)
     {
-        StateMachine.Reload(this, entity.State).With<SetupJobStateBase>();
+        StateMachine.ForContext(this).With<SetupJobStateBase>(entity.State);
     }
 
     public void UpdateSetup(SetupRecipe updatedRecipe)
@@ -94,7 +94,7 @@ internal sealed class SetupJobData : JobDataBase, ISetupJobData, INotificationSe
             // resolve type of current disabled step
             foreach (var oldDisabledStepId in base.Recipe.DisabledSteps)
             {
-                // find task in current recipe 
+                // find task in current recipe
                 var disabledStep = base.Recipe.Workplan.Steps.First(step => step.Id == oldDisabledStepId);
                 // find same task in new recipe
                 var step = recipe.Workplan.Steps.FirstOrDefault(step => step.GetType() == disabledStep.GetType());

--- a/src/Moryx.Drivers.Mqtt/MqttDriver.cs
+++ b/src/Moryx.Drivers.Mqtt/MqttDriver.cs
@@ -243,7 +243,7 @@ public class MqttDriver : Driver, IMessageDriver
 
         _mqttClient.DisconnectedAsync += OnDisconnected;
 
-        StateMachine.Initialize(this).With<DriverMqttState>();
+        StateMachine.ForContext(this).With<DriverMqttState>();
     }
 
     internal void InitializeForTest(IMqttClient client) //TODO: no explicit method for tests
@@ -252,7 +252,7 @@ public class MqttDriver : Driver, IMessageDriver
         _mqttClient.ApplicationMessageReceivedAsync += OnReceived;
         _mqttClient.ConnectedAsync += OnConnected;
         _mqttClient.DisconnectedAsync += OnDisconnected;
-        StateMachine.Initialize(this).With<DriverMqttState>();
+        StateMachine.ForContext(this).With<DriverMqttState>();
     }
 
     /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>

--- a/src/Moryx.Drivers.OpcUa/OpcUaDriver.cs
+++ b/src/Moryx.Drivers.OpcUa/OpcUaDriver.cs
@@ -242,7 +242,7 @@ public class OpcUaDriver : Driver, IOpcUaDriver
         Output = new OpcUaOutput(this);
         _nodeIdAliasDictionary ??= [];
 
-        StateMachine.Initialize(this).With<DriverOpcUaState>();
+        StateMachine.ForContext(this).With<DriverOpcUaState>();
 
         ServerStatus = ServerState.Unknown;
     }

--- a/src/Moryx.Orders.Management/Implementation/OperationData/OperationData.cs
+++ b/src/Moryx.Orders.Management/Implementation/OperationData/OperationData.cs
@@ -121,7 +121,7 @@ internal class OperationData : IOperationData, IAsyncStateContext, ILoggingCompo
     /// <inheritdoc />
     public async Task<IOperationData> Initialize(OperationCreationContext context, IOrderData orderData, IOperationSource source)
     {
-        await StateMachine.InitializeAsync(this).WithAsync<OperationDataStateBase>();
+        await StateMachine.ForAsyncContext(this).WithAsync<OperationDataStateBase>();
         _dispatchHandler = new DispatchHandler(this);
 
         AssignState = OperationAssignState.Initial;
@@ -179,7 +179,7 @@ internal class OperationData : IOperationData, IAsyncStateContext, ILoggingCompo
 
         OperationStorage.RestoreOperationData(this, entity);
 
-        await StateMachine.ReloadAsync(this, entity.State).WithAsync<OperationDataStateBase>();
+        await StateMachine.ForAsyncContext(this).WithAsync<OperationDataStateBase>(entity.State);
 
         return this;
     }

--- a/src/Moryx.Runtime/Modules/ServerModuleBase.cs
+++ b/src/Moryx.Runtime/Modules/ServerModuleBase.cs
@@ -56,7 +56,7 @@ public abstract class ServerModuleBase<TConf> : IServerModule, IServerModuleStat
         LoggerFactory = loggerFactory;
         Logger = LoggerFactory.CreateLogger(GetType().Namespace);
 
-        StateMachine.InitializeAsync((IServerModuleStateContext)this).WithAsync<ServerModuleStateBase>().Wait();
+        StateMachine.ForAsyncContext((IServerModuleStateContext)this).WithAsync<ServerModuleStateBase>().Wait();
     }
 
     #region ValidateHealthState

--- a/src/Moryx/Collections/DelayQueue/DelayQueue.cs
+++ b/src/Moryx/Collections/DelayQueue/DelayQueue.cs
@@ -62,7 +62,7 @@ public class DelayQueue<T> : IDelayQueue<T>, IDelayQueueContext
         _parallelOperations = parallelOperations;
         _stopwatch = new Stopwatch();
 
-        StateMachine.Initialize<IDelayQueueContext>(this).With<QueueStateBase>();
+        StateMachine.ForContext<IDelayQueueContext>(this).With<QueueStateBase>();
     }
 
     void IStateContext.SetState(StateBase state)

--- a/src/Moryx/Communication/Sockets/Client/TcpClientConnection.cs
+++ b/src/Moryx/Communication/Sockets/Client/TcpClientConnection.cs
@@ -80,7 +80,7 @@ public class TcpClientConnection : IBinaryConnection, IStateContext
     {
         Config = (TcpClientConfig)config;
 
-        StateMachine.Initialize(this).With<ClientStateBase>();
+        StateMachine.ForContext(this).With<ClientStateBase>();
 
         _endpoint = GetIpEndpointFromHost(Config.IpAddress, Config.Port);
     }

--- a/src/Moryx/Communication/Sockets/Server/TcpListenerConnection.cs
+++ b/src/Moryx/Communication/Sockets/Server/TcpListenerConnection.cs
@@ -98,7 +98,7 @@ public class TcpListenerConnection : IBinaryConnection, IStateContext
         else
             throw new FormatException($"Failed to parse IPAddress: {_config.IpAddress}");
 
-        StateMachine.Initialize(this).With<ServerStateBase>();
+        StateMachine.ForContext(this).With<ServerStateBase>();
     }
 
     /// <summary>

--- a/src/Moryx/StateMachines/StateMachine.cs
+++ b/src/Moryx/StateMachines/StateMachine.cs
@@ -6,7 +6,7 @@ namespace Moryx.StateMachines;
 /// <summary>
 /// Class for creating and handling state machines
 /// </summary>
-public sealed class StateMachine
+public static class StateMachine
 {
     /// <summary>
     /// Prepare fluent API to create a state machine. Call <see cref="TypedContextWrapper{TContext}.With{TState}()"/>
@@ -43,16 +43,16 @@ public sealed class StateMachine
     ///     public void Sample()
     ///     {
     ///         // Initialize a state machine
-    ///         StateMachine.Initialize(this).With&lt;MyStateBase&gt;();
+    ///         StateMachine.ForContext(this).With&lt;MyStateBase&gt;();
     ///     }
     /// }
     /// </code>
     /// </example>
-    public static TypedContextWrapper<TContext> Initialize<TContext>(TContext context)
+    public static TypedContextWrapper<TContext> ForContext<TContext>(TContext context)
         where TContext : IStateContext
 
     {
-        return new TypedContextWrapper<TContext>(context, null);
+        return new TypedContextWrapper<TContext>(context);
     }
 
     /// <summary>
@@ -90,128 +90,15 @@ public sealed class StateMachine
     ///     public async Task SampleAsync()
     ///     {
     ///         // Initialize a state machine
-    ///         await StateMachine.InitializeAsync(this).WithAsync&lt;MyStateBase&gt;();
+    ///         await StateMachine.ForAsyncContext(this).WithAsync&lt;MyStateBase&gt;();
     ///     }
     /// }
     /// </code>
     /// </example>
-    public static TypedContextWrapper<TContext> InitializeAsync<TContext>(TContext context)
+    public static AsyncTypedContextWrapper<TContext> ForAsyncContext<TContext>(TContext context)
         where TContext : IAsyncStateContext
-
     {
-        return new TypedContextWrapper<TContext>(context, null);
-    }
-
-    /// <summary>
-    /// Prepare fluent API to create a state machine. Call <see cref="TypedContextWrapper{TContext}.With{TState}()"/>
-    /// to finalize the operation.
-    /// </summary>
-    /// <param name="context">Context of the state machine</param>
-    /// <param name="state">Key of the state that is reloaded</param>
-    /// <typeparam name="TContext">Type of the context class</typeparam>
-    ///  <exception cref="InvalidOperationException">Thrown if 0 or more states are flagged as initial.</exception>
-    ///  <exception cref="InvalidOperationException">Thrown if types are registered more than one time.</exception>
-    ///  <exception cref="ArgumentException">Given base class is not abstract.</exception>
-    ///  <example>
-    ///  This sample shows how to define states in the state base
-    ///  <code>
-    ///  internal abstract class MyStateBase : StateBase{MyContext}
-    ///  {
-    ///      protected MyStateBase(MyContext context, StateMap stateMap) : base(context, stateMap)
-    ///      {
-    ///      }
-    ///
-    ///      [StateDefinition(typeof(AState), IsInitial = true)]
-    ///      protected const int StateA = 10;
-    ///
-    ///      [StateDefinition(typeof(BState))]
-    ///      protected const int StateB = 20;
-    /// }
-    /// </code>
-    /// </example>
-    /// <example>
-    /// This sample shows how reload a state machine
-    /// <code>
-    /// public class SomeComponent : IStateContext
-    /// {
-    ///     public void Sample()
-    ///     {
-    ///         // Initialize a state machine
-    ///         StateMachine.Initialize(this).With&lt;MyStateBase&gt;();
-    ///         _state.GoToAnotherState();
-    ///
-    ///         // Get the key of the other state
-    ///         var key = StateMachine.GetKey(_stat);
-    ///
-    ///         // ... save key to db or somewhere else
-    ///
-    ///         // Reload the state with the saved key
-    ///         StateMachine.Reload(this, key).With&lt;MyStateBase&gt;();
-    ///     }
-    /// }
-    /// </code>
-    /// </example>
-    public static TypedContextWrapper<TContext> Reload<TContext>(TContext context, int state)
-        where TContext : IStateContext
-
-    {
-        return new TypedContextWrapper<TContext>(context, state);
-    }
-
-    /// <summary>
-    /// Prepare fluent API to create a state machine. Call <see cref="TypedContextWrapper{TContext}.WithAsync{TState}()"/>
-    /// to finalize the operation.
-    /// </summary>
-    /// <param name="context">Context of the state machine</param>
-    /// <param name="state">Key of the state that is reloaded</param>
-    /// <typeparam name="TContext">Type of the context class</typeparam>
-    ///  <exception cref="InvalidOperationException">Thrown if 0 or more states are flagged as initial.</exception>
-    ///  <exception cref="InvalidOperationException">Thrown if types are registered more than one time.</exception>
-    ///  <exception cref="ArgumentException">Given base class is not abstract.</exception>
-    ///  <example>
-    ///  This sample shows how to define states in the state base
-    ///  <code>
-    ///  internal abstract class MyAsyncStateBase : AsyncStateBase{MyContext}
-    ///  {
-    ///      protected MyStateBase(MyAsyncContext context, StateMap stateMap) : base(context, stateMap)
-    ///      {
-    ///      }
-    ///
-    ///      [StateDefinition(typeof(AState), IsInitial = true)]
-    ///      protected const int StateA = 10;
-    ///
-    ///      [StateDefinition(typeof(BState))]
-    ///      protected const int StateB = 20;
-    /// }
-    /// </code>
-    /// </example>
-    /// <example>
-    /// This sample shows how reload a state machine
-    /// <code>
-    /// public class SomeComponent : IStateContext
-    /// {
-    ///     public async Task SampleAsync()
-    ///     {
-    ///         // Initialize a state machine
-    ///         await StateMachine.InitializeAsync(this).WithAsync&lt;MyStateBase&gt;();
-    ///         await _state.GoToAnotherState();
-    ///
-    ///         // Get the key of the other state
-    ///         var key = StateMachine.GetKey(_stat);
-    ///
-    ///         // ... save key to db or somewhere else
-    ///
-    ///         // Reload the state with the saved key
-    ///         await StateMachine.ReloadAsync(this, key).WithAsync&lt;MyStateBase&gt;();
-    ///     }
-    /// }
-    /// </code>
-    /// </example>
-    public static TypedContextWrapper<TContext> ReloadAsync<TContext>(TContext context, int state)
-        where TContext : IAsyncStateContext
-
-    {
-        return new TypedContextWrapper<TContext>(context, state);
+        return new AsyncTypedContextWrapper<TContext>(context);
     }
 
     /// <summary>
@@ -327,32 +214,16 @@ public sealed class StateMachine
     /// Wrapper for the context class to use generic language features
     /// and provide fluent API
     /// </summary>
-    /// <typeparam name="TContext"></typeparam>
-    public readonly struct TypedContextWrapper<TContext>
+    public readonly struct AsyncTypedContextWrapper<TContext>
     {
         private readonly TContext _context;
-        private readonly int? _key;
 
         /// <summary>
         /// Create context wrapper
         /// </summary>
-        internal TypedContextWrapper(TContext context, int? key)
+        internal AsyncTypedContextWrapper(TContext context)
         {
             _context = context;
-            _key = key;
-        }
-
-        /// <summary>
-        /// Finalize the state machine creation by defining the state machine type.
-        /// </summary>
-        /// <typeparam name="TStateBase">Type of state machine base class</typeparam>
-        /// <exception cref="InvalidOperationException">Thrown if 0 or more states are flagged as initial.</exception>
-        /// <exception cref="InvalidOperationException">Thrown if types are registered more than one time.</exception>
-        /// <exception cref="ArgumentException">Given base class is not abstract.</exception>
-        public void With<TStateBase>()
-            where TStateBase : SyncStateBase
-        {
-            SyncStateBase.Create(typeof(TStateBase), (IStateContext)_context, _key);
         }
 
         /// <summary>
@@ -365,19 +236,20 @@ public sealed class StateMachine
         public Task WithAsync<TStateBase>(CancellationToken cancellationToken = default)
             where TStateBase : AsyncStateBase
         {
-            return AsyncStateBase.CreateAsync(typeof(TStateBase), (IAsyncStateContext)_context, _key, cancellationToken);
+            return AsyncStateBase.CreateAsync(typeof(TStateBase), (IAsyncStateContext)_context, null, cancellationToken);
         }
 
         /// <summary>
         /// Finalize the state machine creation by defining the state machine type.
         /// </summary>
-        /// <param name="stateType">Type of state machine base class</param>
+        /// <typeparam name="TStateBase">Type of state machine base class</typeparam>
         /// <exception cref="InvalidOperationException">Thrown if 0 or more states are flagged as initial.</exception>
         /// <exception cref="InvalidOperationException">Thrown if types are registered more than one time.</exception>
         /// <exception cref="ArgumentException">Given base class is not abstract.</exception>
-        public void With(Type stateType)
+        public Task WithAsync<TStateBase>(int initialState, CancellationToken cancellationToken = default)
+            where TStateBase : AsyncStateBase
         {
-            SyncStateBase.Create(stateType, (IStateContext)_context, _key);
+            return AsyncStateBase.CreateAsync(typeof(TStateBase), (IAsyncStateContext)_context, initialState, cancellationToken);
         }
 
         /// <summary>
@@ -390,7 +262,90 @@ public sealed class StateMachine
         /// <exception cref="ArgumentException">Given base class is not abstract.</exception>
         public Task WithAsync(Type stateType, CancellationToken cancellationToken = default)
         {
-            return AsyncStateBase.CreateAsync(stateType, (IAsyncStateContext)_context, _key, cancellationToken);
+            return AsyncStateBase.CreateAsync(stateType, (IAsyncStateContext)_context, null, cancellationToken);
+        }
+
+        /// <summary>
+        /// Finalize the state machine creation by defining the state machine type.
+        /// </summary>
+        /// <param name="initialState">Initial state of the state machine. Used for reloads.</param>
+        /// <param name="stateType">Type of state machine base class</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <exception cref="InvalidOperationException">Thrown if 0 or more states are flagged as initial.</exception>
+        /// <exception cref="InvalidOperationException">Thrown if types are registered more than one time.</exception>
+        /// <exception cref="ArgumentException">Given base class is not abstract.</exception>
+        public Task WithAsync(Type stateType, int initialState, CancellationToken cancellationToken = default)
+        {
+            return AsyncStateBase.CreateAsync(stateType, (IAsyncStateContext)_context, initialState, cancellationToken);
+        }
+    }
+
+    /// <summary>
+    /// Wrapper for the context class to use generic language features
+    /// and provide fluent API
+    /// </summary>
+    public readonly struct TypedContextWrapper<TContext>
+    {
+        private readonly TContext _context;
+
+        /// <summary>
+        /// Create context wrapper
+        /// </summary>
+        internal TypedContextWrapper(TContext context)
+        {
+            _context = context;
+        }
+
+        /// <summary>
+        /// Finalize the state machine creation by defining the state machine type.
+        /// </summary>
+        /// <typeparam name="TStateBase">Type of state machine base class</typeparam>
+        /// <exception cref="InvalidOperationException">Thrown if 0 or more states are flagged as initial.</exception>
+        /// <exception cref="InvalidOperationException">Thrown if types are registered more than one time.</exception>
+        /// <exception cref="ArgumentException">Given base class is not abstract.</exception>
+        public void With<TStateBase>()
+            where TStateBase : SyncStateBase
+        {
+            SyncStateBase.Create(typeof(TStateBase), (IStateContext)_context, null);
+        }
+
+        /// <summary>
+        /// Finalize the state machine creation by defining the state machine type.
+        /// </summary>
+        /// <param name="initialState">Initial state of the state machine. Used for reloads.</param>
+        /// <typeparam name="TStateBase">Type of state machine base class</typeparam>
+        /// <exception cref="InvalidOperationException">Thrown if 0 or more states are flagged as initial.</exception>
+        /// <exception cref="InvalidOperationException">Thrown if types are registered more than one time.</exception>
+        /// <exception cref="ArgumentException">Given base class is not abstract.</exception>
+        public void With<TStateBase>(int initialState)
+            where TStateBase : SyncStateBase
+        {
+            SyncStateBase.Create(typeof(TStateBase), (IStateContext)_context, initialState);
+        }
+
+        /// <summary>
+        /// Finalize the state machine creation by defining the state machine type.
+        /// </summary>
+        /// <param name="stateType">Type of state machine base class</param>
+        /// <exception cref="InvalidOperationException">Thrown if 0 or more states are flagged as initial.</exception>
+        /// <exception cref="InvalidOperationException">Thrown if types are registered more than one time.</exception>
+        /// <exception cref="ArgumentException">Given base class is not abstract.</exception>
+        public void With(Type stateType)
+        {
+            SyncStateBase.Create(stateType, (IStateContext)_context, null);
+        }
+
+        /// <summary>
+        /// Finalize the state machine creation by defining the state machine type.
+        /// </summary>
+        /// <param name="stateType">Type of state machine base class</param>
+        /// <param name="initialState">Initial state of the state machine. Used for reloads.</param>
+        /// <exception cref="InvalidOperationException">Thrown if 0 or more states are flagged as initial.</exception>
+        /// <exception cref="InvalidOperationException">Thrown if types are registered more than one time.</exception>
+        /// <exception cref="ArgumentException">Given base class is not abstract.</exception>
+        public void With(Type stateType, int initialState)
+        {
+            SyncStateBase.Create(stateType, (IStateContext)_context, initialState);
         }
     }
 }

--- a/src/Moryx/Workplans/Implementation/Engine/WorkplanEngine.cs
+++ b/src/Moryx/Workplans/Implementation/Engine/WorkplanEngine.cs
@@ -9,7 +9,7 @@ internal class WorkplanEngine : IMonitoredEngine, IStateContext
 {
     public WorkplanEngine()
     {
-        StateMachine.Initialize(this).With<EngineState>();
+        StateMachine.ForContext(this).With<EngineState>();
     }
 
     internal EngineState State { get; private set; }

--- a/src/Tests/Moryx.Tests/StateMachines/AsyncStateMachineTests.cs
+++ b/src/Tests/Moryx.Tests/StateMachines/AsyncStateMachineTests.cs
@@ -75,18 +75,18 @@ public class AsyncStateMachineTests
     }
 
 
-    [Test]
-    public async Task Reload()
+    [Test(Description = "Create a StateMachine with a specific initial state key.")]
+    public async Task CreateWithSpecificInitialState()
     {
         // Assert
         var context = new MyAsyncContext();
-        await StateMachine.InitializeAsync(context).WithAsync<MyAsyncStateBase>();
+        await StateMachine.ForAsyncContext(context).WithAsync<MyAsyncStateBase>();
         await context.State.AtoBAsync();
 
         // Act
         var reloadedContext = new MyAsyncContext();
         var bkey = context.State.Key;
-        await StateMachine.ReloadAsync(reloadedContext, bkey).WithAsync<MyAsyncStateBase>();
+        await StateMachine.ForAsyncContext(reloadedContext).WithAsync<MyAsyncStateBase>(bkey);
 
         // Assert
         Assert.ThrowsAsync<InvalidOperationException>(() => reloadedContext.State.InitialAsync());
@@ -146,7 +146,7 @@ public class AsyncStateMachineTests
     private static async Task<MyAsyncContext> CreateContext()
     {
         var context = new MyAsyncContext();
-        await StateMachine.InitializeAsync(context).WithAsync<MyAsyncStateBase>();
+        await StateMachine.ForAsyncContext(context).WithAsync<MyAsyncStateBase>();
 
         return context;
     }

--- a/src/Tests/Moryx.Tests/StateMachines/StateMachineTests.cs
+++ b/src/Tests/Moryx.Tests/StateMachines/StateMachineTests.cs
@@ -86,18 +86,18 @@ public class StateMachineTests
         Assert.That(text, Is.EqualTo(resultText));
     }
 
-    [Test]
-    public void Reload()
+    [Test(Description = "Create a StateMachine with a specific initial state key.")]
+    public void CreateWithSpecificInitialState()
     {
         // Assert
         var context = new MyContext();
-        StateMachine.Initialize(context).With<MyStateBase>();
+        StateMachine.ForContext(context).With<MyStateBase>();
         context.State.AtoB();
 
         // Act
         var reloadedContext = new MyContext();
         var bkey = context.State.Key;
-        StateMachine.Reload(reloadedContext, bkey).With<MyStateBase>();
+        StateMachine.ForContext(reloadedContext).With<MyStateBase>(bkey);
 
         // Assert
         Assert.Throws<InvalidOperationException>(() => reloadedContext.State.Initial());
@@ -110,8 +110,8 @@ public class StateMachineTests
         Assert.That(context.CtoATriggered, Is.False);
     }
 
-    [Test]
-    public void ReloadUnknown()
+    [Test(Description = "Create a StateMachine with an unknown initial state key.")]
+    public void CreateWithUnknownInitialState()
     {
         // Arrange
         var context = new MyContext();
@@ -120,7 +120,7 @@ public class StateMachineTests
         Assert.Throws<InvalidOperationException>(delegate
         {
             // Act
-            StateMachine.Reload(context, int.MaxValue).With<MyStateBase>();
+            StateMachine.ForContext(context).With<MyStateBase>(int.MaxValue);
         });
     }
 
@@ -171,7 +171,7 @@ public class StateMachineTests
     private static MyContext CreateContext()
     {
         var context = new MyContext();
-        StateMachine.Initialize(context).With<MyStateBase>();
+        StateMachine.ForContext(context).With<MyStateBase>();
 
         return context;
     }


### PR DESCRIPTION
The `StateMachine.Initialize` method was renamed to `StateMachine.ForContext` to better reflect its purpose. Additionally, a new method `ForAsyncContext` was introduced to create an asynchronous state machines.

The `StateMachine.Reload` methods were merged into `StateMachine.With` which makes it possible to provide the initial state during initialization. Additionally, a new method `WithAsync` was introduced to create an asynchronous state machines including overload for providing an initial state.


can be approved but merged after #966