### PR TITLE
Limit module notifications being returned

### DIFF
--- a/src/Moryx.Runtime.Endpoints/Modules/Endpoint/ModulesController.cs
+++ b/src/Moryx.Runtime.Endpoints/Modules/Endpoint/ModulesController.cs
@@ -48,11 +48,7 @@ namespace Moryx.Runtime.Endpoints.Modules.Endpoint
             var models = new List<ServerModuleModel>(_moduleManager.AllModules.Count());
             foreach (var module in _moduleManager.AllModules)
             {
-                const int MaxNotificationsPerPage = 100;
-                var notifications = module.Notifications
-                    .TakeLast(MaxNotificationsPerPage)
-                    .OrderByDescending(n => n.Timestamp)
-                    .ToArray();
+                var notifications = module.Notifications.ToArray();
 
                 var model = new ServerModuleModel
                 {

--- a/src/Moryx.Runtime/Modules/ServerNotificationCollection.cs
+++ b/src/Moryx.Runtime/Modules/ServerNotificationCollection.cs
@@ -3,6 +3,7 @@
 
 using System.Collections;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using System.Linq;
 using Moryx.Modules;
@@ -11,7 +12,8 @@ namespace Moryx.Runtime.Modules
 {
     internal class ServerNotificationCollection : INotificationCollection
     {
-        private readonly List<IModuleNotification> _internalList = new List<IModuleNotification>();
+        private const int MaxCollectionSize = 2500;
+        private readonly Collection<IModuleNotification> _internalList = new Collection<IModuleNotification>();
         private readonly object _lockObj = new object();
 
         // ReSharper disable once InconsistentlySynchronizedField
@@ -32,10 +34,23 @@ namespace Moryx.Runtime.Modules
 
         public void Add(IModuleNotification item)
         {
+            IModuleNotification removedItem = null;
             lock (_lockObj)
+            {
                 _internalList.Add(item);
-
+                if (_internalList.Count > MaxCollectionSize) ;
+                {
+                    removedItem = _internalList.First();
+                    _internalList.Remove(removedItem);
+                }
+            }
+            
             CollectionChanged?.Invoke(this, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, item));
+
+            if (removedItem != null)
+            {
+                CollectionChanged?.Invoke(this, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Remove, item));
+            }
         }
 
         public void Clear()


### PR DESCRIPTION
Limit module notifications being returned by the `ModulesController` to 100. If there are 'too many' notifications, that could possibly shut the application down.
While there would be some sort of pagination necessary to properly browse all notifications, it's probably fine to expose the latest 100 only.