### PR TITLE
Port #1140: Limit module notifications 

### DIFF
--- a/src/Moryx.Runtime/Modules/ServerNotificationCollection.cs
+++ b/src/Moryx.Runtime/Modules/ServerNotificationCollection.cs
@@ -11,8 +11,8 @@ namespace Moryx.Runtime.Modules;
 internal class ServerNotificationCollection : INotificationCollection
 {
     private const int MaxCollectionSize = 2500;
-    private readonly Collection<IModuleNotification> _internalList = new Collection<IModuleNotification>();
-    private readonly object _lockObj = new();
+    private readonly Collection<IModuleNotification> _internalList = [];
+    private readonly Lock _lockObj = new();
 
     // ReSharper disable once InconsistentlySynchronizedField
     public int Count => _internalList.Count;
@@ -23,7 +23,9 @@ internal class ServerNotificationCollection : INotificationCollection
     {
         List<IModuleNotification> copy;
         lock (_lockObj)
+        {
             copy = _internalList.ToList();
+        }
 
         return copy.GetEnumerator();
     }
@@ -36,7 +38,7 @@ internal class ServerNotificationCollection : INotificationCollection
         lock (_lockObj)
         {
             _internalList.Add(item);
-            if (_internalList.Count > MaxCollectionSize) ;
+            if (_internalList.Count > MaxCollectionSize)
             {
                 removedItem = _internalList.First();
                 _internalList.Remove(removedItem);
@@ -54,7 +56,9 @@ internal class ServerNotificationCollection : INotificationCollection
     public void Clear()
     {
         lock (_lockObj)
+        {
             _internalList.Clear();
+        }
 
         CollectionChanged?.Invoke(this, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset));
     }
@@ -63,7 +67,9 @@ internal class ServerNotificationCollection : INotificationCollection
     {
         bool contains;
         lock (_lockObj)
+        {
             contains = _internalList.Contains(item);
+        }
 
         return contains;
     }
@@ -71,14 +77,18 @@ internal class ServerNotificationCollection : INotificationCollection
     public void CopyTo(IModuleNotification[] array, int arrayIndex)
     {
         lock (_lockObj)
+        {
             _internalList.CopyTo(array, arrayIndex);
+        }
     }
 
     public bool Remove(IModuleNotification item)
     {
         bool removed;
         lock (_lockObj)
+        {
             removed = _internalList.Remove(item);
+        }
 
         CollectionChanged?.Invoke(this, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Remove, item));
         return removed;


### PR DESCRIPTION
To not exceed memory with too many notifications over time, that are usually
created through logging errors and warnings, the notifications collection now
acts as a ringbuffer, limited to 5000 entries.

This change is breaking bevaviour in the way, that it changes the expected
output. But as discussed, that should be considered less an issue than having
an application to crash.