### PR TITLE
starting an operation throws a `NullReferenceException`

### DIFF
--- a/src/Moryx.Operators.Management/ModuleController/ModuleController.cs
+++ b/src/Moryx.Operators.Management/ModuleController/ModuleController.cs
@@ -10,6 +10,7 @@ using Moryx.Runtime.Modules;
 using Moryx.AbstractionLayer.Resources;
 using Moryx.Operators.Attendances;
 using Moryx.Operators.Skills;
+using Moryx.Users;
 
 namespace Moryx.Operators.Management;
 
@@ -23,6 +24,7 @@ public class ModuleController(IModuleContainerFactory containerFactory, IConfigM
 #pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
     ServerModuleBase<ModuleConfig>(containerFactory, configManager, loggerFactory),
     IFacadeContainer<IOperatorManagement>, IFacadeContainer<IAttendanceManagement>,
+    IFacadeContainer<IUserManagement>,
     IFacadeContainer<ISkillManagement>
 {
     /// <summary>
@@ -82,4 +84,5 @@ public class ModuleController(IModuleContainerFactory containerFactory, IConfigM
     IOperatorManagement IFacadeContainer<IOperatorManagement>.Facade => _facade;
     IAttendanceManagement IFacadeContainer<IAttendanceManagement>.Facade => _facade;
     ISkillManagement IFacadeContainer<ISkillManagement>.Facade => _facade;
+    IUserManagement IFacadeContainer<IUserManagement>.Facade => _facade;
 }


### PR DESCRIPTION
### Summary
The issue was that `IUserManagement` was null in the OrderEndpoint due to missing `IOperatorManagement`.

The  fix was to expose the `IOperatorManagement` facade in the  operators `ModuleController` as an `IUserManagement` which now get properly injected into the endpoint.

### Linked Issues

<!-- 
Link to any related issues using GitHub keywords (e.g., Fixes #123, Closes #456).
-->

### Checklist for Submitter

- [ ] I have tested these changes locally
- [ ] I have updated documentation as needed
- [ ] I have added or updated tests as appropriate
- [ ] I have used clear and descriptive commit messages

### Review

**Typical tasks**

- [ ] Merge request is well described
- [ ] Critical sections are *documented in code*
- [ ] *Tests* are extended
- [ ] *Documentation* is created / updated
- [ ] Running in test environment
- [ ] Ports to other maintained versions are created

**Clean code**

- [ ] *All* unused references are removed
- [ ] Clean code rules are respected with passion (naming, ...)
- [ ] Avoid *copy and pasted* code snippets
