### PR TITLE
Add mqtt documentation generator resource

### DIFF
--- a/src/Moryx.Drivers.Mqtt/MqttDocumentationGenerator.cs
+++ b/src/Moryx.Drivers.Mqtt/MqttDocumentationGenerator.cs
@@ -1,0 +1,305 @@
+// Copyright (c) 2026, Phoenix Contact GmbH & Co. KG
+// Licensed under the Apache License, Version 2.0
+
+using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
+using System.Runtime.Serialization;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Text.Json.Schema;
+using System.Text.Json.Serialization;
+using System.Text.Json.Serialization.Metadata;
+using Microsoft.Extensions.Logging;
+using Moryx.AbstractionLayer.Resources;
+using Moryx.Drivers.Mqtt.Properties;
+using Moryx.Drivers.Mqtt.Topics;
+using Moryx.Serialization;
+
+namespace Moryx.Drivers.Mqtt;
+
+/// <summary>
+/// Allows automatically creating and updating a description of the published and subscribed topics of a connected MqttDriver
+/// </summary>
+[ResourceRegistration]
+[Display(Name = nameof(Strings.MqttDocumentationGenerator_DisplayName), Description = nameof(Strings.MqttDocumentationGenerator_Description), ResourceType = typeof(Strings))]
+public class MqttDocumentationGenerator : Resource
+{
+    /// <summary>
+    /// MqttDriver to collect topics from
+    /// </summary>
+    [ResourceReference(ResourceRelationType.Decorated)]
+    public MqttDriver MqttDriver { get; set; }
+
+    /// <summary>
+    /// Check when a file should be generated each time this resource is started
+    /// </summary>
+    [DataMember, EntrySerialize]
+    [Display(Name = nameof(Strings.MqttDocumentationGenerator_AutoGenerateOnStart), ResourceType = typeof(Strings))]
+    public bool AutoGenerateOnStart { get; set; }
+
+    /// <summary>
+    /// OutputPath used when documentation is generated on startup
+    /// </summary>
+    [Display(Name = nameof(Strings.MqttDocumentationGenerator_OutputPath), ResourceType = typeof(Strings))]
+    [DataMember, EntrySerialize, DefaultValue("./Schema.md")]
+    public string OutputPath { get; set; } = "./Schema.md";
+
+    /// <summary>
+    /// Generates the documentation file and writes it to the specified path;
+    /// </summary>
+    /// <param name="schemaPath"></param>
+    [EntrySerialize]
+    [Display(Name = nameof(Strings.MqttDocumentationGenerator_GenerateDocumentationFile), Description = nameof(Strings.MqttDocumentationGenerator_GenerateDocumentationFile_Description), ResourceType = typeof(Strings))]
+    public void GenerateDocumentationFile(string schemaPath)
+    {
+        if (string.IsNullOrWhiteSpace(schemaPath))
+        {
+            schemaPath = OutputPath;
+        }
+
+        var file = File.Open(schemaPath, FileMode.Create);
+        using var writer = new StreamWriter(file, Encoding.UTF8);
+        GenerateDocumentation(writer);
+    }
+
+    /// <summary>
+    /// Generates the Documentation and writes it to the provided stream
+    /// </summary>
+    /// <param name="writer"></param>
+    public void GenerateDocumentation(TextWriter writer)
+    {
+        writer.WriteLine("# Topic Structure");
+
+        writer.WriteLine("You may need a mermaid viewer to visualize. I recommend the 'Markown Preview Mermaid Support' extension for vs code");
+
+        writer.WriteLine("```mermaid");
+        GenerateMermaidGraph(writer);
+        writer.WriteLine("```");
+        writer.WriteLine();
+
+        writer.WriteLine("# Message definitions");
+        writer.WriteLine();
+        foreach (var topic in MqttDriver.Channels)
+        {
+            try
+            {
+                RenderTopicDoc(writer, topic);
+            }
+            catch (Exception)
+            {
+                writer.WriteLine($"Failed to render topic: {topic.Identifier}");
+            }
+        }
+    }
+
+    /// <inheritdoc />
+    protected override async Task OnStartAsync(CancellationToken cancellationToken)
+    {
+        await base.OnStartAsync(cancellationToken);
+        if (!AutoGenerateOnStart)
+        {
+            return;
+        }
+        if (MqttDriver is null)
+        {
+            Logger.LogWarning("MqttDocumentationGenerator not connected to a MqttDriver");
+            return;
+        }
+        try
+        {
+            GenerateDocumentationFile(OutputPath);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Failed to write schema file to {file}", OutputPath);
+        }
+    }
+
+    private static void GenerateSchemaSerializationOptions(bool enumsAsString, out JsonSerializerOptions options, out JsonSchemaExporterOptions exporterOptions)
+    {
+        options = new JsonSerializerOptions(JsonSerializerDefaults.General);
+        options.WriteIndented = true;
+        options.RespectNullableAnnotations = true;
+        options.TypeInfoResolver = new DefaultJsonTypeInfoResolver();
+
+        options.Converters.Clear();
+        if (enumsAsString)
+        {
+            options.Converters.Add(new JsonStringEnumConverter());
+            exporterOptions = new JsonSchemaExporterOptions()
+            {
+                TreatNullObliviousAsNonNullable = true,
+            };
+        }
+        else
+        {
+            exporterOptions = new JsonSchemaExporterOptions()
+            {
+                TreatNullObliviousAsNonNullable = true,
+                // Without the TransformSchemaNode integer enums would just be rendered as type integer
+                TransformSchemaNode = (context, schema) =>
+                {
+                    if (schema is not JsonObject obj)
+                    {
+                        obj = new JsonObject();
+                    }
+                    var provider =
+                        context.PropertyInfo?.AttributeProvider
+                        ?? context.TypeInfo.Type;
+
+                    var descriptionAttr = provider?
+                        .GetCustomAttributes(inherit: true)
+                        .OfType<DescriptionAttribute>()
+                        .FirstOrDefault();
+
+                    if (descriptionAttr != null)
+                    {
+                        obj["description"] = descriptionAttr.Description;
+                    }
+
+                    if (context.TypeInfo.Type.IsEnum)
+                    {
+                        var enumValues =
+                            Enum.GetValues(context.TypeInfo.Type)
+                            .Cast<object>()
+                            .Select(v => JsonValue.Create((int)v))
+                            .ToArray();
+                        var enumNames = Enum.GetNames(context.TypeInfo.Type).Select(v => JsonValue.Create(v)).ToArray();
+                        var enumArray = new JsonArray(enumValues);
+                        obj["enum"] = enumArray;
+                        obj["x-enumNames"] = new JsonArray(enumNames);
+                    }
+                    return obj;
+                }
+            };
+        }
+    }
+
+    private static void WriteJsonSchemaForType(TextWriter writer, Type messageType, bool enumsAsString)
+    {
+        GenerateSchemaSerializationOptions(enumsAsString, out var options, out var exporterOptions);
+        writer.WriteLine(options.GetJsonSchemaAsNode(messageType, exporterOptions).ToString());
+    }
+
+    private void GenerateMermaidGraph(TextWriter writer)
+    {
+        writer.WriteLine("""
+        ---
+        config:
+            theme: 'base'
+            themeVariables:
+                primaryTextColor: '#000'
+                darkMode: true
+                background: rgb(0, 0, 0)
+        ---
+        """);
+        // TODO: Consider make styling configurable
+        writer.WriteLine("graph TD;");
+        writer.WriteLine("classDef receiveRetain fill:#DAE8FC");
+        writer.WriteLine("classDef receive fill:#F8CECC");
+        writer.WriteLine("classDef publishRetain fill:#D5E8D4");
+        writer.WriteLine("classDef publish fill:#E1D5E7");
+        writer.WriteLine("classDef bidirectionalRetain fill:#bbf");
+        writer.WriteLine("classDef bidirectional fill:#bbf");
+        var idCounter = 1;
+        Stack<(string topic, int id)> previousTopics = new();
+        foreach (var topic in MqttDriver.Channels.OrderBy(t => t.Identifier))
+        {
+            var topicString = MqttDriver.Identifier + topic.Identifier;
+
+            (string topic, int id) previous;
+            while (previousTopics.TryPeek(out previous) && !topicString.StartsWith(previous.topic + '/'))
+            {
+                previousTopics.Pop();
+            }
+
+            var segments = topicString.Substring(previous.topic?.Length + 1 ?? 0).Split("/");
+            foreach (var segment in segments)
+            {
+                var segmentName = segment;//.Replace("{", @"\{").Replace("}", @"\}");
+                var newId = idCounter++;
+                if (previous.topic == null)
+                {
+                    writer.WriteLine($"A{newId}[\"{segmentName}\"];");
+                    previous = (segment, newId);
+                }
+                else
+                {
+                    writer.WriteLine($"A{previous.id} --> A{newId}[\"{segmentName}\"];");
+                    previous = (previous.topic + '/' + segment, newId);
+                }
+                previousTopics.Push(previous);
+            }
+
+            var nodeClass = topic.TopicType switch
+            {
+                TopicType.BiDirectional => "bidirectional",
+                TopicType.SubscribeOnly => "receive",
+                TopicType.PublishOnly => "publish",
+                _ => throw new NotImplementedException(),
+            };
+
+            writer.WriteLine($"class A{previous.id} {nodeClass}{(topic.Retain ? "Retain" : "")}");
+            // anchor links don't work in gitlab. See: [gitlab issue 405296](https://gitlab.com/gitlab-org/gitlab/-/issues/405296)
+            // so I removed them for now
+            // var topicLink = topicString.ToLower().Replace("/", "").Replace("{", "").Replace("}", "");
+            // writer.WriteLine($"click A{previous.id} #{topicLink}");
+        }
+    }
+
+    private void RenderTopicDoc(TextWriter writer, MqttTopic topic)
+    {
+        writer.Write("## ");
+        if (topic.Identifier is null)
+        {
+            writer.WriteLine("null topic");
+        }
+        else
+        {
+            writer.WriteLine(MqttDriver.Identifier + topic.Identifier);
+        }
+        writer.WriteLine();
+
+        if (topic.MessageType is not Type messageType)
+        {
+
+            writer.Write("Unresolved topic type");
+            writer.WriteLine(topic.MessageName);
+            writer.WriteLine();
+            return;
+        }
+
+        // TODO: support more topic types if necessary (strategy to allow rendering of custom topics?)
+        switch (topic)
+        {
+            case MqttTopicJson jsonTopic:
+                GenerateJsonTopicDoc(writer, jsonTopic, messageType);
+                break;
+            default:
+                writer.WriteLine("Topic of type {0} and message type {1}", topic.GetType().Name, messageType.Name);
+                break;
+        }
+        writer.WriteLine();
+    }
+
+    private void GenerateJsonTopicDoc(TextWriter writer, MqttTopicJson topic, Type messageType)
+    {
+        var enumsAsString = topic is MqttTopicJson tJson && tJson.EnumsAsStrings;
+
+        writer.WriteLine("```jsonc");
+        writer.WriteLine("// {0}", messageType.FullName);
+        writer.WriteLine("// kind: {0}", topic.TopicType.ToString());
+        writer.WriteLine("// retain: {0}", topic.Retain);
+        try
+        {
+            WriteJsonSchemaForType(writer, messageType, enumsAsString);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Failed to generate schema for {type}", messageType);
+            writer.WriteLine("// Failed to generate schema");
+        }
+        writer.WriteLine("```");
+    }
+}

--- a/src/Moryx.Drivers.Mqtt/Properties/Strings.Designer.cs
+++ b/src/Moryx.Drivers.Mqtt/Properties/Strings.Designer.cs
@@ -19,7 +19,7 @@ namespace Moryx.Drivers.Mqtt.Properties {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "18.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class Strings {
@@ -57,6 +57,60 @@ namespace Moryx.Drivers.Mqtt.Properties {
             }
             set {
                 resourceCulture = value;
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Auto generate documentation on startup.
+        /// </summary>
+        public static string MqttDocumentationGenerator_AutoGenerateOnStart {
+            get {
+                return ResourceManager.GetString("MqttDocumentationGenerator_AutoGenerateOnStart", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Resource that allows generating a documentation file for the topics connected to an MQTT Driver.
+        /// </summary>
+        public static string MqttDocumentationGenerator_Description {
+            get {
+                return ResourceManager.GetString("MqttDocumentationGenerator_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to MQTT Documentation Generator.
+        /// </summary>
+        public static string MqttDocumentationGenerator_DisplayName {
+            get {
+                return ResourceManager.GetString("MqttDocumentationGenerator_DisplayName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Generate documentation file.
+        /// </summary>
+        public static string MqttDocumentationGenerator_GenerateDocumentationFile {
+            get {
+                return ResourceManager.GetString("MqttDocumentationGenerator_GenerateDocumentationFile", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The path were the documentation should be placed. (Empty or whitespace uses the configured output path property).
+        /// </summary>
+        public static string MqttDocumentationGenerator_GenerateDocumentationFile_Description {
+            get {
+                return ResourceManager.GetString("MqttDocumentationGenerator_GenerateDocumentationFile_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Output path.
+        /// </summary>
+        public static string MqttDocumentationGenerator_OutputPath {
+            get {
+                return ResourceManager.GetString("MqttDocumentationGenerator_OutputPath", resourceCulture);
             }
         }
         

--- a/src/Moryx.Drivers.Mqtt/Properties/Strings.de.resx
+++ b/src/Moryx.Drivers.Mqtt/Properties/Strings.de.resx
@@ -270,4 +270,22 @@
   <data name="MqttTopic_TraceDecodedMessage_Description" xml:space="preserve">
     <value>Entscheidet, ob die dekodierte Nachricht für debugging Zwecke aufgezeichnet werden soll</value>
   </data>
+  <data name="MqttDocumentationGenerator_DisplayName" xml:space="preserve">
+    <value>MQTT Dokumentationsgenerator</value>
+  </data>
+  <data name="MqttDocumentationGenerator_Description" xml:space="preserve">
+    <value>Ressource, die es erlaubt eine Dokumentationsdatei für alle an einen MQTT Broker angeschlossenen Topics zu generieren</value>
+  </data>
+  <data name="MqttDocumentationGenerator_AutoGenerateOnStart" xml:space="preserve">
+    <value>Dokumentation automatisch beim Start erzeugen</value>
+  </data>
+  <data name="MqttDocumentationGenerator_OutputPath" xml:space="preserve">
+    <value>Ausgabepfad</value>
+  </data>
+  <data name="MqttDocumentationGenerator_GenerateDocumentationFile" xml:space="preserve">
+    <value>Dokumentationsdatei generieren</value>
+  </data>
+  <data name="MqttDocumentationGenerator_GenerateDocumentationFile_Description" xml:space="preserve">
+    <value>Pfad wo die Dokumentation abgelegt werden soll. (Leer oder Leerzeichen, um die Ausgabepfad Eigenschaft zu nutzen)</value>
+  </data>
 </root>

--- a/src/Moryx.Drivers.Mqtt/Properties/Strings.resx
+++ b/src/Moryx.Drivers.Mqtt/Properties/Strings.resx
@@ -270,4 +270,22 @@
   <data name="MqttTopic_TraceDecodedMessage_Description" xml:space="preserve">
     <value>Determines if the decoded message is stored as part of the activity span for debugging purposes</value>
   </data>
+  <data name="MqttDocumentationGenerator_DisplayName" xml:space="preserve">
+    <value>MQTT Documentation Generator</value>
+  </data>
+  <data name="MqttDocumentationGenerator_Description" xml:space="preserve">
+    <value>Resource that allows generating a documentation file for the topics connected to an MQTT Driver</value>
+  </data>
+  <data name="MqttDocumentationGenerator_AutoGenerateOnStart" xml:space="preserve">
+    <value>Auto generate documentation on startup</value>
+  </data>
+  <data name="MqttDocumentationGenerator_OutputPath" xml:space="preserve">
+    <value>Output path</value>
+  </data>
+  <data name="MqttDocumentationGenerator_GenerateDocumentationFile" xml:space="preserve">
+    <value>Generate documentation file</value>
+  </data>
+  <data name="MqttDocumentationGenerator_GenerateDocumentationFile_Description" xml:space="preserve">
+    <value>The path were the documentation should be placed. (Empty or whitespace uses the configured output path property)</value>
+  </data>
 </root>

--- a/src/Tests/Moryx.Drivers.Mqtt.Tests/MqttDocumentationGeneratorTest.cs
+++ b/src/Tests/Moryx.Drivers.Mqtt.Tests/MqttDocumentationGeneratorTest.cs
@@ -1,0 +1,59 @@
+// Copyright (c) 2026, Phoenix Contact GmbH & Co. KG
+// Licensed under the Apache License, Version 2.0
+
+using System.IO;
+using System.Text;
+using System.Text.Json.Serialization;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moryx.AbstractionLayer.TestTools;
+using Moryx.Drivers.Mqtt.Topics;
+using Moryx.Logging;
+using NUnit.Framework;
+
+namespace Moryx.Drivers.Mqtt.Tests;
+
+public class MqttDocumentationGeneratorTest
+{
+    [System.ComponentModel.Description("Example 1 class description")]
+    public class Example1
+    {
+        [JsonIgnore] // Captured from topic
+        public string Captured { get; set; }
+
+        [System.ComponentModel.Description("Example field")]
+        public string Field { get; set; }
+    }
+
+    [Test]
+    [Description("Description annotations on json objects should be included in documentation")]
+    public void GeneratedOutputContainsDocComments()
+    {
+        // Arrange
+        var sb = new StringBuilder();
+        using var writer = new StringWriter(sb);
+
+        var driver = new MqttDriver()
+        {
+            Logger = new ModuleLogger("Dummy", new NullLoggerFactory()),
+            Identifier = "BM/example/",
+            Channels = new ReferenceCollectionMock<MqttTopic>(),
+        };
+
+        driver.Channels.Add(new MqttTopicJson() { Identifier = "test/{Captured}", MessageName = nameof(Example1) });
+        driver.Channels.Add(new MqttTopicJson() { Identifier = "test/{Captured}/Subtopic", MessageName = nameof(Example1) });
+        driver.Channels.Add(new MqttTopicJson() { Identifier = "test2/+/example", MessageName = nameof(Example1) });
+        var generator = new MqttDocumentationGenerator()
+        {
+            MqttDriver = driver,
+        };
+
+        // Act
+        generator.GenerateDocumentation(writer);
+
+        // Assert
+        var result = sb.ToString();
+        using var _ = Assert.EnterMultipleScope();
+        Assert.That(result, Contains.Substring("Example field"));
+        Assert.That(result, Contains.Substring("Example 1 class description"));
+    }
+}


### PR DESCRIPTION


### Summary

<!-- 
Summarize the feature.
-->

It's designed to automatically generate up to date documentation from the Topics connected to an MQTT Driver.

It has some known limitiations:
a) It has no localization support, but I think thats ok for an engineering focused tool.
b) It only supports MqttJsonTopics natively. It would be nice to find a way to support our other topic types or even user defined topic types

### Linked Issues

<!-- 
Link to any related issues or feature requests using GitHub keywords (e.g., Closes #123).
-->

### Relevant logs and/or screenshots

<!-- 
Paste any relevant logs - please use code blocks (```) to format console output, logs, and code.

Paste images of the new features.
-->

<img width="1125" height="875" alt="image" src="https://github.com/user-attachments/assets/8347eec8-5ca6-4cb4-95d8-0d70c0708035" />


### Breaking Changes

<!-- 
Does this PR introduce any breaking changes? If yes, describe them.
-->

### Checklist for Submitter

- [x] I have tested these changes locally
- [ ] I have updated documentation as needed
- [x] I have added or updated tests as appropriate
- [x] I have used clear and descriptive commit messages

### Review

**Typical tasks**

- [ ] Merge request is well described
- [ ] Added `Obsolete` attributes if necessary
- [ ] Critical sections are *documented in code*
- [ ] *Tests* available or extended
- [ ] *Documentation* is created / updated
- [ ] Running in test environment
- [ ] *Manual* is created / updated
- [ ] Ports to other maintained versions are created

**Clean code**

- [ ] *All* unused references are removed
- [ ] Clean code rules are respected with passion (naming, ...)
- [ ] Avoid *copy and pasted* code snippets