### PR TITLE
Add missing Converter to  the JsonConverter options

### DIFF
--- a/docs/articles/mqtt/resource-synchronization.md
+++ b/docs/articles/mqtt/resource-synchronization.md
@@ -30,12 +30,9 @@
 
     ```csharp
     // Program.cs
-    builder.Services.AddTransient<ResourceToJsonConvert>(); // Required
     builder.Services.AddMqttClient((provider, options) =>
     {
         // Json Serialization options
-        var resourceJsonConverter = provider.GetRequiredService<ResourceToJsonConverter>();
-        options.JsonSerializerOptions.Converters.Add(resourceJsonConverter);
         options.JsonSerializerOptions.ReferenceHandler = ReferenceHandler.IgnoreCycles;
         options.DefaultTopicStrategy.NoLocal = true; // optional
         options.DefaultTopicStrategy.RetainAsPublished = true; // optional

--- a/src/Moryx.AbstractionLayer.Resources.Mqtt.Endpoints/ResourceSynchronizationService.cs
+++ b/src/Moryx.AbstractionLayer.Resources.Mqtt.Endpoints/ResourceSynchronizationService.cs
@@ -8,7 +8,6 @@ using System.Text.Json;
 using Microsoft.Extensions.Logging;
 using Moryx.AbstractionLayer.Identity;
 using Moryx.AbstractionLayer.Resources.Attributes;
-using Moryx.AspNetCore.Mqtt;
 using Moryx.AspNetCore.Mqtt.Builders;
 using Moryx.AspNetCore.Mqtt.Components;
 using Moryx.AspNetCore.Mqtt.Converters;
@@ -52,6 +51,7 @@ public class ResourceSynchronizationService : IMqttService
         _client = client;
         _logger = logger;
         _options = options;
+        EnsureResourceConverterAdded();
     }
 
     #region IHostedService
@@ -165,6 +165,14 @@ public class ResourceSynchronizationService : IMqttService
 
                 return Task.CompletedTask;
             });
+        }
+    }
+
+    private void EnsureResourceConverterAdded()
+    {
+        if (!_options.JsonSerializerOptions.Converters.Any(x => x is ResourceToJsonConverter))
+        {
+            _options.JsonSerializerOptions.Converters.Add(new ResourceToJsonConverter(_resourceManagement));
         }
     }
 


### PR DESCRIPTION
## Problem
The resource synchronization is not working because the `ResourceToJsonConverter` is not used by the JsonSerializer.

## Solution
By default the Converter option is empty unless the user defined custom converters . I added the `ResourceToJsonConverter` to the options in constructor to make sure if the user doesn't use a custom converter it will be the default.