### PR TITLE
Added extension to register internal launcher dependencies

### DIFF
--- a/docs/articles/launcher/launcher.md
+++ b/docs/articles/launcher/launcher.md
@@ -1,5 +1,13 @@
 # Launcher
 
+## Usage
+
+To register the launcher to your application use the `AddMoryxLauncher()` extension on the service collection. It registers all required components to use the Launcher.
+
+```csharp
+services.AddMoryxLauncher();
+```
+
 ## Configuration
 
 The launcher generates a config file named `Moryx.Launcher.LauncherConfig.json` in your configuration directory. This file contains settings for the launcher, including module sort-indices and external modules.

--- a/src/Moryx.Launcher/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Moryx.Launcher/Extensions/ServiceCollectionExtensions.cs
@@ -1,0 +1,24 @@
+// Copyright (c) 2026 Phoenix Contact GmbH & Co. KG
+// Licensed under the Apache License, Version 2.0
+
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Moryx.Launcher;
+
+/// <summary>
+/// Extension methods for setting up MORYX Launcher services in an <see cref="IServiceCollection" />.
+/// </summary>
+public static class ServiceCollectionExtensions
+{
+    /// <summary>
+    /// Adds services required for application localization.
+    /// </summary>
+    /// <param name="services">The <see cref="IServiceCollection" /> to add the services to.</param>
+    /// <returns>>The <see cref="IServiceCollection"/> so that additional calls can be chained.</returns>
+    public static IServiceCollection AddMoryxLauncher(this IServiceCollection services)
+    {
+        services.AddSingleton<IShellNavigator, ShellNavigator>();
+
+        return services;
+    }
+}

--- a/src/Moryx.Launcher/Moryx.Launcher.csproj.DotSettings
+++ b/src/Moryx.Launcher/Moryx.Launcher.csproj.DotSettings
@@ -1,2 +1,3 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
-	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=config/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=config/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=extensions/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/src/StartProject.Asp/Startup.cs
+++ b/src/StartProject.Asp/Startup.cs
@@ -25,8 +25,7 @@ public class Startup
     // This method is optional for the Startup class.
     public void ConfigureServices(IServiceCollection services)
     {
-
-        services.AddSingleton<IShellNavigator, ShellNavigator>();
+        services.AddMoryxLauncher();
 
         services.AddLocalization();
 


### PR DESCRIPTION
Launcher components can be internal because they are only used inside of the launcher. To keep flexibility in changes, added an extension so register internal components of the launcher. 

`IShellNavigator` and the implementation can be internal now in MORYX: