### PR TITLE
Casting `(Func<Resource, Resource>)` to `(Func<Resource, IEnumerable<…

### DIFF
--- a/src/Moryx.AbstractionLayer/Resources/Extensions/ResourceExtensions.cs
+++ b/src/Moryx.AbstractionLayer/Resources/Extensions/ResourceExtensions.cs
@@ -32,10 +32,9 @@ public static class ResourceExtensions
         /// <returns>The first resource that occurs in the recursion to match the condition, null otherwise</returns>
         public Resource GetFirstRelatedResource(Predicate<Resource> conditionToMatch, Func<Resource, Resource> methodToNavigate)
         {
-            if (resource is null || conditionToMatch(resource))
-                return resource;
-            else
-                return GetFirstRelatedResource(methodToNavigate(resource), conditionToMatch, (Func<Resource, IEnumerable<Resource>>)methodToNavigate);
+            return resource is null || conditionToMatch(resource)
+                ? resource
+                : GetFirstRelatedResource(methodToNavigate(resource), conditionToMatch, methodToNavigate);
         }
 
         /// <summary>
@@ -51,14 +50,18 @@ public static class ResourceExtensions
         public Resource GetFirstRelatedResource(Predicate<Resource> conditionToMatch, Func<Resource, IEnumerable<Resource>> methodToNavigate)
         {
             if (resource is null || conditionToMatch(resource))
+            {
                 return resource;
+            }
             else
             {
                 foreach (var subsequentResource in methodToNavigate(resource))
                 {
                     var matchingResource = GetFirstRelatedResource(subsequentResource, conditionToMatch, methodToNavigate);
-                    if (!(matchingResource is null))
+                    if (matchingResource is not null)
+                    {
                         return matchingResource;
+                    }
                 }
 
                 return null;

--- a/src/Moryx.Resources.Samples/MountingCell.cs
+++ b/src/Moryx.Resources.Samples/MountingCell.cs
@@ -3,7 +3,6 @@
 
 using System.ComponentModel;
 using System.Runtime.Serialization;
-using Moryx.AbstractionLayer;
 using Moryx.AbstractionLayer.Drivers.Message;
 using Moryx.AbstractionLayer.Resources;
 using Moryx.Serialization;

--- a/src/Tests/Moryx.AbstractionLayer.Tests/Moryx.AbstractionLayer.Tests.csproj
+++ b/src/Tests/Moryx.AbstractionLayer.Tests/Moryx.AbstractionLayer.Tests.csproj
@@ -17,6 +17,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\Moryx.AbstractionLayer\Moryx.AbstractionLayer.csproj" />
     <ProjectReference Include="..\..\Moryx.Products.Samples\Moryx.Products.Samples.csproj" />
+    <ProjectReference Include="..\..\Moryx.Resources.Samples\Moryx.Resources.Samples.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Tests/Moryx.AbstractionLayer.Tests/ResourceExtensionsGetFirstRelatedResourceTests.cs
+++ b/src/Tests/Moryx.AbstractionLayer.Tests/ResourceExtensionsGetFirstRelatedResourceTests.cs
@@ -1,0 +1,68 @@
+// Copyright (c) 2026 Phoenix Contact GmbH & Co. KG
+// Licensed under the Apache License, Version 2.0
+
+using System.Linq;
+using Moryx.AbstractionLayer.Products;
+using Moryx.AbstractionLayer.Resources;
+using Moryx.Resources.Samples;
+using NUnit.Framework;
+
+namespace Moryx.AbstractionLayer.Tests;
+
+[TestFixture]
+public class ResourceExtensionsGetFirstRelatedResourceTests
+{
+    [Test]
+    public void WhenResourceAvailable_ReturnsFirstRelatedResource()
+    {
+        var machine = new Machine();
+        var mountingCell = new MountingCell();
+        var solderingCell = new SolderingCell();
+        machine.Parent = mountingCell;
+        mountingCell.Parent = solderingCell;
+
+        var firstRelatedResource = machine.GetFirstRelatedResource(r => r is SolderingCell, r => r.Parent);
+
+        Assert.That(firstRelatedResource, Is.SameAs(solderingCell));
+    }
+
+    [Test]
+    public void WhenNoMatchingResource_ReturnsNull()
+    {
+        var machine = new Machine();
+        var mountingCell = new MountingCell();
+        machine.Parent = mountingCell;
+        mountingCell.Parent = null;
+
+        var firstRelatedResource = machine.GetFirstRelatedResource(r => r is SolderingCell, r => r.Parent);
+
+        Assert.That(firstRelatedResource, Is.Null);
+    }
+
+    [Test]
+    public void UsingListExtension_WhenResourceInTree_ReturnsResource()
+    {
+        var machine = new Machine();
+        var mountingCell = new MountingCell();
+        var solderingCell = new SolderingCell();
+        machine.Parent = mountingCell;
+        mountingCell.Parent = solderingCell;
+
+        var firstRelatedResource = machine.GetFirstRelatedResource(r => r is SolderingCell, r => [r.Parent]);
+
+        Assert.That(firstRelatedResource, Is.SameAs(solderingCell));
+    }
+
+    [Test]
+    public void UsingListExtension_WhenNoMatchingResource_ReturnsNull()
+    {
+        var machine = new Machine();
+        var mountingCell = new MountingCell();
+        machine.Parent = mountingCell;
+        mountingCell.Parent = null;
+
+        var firstRelatedResource = machine.GetFirstRelatedResource(r => r is SolderingCell, r => [r.Parent]);
+
+        Assert.That(firstRelatedResource, Is.Null);
+    }
+}


### PR DESCRIPTION
…Resource>>)` threw exception