### PR TITLE
Usage of default database for testing database-server connections

### DIFF
--- a/src/Moryx.Model/Configuration/ModelConfiguratorBase.cs
+++ b/src/Moryx.Model/Configuration/ModelConfiguratorBase.cs
@@ -67,7 +67,7 @@ public abstract class ModelConfiguratorBase<TConfig> : IModelConfigurator
             return TestConnectionResult.ConfigurationError;
 
         // Simple ef independent database connection
-        var connectionResult = await TestDatabaseConnection(config, cancellationToken);
+        var connectionResult = await TestServerConnection(config, cancellationToken);
         if (!connectionResult)
             return TestConnectionResult.ConnectionError;
 
@@ -241,9 +241,9 @@ public abstract class ModelConfiguratorBase<TConfig> : IModelConfigurator
     public abstract Task DeleteDatabaseAsync(DatabaseConfig config, CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Generally tests the connection to the database
+    /// Generally tests the connection to the database-server. It does not check for the existence of the database itself.
     /// </summary>
-    private async Task<bool> TestDatabaseConnection(DatabaseConfig config, CancellationToken cancellationToken)
+    private async Task<bool> TestServerConnection(DatabaseConfig config, CancellationToken cancellationToken)
     {
         if (!CheckDatabaseConfig(config))
             return false;


### PR DESCRIPTION
- close #1047
- close #705

fyi @MathoMathiasCamara 

This also closes #705 there is no need for additional complexity for now. 

**Potential issues:**  

1. The "postgres" database might not exist - While it's created by default, it can be deleted. 
2. The configured user might not have CONNECT privileges on the postgres database.
4. If the user only has permissions on their application database, DeleteDatabaseAsync would fail with a permission     
  error rather than a clear message about needing access to postgres.

**Ideas for the potential issues:**

- Use template1 instead (another default database, harder to accidentally delete)
- Connect to any other existing database the user has access to                                                                                        
- Make the fallback database configurable 

If we want to improve this connection handling for our database providers, we could create a ticket for that. 