### PR TITLE
Add exception handling around all CountStrategy

### DIFF
--- a/src/Moryx.Orders.Management/Implementation/OperationData/OperationData.cs
+++ b/src/Moryx.Orders.Management/Implementation/OperationData/OperationData.cs
@@ -95,7 +95,9 @@ internal class OperationData : IOperationData, IAsyncStateContext, ILoggingCompo
             field = value;
             //Update the state of the internal operation
             if (_state is not null)
+            {
                 Operation.State = _state.GetFullClassification();
+            }
         }
     }
 
@@ -156,13 +158,17 @@ internal class OperationData : IOperationData, IAsyncStateContext, ILoggingCompo
 
         var overDeliveryAmount = context.OverDeliveryAmount;
         if (overDeliveryAmount < context.TotalAmount)
+        {
             overDeliveryAmount = context.TotalAmount;
+        }
 
         Operation.OverDeliveryAmount = overDeliveryAmount;
 
         var underDeliveryAmount = context.UnderDeliveryAmount;
         if (underDeliveryAmount > context.TotalAmount)
+        {
             underDeliveryAmount = context.TotalAmount;
+        }
 
         Operation.UnderDeliveryAmount = underDeliveryAmount;
 
@@ -270,14 +276,16 @@ internal class OperationData : IOperationData, IAsyncStateContext, ILoggingCompo
     {
         Log(LogLevel.Information, "Starting assignment");
 
-        return _stateLock.ExecuteAsync(() => _state.Assign());
+        return _stateLock.ExecuteAsync(_state.Assign);
     }
 
     /// <inheritdoc cref="IOperationData"/>
     public Task AssignCompleted(bool success)
     {
         if (success)
+        {
             Operation.CreationContext = null;
+        }
 
         return _stateLock.ExecuteAsync(() => _state.AssignCompleted(success));
     }
@@ -307,7 +315,7 @@ internal class OperationData : IOperationData, IAsyncStateContext, ILoggingCompo
     {
         Log(LogLevel.Information, "Aborting operation");
 
-        return _stateLock.ExecuteAsync(() => _state.Abort());
+        return _stateLock.ExecuteAsync(_state.Abort);
     }
 
     internal async Task HandleAbort()
@@ -359,7 +367,7 @@ internal class OperationData : IOperationData, IAsyncStateContext, ILoggingCompo
     public async Task Resume()
     {
         // Restore on state
-        await _stateLock.ExecuteAsync(() => _state.Resume());
+        await _stateLock.ExecuteAsync(_state.Resume);
     }
 
     /// <inheritdoc cref="IOperationData"/>
@@ -501,7 +509,7 @@ internal class OperationData : IOperationData, IAsyncStateContext, ILoggingCompo
     /// <inheritdoc cref="IOperationData"/>
     public AdviceContext GetAdviceContext()
     {
-        var adviceContext = _stateLock.Execute(() => _state.GetAdviceContext());
+        var adviceContext = _stateLock.Execute(_state.GetAdviceContext);
 
         return adviceContext;
     }
@@ -529,13 +537,19 @@ internal class OperationData : IOperationData, IAsyncStateContext, ILoggingCompo
         }
 
         if (orderAdvice is { Amount: <= 0 })
+        {
             ThrowError("Amount less then or equals zero cannot be adviced!");
+        }
 
         if (pickPartAdvice != null && !Operation.Parts.Contains(pickPartAdvice.Part))
+        {
             ThrowError("The part to advice is not part of the operation!");
+        }
 
         if (orderAdvice == null && pickPartAdvice == null)
+        {
             ThrowError("Advices of type " + advice.GetType().Name + " cannot be handled.");
+        }
 
         return _stateLock.ExecuteAsync(() => _state.Advice(advice));
     }
@@ -592,7 +606,7 @@ internal class OperationData : IOperationData, IAsyncStateContext, ILoggingCompo
     /// <inheritdoc cref="IOperationData"/>
     public ReportContext GetReportContext()
     {
-        var reportContext = _stateLock.Execute(() => _state.GetReportContext());
+        var reportContext = _stateLock.Execute(_state.GetReportContext);
         return reportContext;
     }
 
@@ -603,11 +617,15 @@ internal class OperationData : IOperationData, IAsyncStateContext, ILoggingCompo
 
         var unreportedFailure = Operation.Progress.ScrapCount - reportedFailure;
         if (unreportedFailure < 0)
+        {
             unreportedFailure = 0;
+        }
 
         var unreportedSuccess = Operation.Progress.SuccessCount - reportedSuccess;
         if (unreportedSuccess < 0)
+        {
             unreportedSuccess = 0;
+        }
 
         var context = GetOperationInfo<ReportContext>();
 
@@ -654,7 +672,9 @@ internal class OperationData : IOperationData, IAsyncStateContext, ILoggingCompo
             // Only update a recipe if it is part of the current recipes
             var affectedRecipe = Operation.Recipes.FirstOrDefault(r => r.Id == productRecipe.Id);
             if (affectedRecipe == null)
+            {
                 return;
+            }
 
             Operation.Recipes.Remove(affectedRecipe);
             Operation.Recipes.Add(productRecipe);
@@ -751,7 +771,9 @@ internal class OperationData : IOperationData, IAsyncStateContext, ILoggingCompo
         var scrapCount = Operation.Progress.ScrapCount;
 
         if (scrapCount < 0)
+        {
             scrapCount = 0;
+        }
 
         info.SuccessCount = successCount;
         info.ScrapCount = scrapCount;
@@ -843,7 +865,9 @@ internal class OperationData : IOperationData, IAsyncStateContext, ILoggingCompo
                 _isDispatching = false;
 
                 if (!_isDispatchingRequested)
+                {
                     return;
+                }
 
                 // Dispatch again if a dispatch was requested during the last dispatching
                 _isDispatchingRequested = false;


### PR DESCRIPTION
Add exception handling around all CountStrategy calls to prevent OrderManagement from entering a faulted state and ensure safe fallback behavior