### PR TITLE
Introduced DriverException and fixed constructors of specific driver exceptions

### DIFF
--- a/src/Moryx.AbstractionLayer/Drivers/AsyncDriverState.cs
+++ b/src/Moryx.AbstractionLayer/Drivers/AsyncDriverState.cs
@@ -11,7 +11,6 @@ namespace Moryx.AbstractionLayer.Drivers;
 /// <typeparam name="TContext">Type of the driver context</typeparam>
 public abstract class AsyncDriverState<TContext> : AsyncStateBase<TContext>, IDriverState
     where TContext : Driver
-
 {
     /// <inheritdoc />
     public StateClassification Classification { get; protected set; }

--- a/src/Moryx.AbstractionLayer/Drivers/Axis/IAxesController.cs
+++ b/src/Moryx.AbstractionLayer/Drivers/Axis/IAxesController.cs
@@ -13,8 +13,9 @@ public interface IAxesController : IDriver
     /// </summary>
     /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
     /// <param name="movement">Array of axes which should be moved</param>
+    /// <exception cref="DriverException">Thrown when the driver encounters an error during execution.</exception>
     /// <exception cref="DriverStateException">Thrown if the driver is in an invalid state for this operation.</exception>
-    /// <exception cref="MoveAxesException">Will be thrown for errors during moving axes</exception>
+    /// <exception cref="MoveAxesException">Will be thrown for errors during moving axes.</exception>
     /// <exception cref="OperationCanceledException">The cancellation token was canceled. This exception is stored into the returned task.</exception>
     Task<AxisMovementResponse> MoveAxesAsync(CancellationToken cancellationToken = default, params AxisMovement[] movement);
 }

--- a/src/Moryx.AbstractionLayer/Drivers/Axis/MoveAxesException.cs
+++ b/src/Moryx.AbstractionLayer/Drivers/Axis/MoveAxesException.cs
@@ -6,6 +6,31 @@ namespace Moryx.AbstractionLayer.Drivers.Axis;
 /// <summary>
 /// Exception type which will be used for errors during moving axes of <see cref="IAxesController"/>
 /// </summary>
-public class MoveAxesException : Exception
+public class MoveAxesException : DriverException
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MoveAxesException"/> class.
+    /// </summary>
+    public MoveAxesException()
+    {
+
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MoveAxesException"/> class.
+    /// </summary>
+    public MoveAxesException(string message)
+        : base(message)
+    {
+
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MoveAxesException"/> class.
+    /// </summary>
+    public MoveAxesException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+
+    }
 }

--- a/src/Moryx.AbstractionLayer/Drivers/Camera/ICameraDriver.cs
+++ b/src/Moryx.AbstractionLayer/Drivers/Camera/ICameraDriver.cs
@@ -15,6 +15,7 @@ public interface ICameraDriver<TImage> : IInputDriver where TImage : class
     /// </summary>
     /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
     /// <returns>The image that was captured</returns>
+    /// <exception cref="DriverException">Thrown when the driver encounters an error during execution.</exception>
     /// <exception cref="DriverStateException">Thrown if the driver is in an invalid state for this operation.</exception>
     /// <exception cref="OperationCanceledException">The cancellation token was canceled. This exception is stored into the returned task.</exception>
     Task<TImage> CaptureImageAsync(CancellationToken cancellationToken = default);

--- a/src/Moryx.AbstractionLayer/Drivers/DriverException.cs
+++ b/src/Moryx.AbstractionLayer/Drivers/DriverException.cs
@@ -1,0 +1,36 @@
+// Copyright (c) 2026, Phoenix Contact GmbH & Co. KG
+// Licensed under the Apache License, Version 2.0
+
+namespace Moryx.AbstractionLayer.Drivers;
+
+/// <summary>
+/// General exception for driver errors
+/// </summary>
+public class DriverException : Exception
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DriverException"/> class.
+    /// </summary>
+    public DriverException()
+    {
+
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DriverException"/> class.
+    /// </summary>
+    public DriverException(string message)
+        : base(message)
+    {
+
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DriverException"/> class.
+    /// </summary>
+    public DriverException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+
+    }
+}

--- a/src/Moryx.AbstractionLayer/Drivers/DriverStateException.cs
+++ b/src/Moryx.AbstractionLayer/Drivers/DriverStateException.cs
@@ -6,7 +6,7 @@ namespace Moryx.AbstractionLayer.Drivers;
 /// <summary>
 /// Exception for busy drivers. The driver cannot handle requests.
 /// </summary>
-public class DriverStateException : Exception
+public class DriverStateException : DriverException
 {
     /// <summary>
     /// Information about the required state of the driver for the execution

--- a/src/Moryx.AbstractionLayer/Drivers/InOut/IContinuousInput.cs
+++ b/src/Moryx.AbstractionLayer/Drivers/InOut/IContinuousInput.cs
@@ -20,6 +20,7 @@ public interface IContinuousInput<in TOptions, TResult>
     /// </summary>
     /// <param name="options">Options that define how the operation should be performed.</param>
     /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+    /// <exception cref="DriverException">Thrown when the driver encounters an error during execution.</exception>
     /// <exception cref="DriverStateException">Thrown if the driver is in an invalid state for this operation.</exception>
     /// <exception cref="OperationCanceledException">The cancellation token was canceled. This exception is stored into the returned task.</exception>
     Task ActivateAsync(TOptions options, CancellationToken cancellationToken = default);
@@ -28,6 +29,7 @@ public interface IContinuousInput<in TOptions, TResult>
     /// Deactivates the device. The event <see cref="cancellationToken"/> is not raised for new values anymore.
     /// </summary>
     /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+    /// <exception cref="DriverException">Thrown when the driver encounters an error during execution.</exception>
     /// <exception cref="OperationCanceledException">Thrown if the driver is in an invalid state for this operation.</exception>
     /// <exception cref="ValueRead">The cancellation token was canceled. This exception is stored into the returned task.</exception>
     Task DeactivateAsync(CancellationToken cancellationToken = default);

--- a/src/Moryx.AbstractionLayer/Drivers/InOut/ISingleInput.cs
+++ b/src/Moryx.AbstractionLayer/Drivers/InOut/ISingleInput.cs
@@ -15,6 +15,7 @@ public interface ISingleInput<in TOptions, TResult>
     /// </summary>
     /// <param name="options">Options that define how the operation should be performed.</param>
     /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+    /// <exception cref="DriverException">Thrown when the driver encounters an error during execution.</exception>
     /// <exception cref="DriverStateException">Thrown if the driver is in an invalid state for this operation.</exception>
     /// <exception cref="OperationCanceledException">The cancellation token was canceled. This exception is stored into the returned task.</exception>
     Task<TResult> ReadAsync(TOptions options, CancellationToken cancellationToken = default);

--- a/src/Moryx.AbstractionLayer/Drivers/Marking/IMarkingLaserDriver.cs
+++ b/src/Moryx.AbstractionLayer/Drivers/Marking/IMarkingLaserDriver.cs
@@ -11,10 +11,11 @@ public interface IMarkingLaserDriver : IDriver
     /// <summary>
     /// Set up marking file as a preparation for the marking process
     /// </summary>
-    /// <param name="file">The marking file used for the marking system</param>
+    /// <param name="file">The marking file used for the marking system.</param>
     /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+    /// <exception cref="DriverException">Thrown when the driver encounters an error during execution.</exception>
     /// <exception cref="DriverStateException">Thrown if the driver is in an invalid state for this operation.</exception>
-    /// <exception cref="MarkingFileException">Will be thrown when errors occur during setting the marking file</exception>
+    /// <exception cref="MarkingFileException">Will be thrown when errors occur during setting the marking file.</exception>
     /// <exception cref="OperationCanceledException">The cancellation token was canceled. This exception is stored into the returned task.</exception>
     Task<MarkingFileResponse> SetMarkingFileAsync(MarkingFile file, CancellationToken cancellationToken = default);
 
@@ -23,6 +24,7 @@ public interface IMarkingLaserDriver : IDriver
     /// </summary>
     /// <param name="config">The configuration for the marking process.</param>
     /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+    /// <exception cref="DriverException">Thrown when the driver encounters an error during execution.</exception>
     /// <exception cref="DriverStateException">Thrown if the driver is in an invalid state for this operation.</exception>
     /// <exception cref="MarkingException">Will be thrown when errors occur during marking execution</exception>
     /// <exception cref="SegmentsNotSupportedException">Exception if the system does not support segments</exception>

--- a/src/Moryx.AbstractionLayer/Drivers/Marking/MarkingException.cs
+++ b/src/Moryx.AbstractionLayer/Drivers/Marking/MarkingException.cs
@@ -6,6 +6,29 @@ namespace Moryx.AbstractionLayer.Drivers.Marking;
 /// <summary>
 /// Exception type which will be used for errors during marking execution of the <see cref="IMarkingLaserDriver"/>
 /// </summary>
-public class MarkingException : Exception
+public class MarkingException : DriverException
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MarkingException"/> class.
+    /// </summary>
+    public MarkingException()
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MarkingException"/> class.
+    /// </summary>
+    public MarkingException(string message)
+        : base(message)
+    {
+
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MarkingException"/> class.
+    /// </summary>
+    public MarkingException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
 }

--- a/src/Moryx.AbstractionLayer/Drivers/Marking/MarkingFileException.cs
+++ b/src/Moryx.AbstractionLayer/Drivers/Marking/MarkingFileException.cs
@@ -6,6 +6,31 @@ namespace Moryx.AbstractionLayer.Drivers.Marking;
 /// <summary>
 /// Exception type which will be used for errors during setting the marking file of the <see cref="IMarkingLaserDriver"/>
 /// </summary>
-public class MarkingFileException : Exception
+public class MarkingFileException : DriverException
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MarkingFileException"/> class.
+    /// </summary>
+    public MarkingFileException()
+    {
+
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MarkingFileException"/> class.
+    /// </summary>
+    public MarkingFileException(string message)
+        : base(message)
+    {
+
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MarkingFileException"/> class.
+    /// </summary>
+    public MarkingFileException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+
+    }
 }

--- a/src/Moryx.AbstractionLayer/Drivers/Message/IMessageChannel.cs
+++ b/src/Moryx.AbstractionLayer/Drivers/Message/IMessageChannel.cs
@@ -28,6 +28,7 @@ public interface IMessageChannel
     /// </summary>
     /// <param name="payload">Message to send through the driver</param>
     /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+    /// <exception cref="DriverException">Thrown when the driver encounters an error during execution.</exception>
     /// <exception cref="DriverStateException">Thrown if the driver is in an invalid state for this operation.</exception>
     /// <exception cref="OperationCanceledException">The cancellation token was canceled. This exception is stored into the returned task.</exception>
     Task SendAsync(object payload, CancellationToken cancellationToken = default);

--- a/src/Moryx.AbstractionLayer/Drivers/PickByLight/IPickByLightDriver.cs
+++ b/src/Moryx.AbstractionLayer/Drivers/PickByLight/IPickByLightDriver.cs
@@ -14,6 +14,7 @@ public interface IPickByLightDriver : IDriver
     /// <param name="positions"></param>
     /// <param name="instruction"></param>
     /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+    /// <exception cref="DriverException">Thrown when the driver encounters an error during execution.</exception>
     /// <exception cref="DriverStateException">Thrown if the driver is in an invalid state for this operation.</exception>
     /// <exception cref="OperationCanceledException">The cancellation token was canceled. This exception is stored into the returned task.</exception>
     Task<InstructionResult> ActivateInstructionAsync(LightInstruction instruction, IReadOnlyCollection<LightPosition> positions, CancellationToken cancellationToken = default);
@@ -23,6 +24,7 @@ public interface IPickByLightDriver : IDriver
     /// </summary>
     /// <param name="positions"></param>
     /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+    /// <exception cref="DriverException">Thrown when the driver encounters an error during execution.</exception>
     /// <exception cref="DriverStateException">Thrown if the driver is in an invalid state for this operation.</exception>
     /// <exception cref="OperationCanceledException">The cancellation token was canceled. This exception is stored into the returned task.</exception>
     Task<InstructionResult> DeactivateInstructionAsync(IReadOnlyCollection<LightPosition> positions, CancellationToken cancellationToken = default);

--- a/src/Moryx.AbstractionLayer/Drivers/Rfid/IRfidDriver.cs
+++ b/src/Moryx.AbstractionLayer/Drivers/Rfid/IRfidDriver.cs
@@ -18,6 +18,7 @@ public interface IRfidDriver : IInputDriver,
     /// <param name="rfidTag">The RFID tag to be killed.</param>
     /// <param name="options">Options that define how the kill operation should be performed.</param>
     /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+    /// <exception cref="DriverException">Thrown when the driver encounters an error during execution.</exception>
     /// <exception cref="OperationCanceledException">The cancellation token was canceled. This exception is stored into the returned task.</exception>
     /// <exception cref="DriverStateException">Thrown if the driver is in an invalid state for this operation.</exception>
     Task<KillTagResult> KillTagAsync(RfidTag rfidTag, KillTagOptions options, CancellationToken cancellationToken = default);

--- a/src/Moryx.AbstractionLayer/Drivers/Scales/IWeightScaleDriver.cs
+++ b/src/Moryx.AbstractionLayer/Drivers/Scales/IWeightScaleDriver.cs
@@ -16,6 +16,7 @@ public interface IWeightScaleDriver : IInputDriver,
     /// Performs a tare operation on the weight scale, resetting its measurement to zero.
     /// </summary>
     /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+    /// <exception cref="DriverException">Thrown when the driver encounters an error during execution.</exception>
     /// <exception cref="DriverStateException">Thrown if the driver is in an invalid state for this operation.</exception>
     /// <exception cref="OperationCanceledException">The cancellation token was canceled. This exception is stored into the returned task.</exception>
     Task TaraAsync(CancellationToken cancellationToken = default);


### PR DESCRIPTION
- MarkingException, MarkingFileException and MoveAxesException could not be instantiated because of missing constructors
- Introduced general DriverException, thrown when the driver encounters an error during execution.

We could think about marking MarkingException, MarkingFileException and MoveAxesException as obsolete in 10.1 because they do not define additional properties and therefore they are useless. A classic case of releasing too quickly and not testing in the application. Remember in [MORYX 12](https://github.com/PHOENIXCONTACT/MORYX-Framework/milestone/36).