### PR TITLE
Do not throw exception if initializer returns no resources

### DIFF
--- a/src/Moryx.Resources.Management/Resources/ResourceManager.cs
+++ b/src/Moryx.Resources.Management/Resources/ResourceManager.cs
@@ -434,7 +434,9 @@ internal class ResourceManager : IResourceManager
         var result = await initializer.ExecuteAsync(Graph, parameters, CancellationToken.None);
 
         if (result.InitializedResources.Count == 0)
-            throw new InvalidOperationException("ResourceInitializer must return at least one resource");
+        {
+            return result;
+        }
 
         if (!result.Saved)
         {


### PR DESCRIPTION
There is no reason for returning resources if they are saved by the initializer itself. It was never a problem in MORYX 8 but since we can execute initializers from the facade, it throws exceptions for initializers returning no resources.