### PR TITLE
Fix: Cells and FixupCells not rendered correctly in FactoryMonitor

### DIFF
--- a/src/Moryx.FactoryMonitor.Endpoints/Models/SimpleGraph.cs
+++ b/src/Moryx.FactoryMonitor.Endpoints/Models/SimpleGraph.cs
@@ -61,7 +61,7 @@ internal class SimpleGraph
             }
 
             var resourcesAtThisLocation = resource.Children.Where(x => x is ICell || x is IManufacturingFactory).ToArray();
-            if(resourcesAtThisLocation.Length == 0 && resource is ICell)
+            if(resource is ICell)
             {
                 resourcesAtThisLocation = [resource];
             }


### PR DESCRIPTION
### **Summary**
Fix incorrect rendering of Cells and implementations of IMachineLocation in FactoryMonitor

In the FactoryMonitor, Cells and implementations of IMachineLocation were not displayed.

The underlying cause was that [SimpleGraph.ToVisualItemModel](https://github.com/PHOENIXCONTACT/MORYX-Framework/blob/e70ba74f6b7a6cce6c61efae496c3e499563bb79/src/Moryx.FactoryMonitor.Endpoints/Models/SimpleGraph.cs#L51) only processed concrete types (MachineLocation, Cell, ManufacturingFactory) and expected Cells exclusively as child resources of a location.
These conditions were not met, if anyone implemented their own IMachineLocation. As a result, the visualization step returned null for valid Cells, which removed them from the UI.

This PR updates the resource resolution logic so that Cells and FixupCells are correctly detected and visualized.

### **Details**

**Use IMachineLocation instead of MachineLocation**

- The previous implementation returned null when resource was not a concrete MachineLocation
- The updated code checks for IMachineLocation, which matches the current runtime type of location resources

**Updated resource filtering**
- Originally, only child resources of type Cell or ManufacturingFactory were accepted
- In cases where a location had no such children but was itself a Cell, the method returned an error

**The updated logic handles both cases:**

- It filters children for ICell and IManufacturingFactory
- If no matching children exist and the resource itself implements ICell, the resource is selected directly

### Result
**After applying these changes:**
- Cells that also implement IMachineLocation are rendered in the FactoryMonitor
- Custom implementations of IMachineLocation are rendered
- Locations without relevant children no longer cause incorrect null returns
