### PR TITLE
Fix ValidateHealthState null issue by correcting facade lifecycle and base class integration

### DIFF
--- a/src/Moryx.Orders.Management/Facade/OrderManagementFacade.cs
+++ b/src/Moryx.Orders.Management/Facade/OrderManagementFacade.cs
@@ -13,7 +13,7 @@ using Newtonsoft.Json;
 
 namespace Moryx.Orders.Management;
 
-internal class OrderManagementFacade : IOrderManagement, IFacadeControl
+internal class OrderManagementFacade : FacadeBase, IOrderManagement
 {
     public IOperationDataPool OperationDataPool { get; set; }
 
@@ -27,9 +27,7 @@ internal class OrderManagementFacade : IOrderManagement, IFacadeControl
 
     public IAdviceManager AdviceManager { get; set; }
 
-    public Action ValidateHealthState { get; set; }
-
-    public void Activate()
+    public override void Activate()
     {
         OperationDataPool.OperationStarted += OnOperationStarted;
         OperationDataPool.OperationInterrupted += OnOperationInterrupted;
@@ -43,10 +41,14 @@ internal class OrderManagementFacade : IOrderManagement, IFacadeControl
 
         OperationManager.BeginRequest += OnOperationBeginRequest;
         OperationManager.ReportRequest += OnOperationReportRequest;
+
+        base.Activate();
     }
 
-    public void Deactivate()
+    public override void Deactivate()
     {
+        base.Deactivate();
+
         OperationDataPool.OperationStarted -= OnOperationStarted;
         OperationDataPool.OperationInterrupted -= OnOperationInterrupted;
         OperationDataPool.OperationCompleted -= OnOperationCompleted;


### PR DESCRIPTION
**Description**
In OrderManagement, the [OrderManagementFacade ](https://github.com/PHOENIXCONTACT/MORYX-Framework/blob/fix/facade-lifecycle-validatehealthstate-null/src/Moryx.Orders.Management/Facade/OrderManagementFacade.cs)exposed ValidateHealthState as null during early calls from external endpoints (e.g., Factory Monitor) that resolve the facade via its interface before the facade is activated. This leads to a `NullReferenceException `on the first method invocation.
As a precedent, the ProcessEngine’s [ModuleController ](https://github.com/PHOENIXCONTACT/MORYX-Framework/blob/fix/facade-lifecycle-validatehealthstate-null/src/Moryx.Orders.Management/ModuleController/ModuleController.cs)activates its facades first, preventing this issue; [OrderManagement ](https://github.com/PHOENIXCONTACT/MORYX-Framework/blob/fix/facade-lifecycle-validatehealthstate-null/src/Moryx.Orders.Management/Facade/OrderManagementFacade.cs) behaved differently.

### **Already changed**

- Updated the facade to inherit correctly from[ FacadeBase](https://github.com/PHOENIXCONTACT/MORYX-Framework/blob/fix/facade-lifecycle-validatehealthstate-null/src/Moryx.Runtime/Modules/FacadeBase.cs).
- Removed the redundant ValidateHealthState property.
- Converted Activate() and Deactivate() to proper overrides and added the required base calls.

### **What still needs to be done**
- How should the activation order be handled in the module controller?
- Should the OrderManagement facade follow the same activation pattern as the ProcessEngine?