### PR TITLE
Resolve several issues with user interactions in the products web UI

### DIFF
--- a/src/Moryx.Products.Web/app/src/app/app-guard.ts
+++ b/src/Moryx.Products.Web/app/src/app/app-guard.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2026 Phoenix Contact GmbH & Co. KG
+ * Licensed under the Apache License, Version 2.0
+*/
+
+import { inject } from '@angular/core';
+import { CanActivateFn, RedirectCommand, Router } from '@angular/router';
+import { SessionService } from './services/session.service';
+
+/**
+ * Verifies if there is a work in progress product in the session storage and redirects
+ * to the details view of this product to continue work, if there is one.
+ *
+ * @returns true if there is no work in progress product, a RedirectCommand otherwise.
+ */
+export const WorkInProgressGuard: CanActivateFn = () => {
+  const sessionService = inject(SessionService);
+  const router = inject(Router);
+
+  const workInProgress = sessionService.getWipProduct();
+  if (workInProgress) {
+    return new RedirectCommand(router.parseUrl(`/details/${workInProgress.product.id}`));
+  }
+
+  return true;
+};

--- a/src/Moryx.Products.Web/app/src/app/app.config.ts
+++ b/src/Moryx.Products.Web/app/src/app/app.config.ts
@@ -9,7 +9,7 @@ import { FormsModule, ReactiveFormsModule } from "@angular/forms";
 import { MatButtonModule } from "@angular/material/button";
 import { MatCardModule } from "@angular/material/card";
 import { MatCheckboxModule } from "@angular/material/checkbox";
-import { MatDialogModule } from "@angular/material/dialog";
+import { MatDialogModule, MAT_DIALOG_DEFAULT_OPTIONS } from "@angular/material/dialog";
 import { MatExpansionModule } from "@angular/material/expansion";
 import { MatFormFieldModule } from "@angular/material/form-field";
 import { MatIconModule } from "@angular/material/icon";
@@ -79,6 +79,13 @@ export const appConfig: ApplicationConfig = {
       }),
       fallbackLang: 'en'
     }),
+    {
+      provide: MAT_DIALOG_DEFAULT_OPTIONS,
+      useValue: {
+        maxWidth: 'min(560px, 95vw)',
+        maxHeight: '90vh'
+      }
+    },
     provideAnimationsAsync(),
   ],
 };

--- a/src/Moryx.Products.Web/app/src/app/app.html
+++ b/src/Moryx.Products.Web/app/src/app/app.html
@@ -97,7 +97,7 @@
                 matTooltipShowDelay="500"
                 type="button"
                 (click)="onEdit()"
-                [disabled]="editDisabled()"
+                [disabled]="!selected()"
               >
                 <mat-icon>edit</mat-icon>
               </button>
@@ -167,7 +167,7 @@
         </mat-toolbar>
       }
 
-      @if (!importDisabled()) {
+      @if (!isEditMode()) {
         <button
           mat-fab
           color="primary"

--- a/src/Moryx.Products.Web/app/src/app/app.routes.ts
+++ b/src/Moryx.Products.Web/app/src/app/app.routes.ts
@@ -14,6 +14,8 @@ import { ProductsDetailsView } from "./components/products-details-view/products
 import { ProductsImporter } from "./components/products-importer/products-importer";
 import { SearchResult } from "./components/search-result/search-result";
 import { ProductsDetailsViewResolver } from "./components/products-details-view/products-details-view-resolver";
+import { WorkInProgressGuard } from "./app-guard";
+import { ProductReferencesResolver } from "./components/products-details-view/product-references/products-references-resolver";
 
 export const routes: Routes = [
   {
@@ -25,7 +27,7 @@ export const routes: Routes = [
     children: [
       { path: '', redirectTo: 'properties', pathMatch: 'full' },
       { path: 'properties', component: ProductProperties },
-      { path: 'references', component: ProductReferences },
+      { path: 'references', component: ProductReferences, resolve: { references: ProductReferencesResolver } },
       {
         path: 'parts/:partName/:partId',
         component: ProductParts,
@@ -40,7 +42,7 @@ export const routes: Routes = [
       },
     ],
   },
-  { path: '', component: DefaultView, pathMatch: 'full' },
+  { path: '', component: DefaultView, pathMatch: 'full', canActivate: [WorkInProgressGuard] },
   { path: 'import/:importer', component: ProductsImporter },
   { path: 'search', component: SearchResult }
 ]

--- a/src/Moryx.Products.Web/app/src/app/app.routes.ts
+++ b/src/Moryx.Products.Web/app/src/app/app.routes.ts
@@ -18,6 +18,7 @@ import { WorkInProgressGuard } from "./app-guard";
 import { ReferencesResolver } from "./components/products-details-view/product-references/references-resolver";
 import { RecipeResolver } from "./components/products-details-view/product-recipes/product-recipes-details/recipe-resolver";
 import { PartsResolver } from "./components/products-details-view/product-parts/part-resolver";
+import { CancellationComponent } from "./components/cancellation/cancellation.component";
 
 export const routes: Routes = [
   {
@@ -43,5 +44,6 @@ export const routes: Routes = [
   },
   { path: '', component: DefaultView, pathMatch: 'full', canActivate: [WorkInProgressGuard] },
   { path: 'import/:importer', component: ProductsImporter },
-  { path: 'search', component: SearchResult }
+  { path: 'search', component: SearchResult },
+  { path: 'cancel', component: CancellationComponent }
 ]

--- a/src/Moryx.Products.Web/app/src/app/app.routes.ts
+++ b/src/Moryx.Products.Web/app/src/app/app.routes.ts
@@ -13,22 +13,22 @@ import { ProductReferences } from "./components/products-details-view/product-re
 import { ProductsDetailsView } from "./components/products-details-view/products-details-view";
 import { ProductsImporter } from "./components/products-importer/products-importer";
 import { SearchResult } from "./components/search-result/search-result";
-import { ProductsDetailsViewResolver } from "./components/products-details-view/products-details-view-resolver";
+import { ProductResolver } from "./components/products-details-view/products-resolver";
 import { WorkInProgressGuard } from "./app-guard";
-import { ProductReferencesResolver } from "./components/products-details-view/product-references/products-references-resolver";
-import { RecipeDetailsViewResolver as RecipeResolver } from "./components/products-details-view/product-recipes/product-recipes-details/recipe-details-view-resolver";
+import { ReferencesResolver } from "./components/products-details-view/product-references/references-resolver";
+import { RecipeResolver } from "./components/products-details-view/product-recipes/product-recipes-details/recipe-resolver";
 
 export const routes: Routes = [
   {
     path: 'details/:id',
     component: ProductsDetailsView,
     resolve: {
-      product: ProductsDetailsViewResolver
+      product: ProductResolver
     },
     children: [
       { path: '', redirectTo: 'properties', pathMatch: 'full' },
       { path: 'properties', component: ProductProperties },
-      { path: 'references', component: ProductReferences, resolve: { references: ProductReferencesResolver } },
+      { path: 'references', component: ProductReferences, resolve: { references: ReferencesResolver } },
       {
         path: 'parts/:partName/:partId',
         component: ProductParts,
@@ -38,7 +38,6 @@ export const routes: Routes = [
         component: ProductRecipes,
         children: [
           { path: '', component: DefaultView, pathMatch: 'full' },
-          // ToDo: Unify resolver names
           { path: ':recipeId', component: ProductRecipesDetails, resolve: { references: RecipeResolver } },
         ],
       },

--- a/src/Moryx.Products.Web/app/src/app/app.routes.ts
+++ b/src/Moryx.Products.Web/app/src/app/app.routes.ts
@@ -17,6 +17,7 @@ import { ProductResolver } from "./components/products-details-view/products-res
 import { WorkInProgressGuard } from "./app-guard";
 import { ReferencesResolver } from "./components/products-details-view/product-references/references-resolver";
 import { RecipeResolver } from "./components/products-details-view/product-recipes/product-recipes-details/recipe-resolver";
+import { PartsResolver } from "./components/products-details-view/product-parts/part-resolver";
 
 export const routes: Routes = [
   {
@@ -29,10 +30,7 @@ export const routes: Routes = [
       { path: '', redirectTo: 'properties', pathMatch: 'full' },
       { path: 'properties', component: ProductProperties },
       { path: 'references', component: ProductReferences, resolve: { references: ReferencesResolver } },
-      {
-        path: 'parts/:partName/:partId',
-        component: ProductParts,
-      },
+      { path: 'parts/:partName/:partId', component: ProductParts, resolve: { references: PartsResolver }},
       {
         path: 'recipes',
         component: ProductRecipes,

--- a/src/Moryx.Products.Web/app/src/app/app.routes.ts
+++ b/src/Moryx.Products.Web/app/src/app/app.routes.ts
@@ -16,6 +16,7 @@ import { SearchResult } from "./components/search-result/search-result";
 import { ProductsDetailsViewResolver } from "./components/products-details-view/products-details-view-resolver";
 import { WorkInProgressGuard } from "./app-guard";
 import { ProductReferencesResolver } from "./components/products-details-view/product-references/products-references-resolver";
+import { RecipeDetailsViewResolver as RecipeResolver } from "./components/products-details-view/product-recipes/product-recipes-details/recipe-details-view-resolver";
 
 export const routes: Routes = [
   {
@@ -37,7 +38,8 @@ export const routes: Routes = [
         component: ProductRecipes,
         children: [
           { path: '', component: DefaultView, pathMatch: 'full' },
-          { path: ':recipeId', component: ProductRecipesDetails },
+          // ToDo: Unify resolver names
+          { path: ':recipeId', component: ProductRecipesDetails, resolve: { references: RecipeResolver } },
         ],
       },
     ],

--- a/src/Moryx.Products.Web/app/src/app/app.ts
+++ b/src/Moryx.Products.Web/app/src/app/app.ts
@@ -288,14 +288,6 @@ export class App implements OnInit, OnDestroy {
     }
   }
 
-  importDisabled(): boolean {
-    return this.isEditMode();
-  }
-
-  editDisabled() {
-    return !this.selected();
-  }
-
   saveDisabled(): boolean {
     const anyUnsetRecipes = this.selected()?.recipes?.some((r) => r.classification === RecipeClassificationModel.Unset);
 
@@ -403,8 +395,8 @@ export class App implements OnInit, OnDestroy {
     const product = this.products().find((p) => p.id === id);
     if (product) {
       this.router
-        .navigate([`details/${product.id}`], {relativeTo: this.route})
-        .then(() => this.editService.loadProduct());
+        .navigate([`details/${id}`], {relativeTo: this.route})
+        .then(() => this.editService.loadProductById(id));
     } else this.router.navigate([``]);
   }
 
@@ -501,8 +493,8 @@ export class App implements OnInit, OnDestroy {
       this.editService.onEdit();
     } else {
       this.router
-        .navigate([`/details/${product.id}`])
-        .then(() => this.editService.loadProduct())
+        .navigate([`/details/${id}`])
+        .then(() => this.editService.loadProductById(id))
         .then(() => {
           this.editService.onEdit();
         });

--- a/src/Moryx.Products.Web/app/src/app/app.ts
+++ b/src/Moryx.Products.Web/app/src/app/app.ts
@@ -6,6 +6,7 @@
 import { FlatTreeControl } from "@angular/cdk/tree";
 import {
   Component,
+  computed,
   inject,
   OnDestroy,
   OnInit,
@@ -96,7 +97,7 @@ export class App implements OnInit, OnDestroy {
   private translateService = inject(TranslateService);
 
   isEditMode = toSignal(this.editService.edit$, { initialValue: false });
-  selected = signal<ProductModel | undefined>(undefined);
+  selected = computed(() => this.products()?.find((p) => p.id === this.editService.currentProductId()));
   products = signal<ProductModel[]>([]);
   productDefinitions = signal<ProductDefinitionModel[]>([]);
   hierarchic = signal(false);
@@ -151,23 +152,9 @@ export class App implements OnInit, OnDestroy {
         this.importer.set(importers[0].name!);
     });
 
-    this.editService.currentProduct.subscribe((product) => {
-      this.selected.set(product);
-    });
-
-    this.router.events.subscribe((e) => {
-      if (e instanceof NavigationEnd) this.selectCurrentProduct();
-    });
-
+    // ToDo: MOve to route resolver for base path
     this.cacheService.loadConfiguration();
     this.cacheService.loadProductsForTree();
-
-    const wipProduct = this.sessionService.getWipProduct();
-    if (wipProduct) {
-      this.editService.loadFromStorage();
-    } else {
-      this.editService.loadProduct();
-    }
 
     this.searchbar.subscribe({
       next: (result: SearchRequest) => {
@@ -189,7 +176,7 @@ export class App implements OnInit, OnDestroy {
       if (products.length > 1)
         this.router.navigate(["search"], {queryParams: {q: searchterm}});
       else if (products.length === 1)
-        this.routeToAnotherProductOnSelect(products[0].id ?? 0);
+        this.router.navigate(['/details', products[0].id ?? 0]);
       this.searchbar.subscribe({
         next: (newRequest: SearchRequest) => {
           this.onSearch(newRequest);
@@ -277,13 +264,13 @@ export class App implements OnInit, OnDestroy {
   }
 
   beforeUnloadHander() {
-    if (this.isEditMode() && this.selected()) {
-      this.sessionService.setWipProduct(this.selected()!, <ProductStorageDetails>{
+    const product = this.selected();
+    if (this.isEditMode() && product) {
+      this.sessionService.pushWipProduct(product, <ProductStorageDetails>{
         currentPartId: this.editService.currentPartId,
         currentRecipeNumber: this.editService.currentRecipeNumber,
         maximumAlreadySavedPartId: this.editService.maximumAlreadySavedPartId,
-        maximumAlreadySavedRecipeId:
-        this.editService.maximumAlreadySavedRecipeId
+        maximumAlreadySavedRecipeId: this.editService.maximumAlreadySavedRecipeId
       });
     }
   }
@@ -365,7 +352,7 @@ export class App implements OnInit, OnDestroy {
   async onDeselect() {
     if (this.isEditMode())
       await this.onCancel();
-    this.editService.unloadProduct();
+    this.editService.resetProduct();
   }
 
   onSelect(id: number) {
@@ -375,42 +362,11 @@ export class App implements OnInit, OnDestroy {
 
     if (id === this.selected()?.id) return;
 
-    const url = this.router.url;
-    const regexSpecificRecipe: RegExp = /(details\/\d*\/recipes\/\d*)/;
-    const regexParts: RegExp = /(details\/\d*\/parts)/;
-    if (regexSpecificRecipe.test(url) || regexParts.test(url)) {
-      this.router.navigate(["../../"], {relativeTo: this.route}).then(() => {
-        this.routeToAnotherProductOnSelect(id);
-      });
-    } else {
-      this.routeToAnotherProductOnSelect(id);
-    }
+    this.router.navigate(['/details', id]);
   }
 
   onOpenContextMenu(event: any, id: number) {
     this.open(event.pointers[0].clientX, event.pointers[0].clientY, id);
-  }
-
-  private routeToAnotherProductOnSelect(id: number) {
-    const product = this.products().find((p) => p.id === id);
-    if (product) {
-      this.router
-        .navigate([`details/${id}`], {relativeTo: this.route})
-        .then(() => this.editService.loadProductById(id));
-    } else this.router.navigate([``]);
-  }
-
-  selectCurrentProduct() {
-    const url = this.router.url;
-    const regexId: RegExp = /(details\/\d*)/;
-    if (!regexId.test(url)) {
-      this.selected.set(undefined);
-      return;
-    }
-
-    const id = Number(url.split("/")[2]);
-    if (this.selected()?.id != id)
-      this.selected.set(this.products()?.find((p) => p.id === id));
   }
 
   clickContainer(event: MouseEvent) {
@@ -435,7 +391,7 @@ export class App implements OnInit, OnDestroy {
       if (productToBeDeleted) {
         const actualProduct = productToBeDeleted();
         await this.cacheService.deleteProduct(actualProduct);
-        this.editService.unloadProduct();
+        this.editService.resetProduct();
       }
     });
   }
@@ -483,22 +439,16 @@ export class App implements OnInit, OnDestroy {
   }
 
   onSelectAndEdit(id: number) {
-    const product = this.products().find((p) => p.id == id);
     this.searchbar.clearSuggestions();
     this.searchbar.unsubscribe();
-    if (id == 0 || product === undefined) {
+
+    if (this.editService.currentProductId() === id) {
+      this.editService.onEdit();
       return;
     }
-    if (this.selected()?.id === id) {
-      this.editService.onEdit();
-    } else {
-      this.router
-        .navigate([`/details/${id}`])
-        .then(() => this.editService.loadProductById(id))
-        .then(() => {
-          this.editService.onEdit();
-        });
-    }
+
+    this.router.navigate(['/details', id])
+      .then(() => this.editService.onEdit());
   }
 
   onDuplicate(id: number | undefined) {

--- a/src/Moryx.Products.Web/app/src/app/app.ts
+++ b/src/Moryx.Products.Web/app/src/app/app.ts
@@ -185,7 +185,7 @@ export class App implements OnInit, OnDestroy {
     } else {
       const searchSuggestions = [] as SearchSuggestion[];
       for (let product of products) {
-        //TODO: change this in MORYX 10
+        //TODO: change this in MORYX 12
         const url = "Products/details/" + product.id; // <= BAD, hard coding a parent url 'Products' is no reliable.
         if (!product.id) continue;
 

--- a/src/Moryx.Products.Web/app/src/app/app.ts
+++ b/src/Moryx.Products.Web/app/src/app/app.ts
@@ -103,7 +103,7 @@ export class App implements OnInit, OnDestroy {
   hierarchic = signal(false);
   revisionOptions = signal<string[]>(Object.keys(RevisionFilter));
   selectorOptions = signal<string[]>(Object.keys(Selector));
-  importer = signal<string | undefined>(undefined);
+  importers = toSignal(this.cacheService.importers$, { initialValue: [] });
   menuTopLeftPosition = signal<{ x: String, y: String }>({x: '0', y: '0'});
   trigger = viewChild.required(MatMenuTrigger);
 
@@ -145,11 +145,6 @@ export class App implements OnInit, OnDestroy {
     this.cacheService.definitions.subscribe((definitions) => {
       this.productDefinitions.set(definitions ?? []);
       this.createDatasource(this.hierarchic());
-    });
-
-    this.cacheService.importers.subscribe((importers) => {
-      if (importers && importers.length > 0 && importers[0].name)
-        this.importer.set(importers[0].name!);
     });
 
     // ToDo: MOve to route resolver for base path
@@ -349,10 +344,12 @@ export class App implements OnInit, OnDestroy {
     this.trigger().openMenu();
   }
 
-  async onDeselect() {
-    if (this.isEditMode())
-      await this.onCancel();
+  async onDeselect() {    
+    if (this.isEditMode()) {
+      await this.editService.onCancel();
+    }
     this.editService.resetProduct();
+    await this.router.navigate([``]);
   }
 
   onSelect(id: number) {
@@ -369,13 +366,11 @@ export class App implements OnInit, OnDestroy {
     this.open(event.pointers[0].clientX, event.pointers[0].clientY, id);
   }
 
-  clickContainer(event: MouseEvent) {
-    if ((event.target as HTMLElement).tagName === "MAT-TREE") {
-      this.snackBar.dismiss();
-      this.router
-        .navigate([``], {relativeTo: this.route})
-        .then(() => this.editService.onCancel());
+  async clickContainer(event: MouseEvent) {
+    if ((event.target as HTMLElement).tagName !== "MAT-TREE") {
+      return;
     }
+    this.onDeselect();
   }
 
   onDelete(id: number | undefined) {
@@ -397,10 +392,10 @@ export class App implements OnInit, OnDestroy {
   }
 
   async onImport() {
-    if (this.importer()) {
-      this.router.navigate([`/import/${this.importer()}`], {
-        relativeTo: this.route
-      });
+    const importers = this.importers();
+    const target = importers?.length ? importers[0].name : undefined;
+    if (target) {
+      this.router.navigate(['import', target]);
     } else {
       const translations = await this.getTranslations();
       this.snackBar.open(

--- a/src/Moryx.Products.Web/app/src/app/app.ts
+++ b/src/Moryx.Products.Web/app/src/app/app.ts
@@ -97,7 +97,7 @@ export class App implements OnInit, OnDestroy {
   private translateService = inject(TranslateService);
 
   isEditMode = toSignal(this.editService.edit$, { initialValue: false });
-  selected = computed(() => this.products()?.find((p) => p.id === this.editService.currentProductId()));
+  selected = toSignal(this.editService.currentProduct$);
   products = signal<ProductModel[]>([]);
   productDefinitions = signal<ProductDefinitionModel[]>([]);
   hierarchic = signal(false);

--- a/src/Moryx.Products.Web/app/src/app/components/cancellation/cancellation.component.ts
+++ b/src/Moryx.Products.Web/app/src/app/components/cancellation/cancellation.component.ts
@@ -1,0 +1,37 @@
+import { Component, inject, OnInit } from '@angular/core';
+import { ActivatedRoute, Router } from '@angular/router';
+
+/**
+ * Component used for resetting the application state on cancellation of the product editing. 
+ * It reads the 'to' query parameter for the target route to navigate to. 
+ * Resetting happens through the route resolvers, the route still functions as the single point of truth.
+ * 
+ * This solution for cancelling the editing is rather heavy weighted, as it requires a full route navigation;
+ * Other considered solutions included
+ * - Resetting the state by reloading the product in the edit service
+ *    => RouteResolver would not be the single point for loading products anymore
+ *    => Cancellation while editing newly added recipes and parts left the url in an inconsistent state
+ * - Manually correcting route state by navigating to parent routes and correcting route parameters
+ *    => Requires more diffuse interference with the route state
+ *    => Requires checking product structure at multiple places
+ *    => Still executes halve of the navigations
+ * - Configuring the provided router to reload on every navigation
+ *    => Causes override of the UI state when switching tabs in a selected product breaking edit mode behavior
+ */
+@Component({
+  selector: 'app-cancellation',
+  imports: [],
+  templateUrl: './cancellation.component.html',
+  styleUrl: './cancellation.component.scss',
+})
+export class CancellationComponent implements OnInit {
+  private route = inject(ActivatedRoute);
+  private router = inject(Router);
+  
+  ngOnInit(): void {
+    const raw = this.route.snapshot.queryParamMap.get('to'); 
+    const to = raw ? decodeURIComponent(raw) : '/'; 
+    const tree = this.router.parseUrl(to); 
+    this.router.navigateByUrl(tree, { replaceUrl: true });
+  }
+}

--- a/src/Moryx.Products.Web/app/src/app/components/products-details-view/product-parts/part-resolver.ts
+++ b/src/Moryx.Products.Web/app/src/app/components/products-details-view/product-parts/part-resolver.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2026 Phoenix Contact GmbH & Co. KG
+ * Licensed under the Apache License, Version 2.0
+*/
+
+import { inject } from '@angular/core';
+import { ActivatedRouteSnapshot, RedirectCommand, ResolveFn, Router } from '@angular/router';
+import { PartModel } from 'src/app/api/models';
+import { EditProductsService } from 'src/app/services/edit-products.service';
+import { toSignal } from '@angular/core/rxjs-interop';
+
+/**
+ * Sets the current part connector and part in the EditProductsService based on the partName and partId route parameter. 
+ * If the either of them is not found, it redirects to the base connector or the first index of the connector page.
+ */
+export const PartsResolver: ResolveFn<PartModel | undefined> = async (route: ActivatedRouteSnapshot) => {
+  const editService = inject(EditProductsService);
+  const router = inject(Router);
+  const currentProduct = toSignal(editService.currentProduct$)();
+  const partId = Number(route.paramMap.get('partId'));
+  const connectorName = route.paramMap.get('partName');
+
+  if (!currentProduct) {
+    throw new Error('Invalid State: Tried to resolve product parts without a current product');
+  }
+
+  const connector = currentProduct.parts?.find(p => p.name === connectorName);
+  editService.setPartConnector(connector);
+  // Base path for the parts view, no connector of part selected
+  if (connectorName === 'base') {
+    return undefined;
+  }
+  // Connector not found, redirect to base path of parts view
+  if (!connector) {
+    return new RedirectCommand(router.createUrlTree(['details', currentProduct.id, 'parts', 'base', 0]));
+  }
+  const part = connector.parts?.find(p => p.id === partId);
+  editService.setPart(part);
+  // No part id provided, i.e. stay on base path of the connector
+  if (!partId) {
+    return undefined;
+  }
+  // Part not found, redirect to first part of the connector if it exists, otherwise redirect to base path of the connector
+  if (!part) {
+    const firstPartId = connector.parts && connector.parts.length > 0 ? connector.parts[0].id : 0;
+    return new RedirectCommand(router.createUrlTree(['details', currentProduct.id, 'parts', connectorName, firstPartId]));
+  }
+  // Connector and part found, set them in the service and return the part for the resolver
+  return part;
+};

--- a/src/Moryx.Products.Web/app/src/app/components/products-details-view/product-parts/product-parts-details/product-parts-details.html
+++ b/src/Moryx.Products.Web/app/src/app/components/products-details-view/product-parts/product-parts-details/product-parts-details.html
@@ -1,13 +1,14 @@
-<h2>
-  {{ partConnector().name }}:
-  {{ createProductIdentity(productPart().product?.identifier, productPart().product?.revision) }}
-  {{ productPart().product?.name }}
-</h2>
-@if (productPart().properties && productPart().properties?.subEntries?.length) {
-  <p>{{ TranslationConstants.PARTS.DETAILS.TITLE | translate }}</p>
+@let connector = partConnector();
+@let part = productPart();
+
+@if (!part || !connector) {
+  <!-- Undefined state -->
+} @else if (part.properties?.subEntries?.length) {
   <navigable-entry-editor
     [disabled]="!isEditMode()"
-    [entry]="productPart().properties!"
+    [entry]="part.properties!"
     queryParam="productPart"
   ></navigable-entry-editor>
+} @else {
+  <empty-state style="scale: 66%;" [header]="''" [message]="''" icon="assignment_turned_in" />
 }

--- a/src/Moryx.Products.Web/app/src/app/components/products-details-view/product-parts/product-parts-details/product-parts-details.ts
+++ b/src/Moryx.Products.Web/app/src/app/components/products-details-view/product-parts/product-parts-details/product-parts-details.ts
@@ -3,20 +3,21 @@
  * Licensed under the Apache License, Version 2.0
 */
 
-import { Component, inject, input } from '@angular/core';
+import { Component, inject, linkedSignal } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { TranslateModule } from '@ngx-translate/core';
 import { TranslationConstants } from 'src/app/extensions/translation-constants.extensions';
-import { PartConnector, PartModel } from '../../../../api/models';
 import { EditProductsService } from '../../../../services/edit-products.service';
 
 import { NavigableEntryEditor } from '@moryx/ngx-web-framework/entry-editor';
+import { EmptyState } from '@moryx/ngx-web-framework/empty-state';
 
 @Component({
   selector: 'app-product-parts-details',
   templateUrl: './product-parts-details.html',
   styleUrls: ['./product-parts-details.scss'],
   imports: [
+    EmptyState,
     NavigableEntryEditor,
     TranslateModule
   ]
@@ -24,10 +25,8 @@ import { NavigableEntryEditor } from '@moryx/ngx-web-framework/entry-editor';
 export class ProductPartsDetailsComponent {
   private editProductsService = inject(EditProductsService);
 
-  // ToDo: Replace with service injection
-  partConnector = input.required<PartConnector>();
-  productPart = input.required<PartModel>();
-
+  partConnector = linkedSignal(this.editProductsService.currentPartConnector);
+  productPart = linkedSignal(this.editProductsService.currentPart);
   isEditMode = toSignal(this.editProductsService.edit$, { initialValue: false });
 
   TranslationConstants = TranslationConstants;

--- a/src/Moryx.Products.Web/app/src/app/components/products-details-view/product-parts/product-parts-details/product-parts-details.ts
+++ b/src/Moryx.Products.Web/app/src/app/components/products-details-view/product-parts/product-parts-details/product-parts-details.ts
@@ -24,6 +24,7 @@ import { NavigableEntryEditor } from '@moryx/ngx-web-framework/entry-editor';
 export class ProductPartsDetailsComponent {
   private editProductsService = inject(EditProductsService);
 
+  // ToDo: Replace with service injection
   partConnector = input.required<PartConnector>();
   productPart = input.required<PartModel>();
 

--- a/src/Moryx.Products.Web/app/src/app/components/products-details-view/product-parts/product-parts.html
+++ b/src/Moryx.Products.Web/app/src/app/components/products-details-view/product-parts/product-parts.html
@@ -18,16 +18,25 @@
         @if (currentConnector?.name === connector.name) {
           @if (connector.isCollection) {
             <div class="parts-part-list">
-              <mat-list class="parts-part-list-list">
+              <mat-nav-list class="parts-part-list-list">
                 @for (partElement of connector.parts; track partElement.id) {
-                  <mat-list-item
+                  <a mat-list-item
                     (click)="onSelectPartElement(partElement)"
                     class="parts-part-list-list-item"
-                    [ngClass]="{ 'moryx-selected': currentPart?.id == partElement.id }">
-                    {{ createProductNameWithIdentity(partElement.product, true, 30) }}
-                  </mat-list-item>
+                    [class.moryx-selected]="currentPart?.id == partElement.id">
+                    <a matListItemMeta 
+                      class="product-link"
+                      [matTooltip]="TranslationConstants.PARTS.OPEN | translate"
+                      aria-label="Go to referenced product"
+                      [class.hidden]="isEditMode()"
+                      (click)="$event.stopPropagation(); $event.preventDefault(); openProduct(partElement)">
+                      <mat-icon>arrow_outward</mat-icon>
+                    </a>
+                    <span matListItemTitle>{{ partElement.product?.name }}</span>
+                    <span matListItemLine>{{ partElement.product?.identifier }}-{{ partElement.product?.revision }}</span>
+                </a>
                 }
-              </mat-list>
+              </mat-nav-list>
               <app-product-parts-details class="parts-part-list-details" />
             </div>
           } @else{
@@ -51,6 +60,15 @@
               {{ TranslationConstants.PARTS.ADD | translate }}
             </button>
           } @else {
+            @if (currentPart) {
+              <button
+                mat-button
+                [disabled]="isEditMode()"
+                (click)="openProduct(currentPart)"
+                >
+                {{ TranslationConstants.PARTS.OPEN | translate }}
+              </button>
+            }
             <button
               mat-button
               [disabled]="!isEditMode() || !currentPart"

--- a/src/Moryx.Products.Web/app/src/app/components/products-details-view/product-parts/product-parts.html
+++ b/src/Moryx.Products.Web/app/src/app/components/products-details-view/product-parts/product-parts.html
@@ -21,7 +21,8 @@
               <mat-nav-list class="parts-part-list-list">
                 @for (partElement of connector.parts; track partElement.id) {
                   <a mat-list-item
-                    (click)="onSelectPartElement(partElement)"
+                    [routerLink]="['/details', this.currentProduct()!.id, 'parts', this.expandedPart()!.name, partElement.id]"
+                    [queryParamsHandling]="'preserve'"
                     class="parts-part-list-list-item"
                     [class.moryx-selected]="currentPart?.id == partElement.id">
                     <a matListItemMeta 

--- a/src/Moryx.Products.Web/app/src/app/components/products-details-view/product-parts/product-parts.html
+++ b/src/Moryx.Products.Web/app/src/app/components/products-details-view/product-parts/product-parts.html
@@ -1,26 +1,30 @@
-@if (currentProduct()?.parts?.length) {
+@let connectors = currentProduct()?.parts;
+@let currentConnector = expandedPart();
+@let currentPart = selectedPart();
+
+@if (connectors?.length) {
   <mat-accordion class="parts">
-    @for (part of currentProduct()?.parts; track part) {
+    @for (connector of connectors; track connector.name) {
       <mat-expansion-panel
         class="parts-part"
-        [expanded]="expandedPart()?.name === part.name"
-        (opened)="onSelectPartConnector(part)"
-        (closed)="onDeselectPartConnector(part)">
+        [expanded]="currentConnector?.name === connector.name"
+        (afterCollapse)="onDeselectPartConnector(connector)"
+        (opened)="onSelectPartConnector(connector)">
         <mat-expansion-panel-header>
-          <mat-panel-title>{{ part.displayName ? part.displayName : part.name }}</mat-panel-title>
+          <mat-panel-title>{{ connector.displayName ? connector.displayName : connector.name }}</mat-panel-title>
         </mat-expansion-panel-header>
         <!-- part is collection -->
-        @if (part.isCollection) {
-          @if (expandedPart()?.name === part.name) {
+        @if (connector.isCollection) {
+          @if (currentConnector?.name === connector.name) {
             <div class="parts-part-list">
               <div class="parts-part-list-list">
-                @if (part.parts) {
+                @if (connector.parts) {
                   <mat-list>
-                    @for (partElement of part.parts; track partElement) {
+                    @for (partElement of connector.parts; track partElement.id) {
                       <mat-list-item
                         (click)="onSelectPartElement(partElement)"
                         class="parts-part-list-list-item"
-                        [ngClass]="{ 'moryx-selected': selectedPart()?.id == partElement.id }">
+                        [ngClass]="{ 'moryx-selected': currentPart?.id == partElement.id }">
                         {{ createProductNameWithIdentity(partElement.product, true, 30) }}
                       </mat-list-item>
                     }
@@ -28,10 +32,10 @@
                 }
               </div>
               <div class="parts-part-list-details">
-                @if (selectedPart()) {
+                @if (currentPart) {
                   <app-product-parts-details
-                    [partConnector]="part"
-                    [productPart]="selectedPart()!"
+                    [partConnector]="connector"
+                    [productPart]="currentPart"
                     >
                   </app-product-parts-details>
                 } @else {
@@ -41,21 +45,21 @@
             </div>
           }
         } @else {
-          @if (expandedPart()?.name === part.name && selectedPart()) {
+          @if (currentConnector?.name === connector.name && currentPart) {
             <div>
               <app-product-parts-details
-                [partConnector]="part"
-                [productPart]="selectedPart()!">
+                [partConnector]="connector"
+                [productPart]="currentPart">
               </app-product-parts-details>
             </div>
           }
         }
         <!-- part is not a collection -->
         <mat-action-row>
-          @if (part.isCollection) {
+          @if (connector.isCollection) {
             <button
               mat-button
-              [disabled]="!isEditMode() || !selectedPart()"
+              [disabled]="!isEditMode() || !currentPart"
               (click)="removePart()"
               >
               {{ TranslationConstants.PARTS.REMOVE | translate }}
@@ -70,7 +74,7 @@
           } @else {
             <button
               mat-button
-              [disabled]="!isEditMode() || !selectedPart()"
+              [disabled]="!isEditMode() || !currentPart"
               (click)="removePart()"
               >
               {{ TranslationConstants.PARTS.REMOVE | translate }}

--- a/src/Moryx.Products.Web/app/src/app/components/products-details-view/product-parts/product-parts.html
+++ b/src/Moryx.Products.Web/app/src/app/components/products-details-view/product-parts/product-parts.html
@@ -12,49 +12,28 @@
         (opened)="onSelectPartConnector(connector)">
         <mat-expansion-panel-header>
           <mat-panel-title>{{ connector.displayName ? connector.displayName : connector.name }}</mat-panel-title>
+          <mat-panel-description>{{ getConnectorPreview(connector) }}</mat-panel-description>
         </mat-expansion-panel-header>
         <!-- part is collection -->
-        @if (connector.isCollection) {
-          @if (currentConnector?.name === connector.name) {
+        @if (currentConnector?.name === connector.name) {
+          @if (connector.isCollection) {
             <div class="parts-part-list">
-              <div class="parts-part-list-list">
-                @if (connector.parts) {
-                  <mat-list>
-                    @for (partElement of connector.parts; track partElement.id) {
-                      <mat-list-item
-                        (click)="onSelectPartElement(partElement)"
-                        class="parts-part-list-list-item"
-                        [ngClass]="{ 'moryx-selected': currentPart?.id == partElement.id }">
-                        {{ createProductNameWithIdentity(partElement.product, true, 30) }}
-                      </mat-list-item>
-                    }
-                  </mat-list>
+              <mat-list class="parts-part-list-list">
+                @for (partElement of connector.parts; track partElement.id) {
+                  <mat-list-item
+                    (click)="onSelectPartElement(partElement)"
+                    class="parts-part-list-list-item"
+                    [ngClass]="{ 'moryx-selected': currentPart?.id == partElement.id }">
+                    {{ createProductNameWithIdentity(partElement.product, true, 30) }}
+                  </mat-list-item>
                 }
-              </div>
-              <div class="parts-part-list-details">
-                @if (currentPart) {
-                  <app-product-parts-details
-                    [partConnector]="connector"
-                    [productPart]="currentPart"
-                    >
-                  </app-product-parts-details>
-                } @else {
-                  <app-default-view></app-default-view>
-                }
-              </div>
+              </mat-list>
+              <app-product-parts-details class="parts-part-list-details" />
             </div>
-          }
-        } @else {
-          @if (currentConnector?.name === connector.name && currentPart) {
-            <div>
-              <app-product-parts-details
-                [partConnector]="connector"
-                [productPart]="currentPart">
-              </app-product-parts-details>
-            </div>
+          } @else{
+            <app-product-parts-details class="parts-part-list-details" />     
           }
         }
-        <!-- part is not a collection -->
         <mat-action-row>
           @if (connector.isCollection) {
             <button

--- a/src/Moryx.Products.Web/app/src/app/components/products-details-view/product-parts/product-parts.scss
+++ b/src/Moryx.Products.Web/app/src/app/components/products-details-view/product-parts/product-parts.scss
@@ -23,14 +23,45 @@
 
 .parts-part-list-list {
   flex: 1 1 20%;
+  max-width: 25%;
 }
 
 .parts-part-list-list-item {
-  cursor: pointer !important;
   -moz-box-sizing: border-box;
   -webkit-box-sizing: border-box;
   box-sizing: border-box;
   width: 100%;
+  height: 64px !important;
+}
+
+.parts-part-list-list-item a[matListItemMeta].product-link { 
+  display: inline-flex;
+  -moz-box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+  box-sizing: border-box;
+  align-items: center; 
+  border-radius: 100%;
+  height: 32px;
+  width: 32px;
+  padding: 6px 4px 4px 6px;
+  margin: 12px 16px 12px 16px;
+  cursor: pointer;
+  transition: background-color 120ms ease, color 120ms ease, transform 120ms ease, box-shadow 120ms ease; 
+}
+
+.parts-part-list-list-item a[matListItemMeta].product-link .mat-icon { 
+  font-size: 20px; 
+  line-height: 20px;
+}
+
+.parts-part-list-list-item a[matListItemMeta].product-link:hover { 
+  background-color: rgba(25, 118, 210, 0.08);
+  border-radius: 60px; 
+}
+
+.hidden { 
+  visibility: hidden; 
+  pointer-events: none;
 }
 
 .parts-part-list-details {
@@ -39,5 +70,5 @@
 }
 
 .moryx-selected {
-  background: $primary-light;
+  background-color: $primary-light;
 }

--- a/src/Moryx.Products.Web/app/src/app/components/products-details-view/product-parts/product-parts.ts
+++ b/src/Moryx.Products.Web/app/src/app/components/products-details-view/product-parts/product-parts.ts
@@ -6,7 +6,7 @@
 import { Component, inject, linkedSignal } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { MatDialog } from '@angular/material/dialog';
-import { Router } from '@angular/router';
+import { Router, RouterLink } from '@angular/router';
 import { TranslateModule } from '@ngx-translate/core';
 import { TranslationConstants } from 'src/app/extensions/translation-constants.extensions';
 import { PartConnector, PartModel, ProductModel } from '../../../api/models';
@@ -33,7 +33,8 @@ import { MatTooltip } from "@angular/material/tooltip";
     MatButtonModule,
     TranslateModule,
     MatIcon,
-    MatTooltip
+    MatTooltip,
+    RouterLink
 ]
 })
 export class ProductParts {
@@ -55,10 +56,6 @@ export class ProductParts {
   onDeselectPartConnector(part: PartConnector) {
     if (part.name !== this.expandedPart()?.name) return;
     this.router.navigate(['details', this.currentProduct()!.id, 'parts', 'base', 0]);
-  }
-
-  onSelectPartElement(part: PartModel) {
-    this.router.navigate(['details', this.currentProduct()!.id, 'parts', this.expandedPart()!.name, part.id], { queryParamsHandling: 'preserve' });
   }
 
   async addPart() {
@@ -108,7 +105,7 @@ export class ProductParts {
 
   openProduct(part: PartModel) {
     if (this.isEditMode()) {
-      this.onSelectPartElement(part);
+      this.router.navigate(['details', this.currentProduct()!.id, 'parts', this.expandedPart()!.name, part.id], { queryParamsHandling: 'preserve' });
       return;
     }
     this.router.navigate(['details', part.product?.id]);

--- a/src/Moryx.Products.Web/app/src/app/components/products-details-view/product-parts/product-parts.ts
+++ b/src/Moryx.Products.Web/app/src/app/components/products-details-view/product-parts/product-parts.ts
@@ -3,10 +3,10 @@
  * Licensed under the Apache License, Version 2.0
 */
 
-import { Component, inject, OnInit, signal } from '@angular/core';
+import { Component, inject, linkedSignal } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { MatDialog } from '@angular/material/dialog';
-import { ActivatedRoute, Router } from '@angular/router';
+import { Router } from '@angular/router';
 import { TranslateModule } from '@ngx-translate/core';
 import { TranslationConstants } from 'src/app/extensions/translation-constants.extensions';
 import { PartConnector, PartModel, ProductModel } from '../../../api/models';
@@ -18,6 +18,7 @@ import { MatListModule } from '@angular/material/list';
 import { ProductPartsDetailsComponent } from './product-parts-details/product-parts-details';
 import { DefaultView } from '../../default-view/default-view';
 import { MatButtonModule } from '@angular/material/button';
+import { firstValueFrom } from 'rxjs';
 
 @Component({
   selector: 'app-product-parts',
@@ -33,170 +34,65 @@ import { MatButtonModule } from '@angular/material/button';
     TranslateModule
   ]
 })
-export class ProductParts implements OnInit {
+export class ProductParts {
   private editProductsService = inject(EditProductsService);
   private router = inject(Router);
-  private activatedRoute = inject(ActivatedRoute);
   private dialog = inject(MatDialog);
 
   isEditMode = toSignal(this.editProductsService.edit$, { initialValue: false });
-  currentProduct = signal<ProductModel | undefined>(undefined);
-  expandedPart = signal<PartConnector | undefined>(undefined);
-  selectedPart = signal<PartModel | undefined>(undefined);
+  currentProduct = toSignal(this.editProductsService.currentProduct$);
+  expandedPart = linkedSignal(this.editProductsService.currentPartConnector);
+  selectedPart = linkedSignal(this.editProductsService.currentPart);
   TranslationConstants = TranslationConstants;
 
-  // ToDo: Add resolver for parts and move init there
-  constructor() {
-    this.editProductsService.currentProduct$.subscribe((product) => {
-      this.currentProduct.set(product);
-      this.init();
-    });
-  }
-
-  ngOnInit(): void {
-    this.init();
-  }
-
-  init() {
-    const partName = this.activatedRoute.snapshot.paramMap.get('partName');
-
-    if (partName === 'base') return;
-
-    if (!this.currentProduct) {
-      this.router.navigate(['']);
-      return;
-    }
-
-    let url = this.getBaseUrl();
-    this.expandedPart.set(this.currentProduct()?.parts?.find(
-      (p) => p.name === partName
-    ));
-    if (!this.expandedPart()) {
-      url += 'base/0';
-      this.router.navigate([url]);
-      return;
-    }
-    const partId = Number(this.activatedRoute.snapshot.paramMap.get('partId'));
-    if (partId === 0) {
-      return;
-    }
-
-    this.selectedPart.set(this.expandedPart()?.parts?.find(
-      (part) => part.id === partId
-    ));
-    if (!this.selectedPart() && this.expandedPart()?.name) {
-      if (this.expandedPart()?.isCollection) {
-        url += this.expandedPart()?.name + '/0';
-        this.router.navigate([url]);
-      } else {
-        this.expandedPart.set(undefined);
-        url += 'base/0';
-        this.router.navigate([url]);
-        return;
-      }
-    }
-  }
-
-  onSelectPartConnector(part: PartConnector) {
-    if (this.expandedPart()?.name === part.name) return;
-    this.expandedPart.set(part);
-    let url = this.getBaseUrl();
-    url += part.name;
-    if (!part.isCollection && part.parts?.length) {
-      this.selectedPart.set(part.parts?.[0]);
-      url += '/' + this.selectedPart()?.id;
-    } else {
-      url += '/0';
-      this.selectedPart.set(undefined);
-    }
-    this.router.navigate([url]);
+  onSelectPartConnector(connector: PartConnector) {
+    const firstPartId = connector.parts && connector.parts.length > 0 ? connector.parts[0].id : 0;
+    this.router.navigate(['details', this.currentProduct()!.id, 'parts', connector.name, firstPartId]);
   }
 
   onDeselectPartConnector(part: PartConnector) {
     if (part.name !== this.expandedPart()?.name) return;
-    this.expandedPart.set(undefined);
-    this.selectedPart.set(undefined);
-    const url = this.getBaseUrl() + 'base/0';
-    this.router.navigate([url]);
+    this.router.navigate(['details', this.currentProduct()!.id, 'parts', 'base', 0]);
   }
 
   onSelectPartElement(part: PartModel) {
-    this.selectedPart.set(part);
-    let url = this.getBaseUrl();
-    url += this.expandedPart()?.name + '/' + part.id;
-    this.router.navigate([url]);
+    this.router.navigate(['details', this.currentProduct()!.id, 'parts', this.expandedPart()!.name, part.id]);
   }
 
-  addPart() {
-    const dialogRef = this.dialog.open(DialogAddPart, {
-      data: this.expandedPart()
-    });
+  async addPart() {
+    const connector = this.expandedPart();
+    const dialogRef = this.dialog.open(DialogAddPart, { data: connector });
 
-    dialogRef.afterClosed().subscribe((product) => {
-      if (!product) return;
+    const product = await firstValueFrom(dialogRef.afterClosed());
+    if (!product) return;
 
-      // Create new Part
-      let newPart = <PartModel>{};
-      newPart.product = product;
-      if (this.expandedPart()?.propertyTemplates) {
-        newPart.properties = structuredClone(this.expandedPart()?.propertyTemplates!);
-      }
-      this.editProductsService.currentPartId++;
-      newPart.id = this.editProductsService.currentPartId;
+    // Create new Part
+    let newPart = <PartModel>{};
+    newPart.product = product;
+    if (connector?.propertyTemplates) {
+      newPart.properties = structuredClone(connector.propertyTemplates!);
+    }
 
-      // Add new Part to PartLink
-      if (this.expandedPart()?.isCollection)
-        this.expandedPart()?.parts?.push(newPart);
-      else {
-        if (this.expandedPart()?.parts?.length)
-          this.expandedPart.update(item => {
-            item!.parts![0] = newPart
-            return item;
-          });
-        else this.expandedPart.update(item => {
-          item!.parts?.push(newPart);
-          return item;
-        })
-      }
-
-      this.onSelectPartElement(newPart);
-    });
+    const addedPart = this.editProductsService.addPartToConnector(newPart);
+    this.router.navigate(['details', this.currentProduct()!.id, 'parts', connector!.name, addedPart.id]);
   }
 
   removePart() {
-    if (!this.expandedPart()) return;
+    const connector = this.expandedPart();
+    if (!connector) {
+      return;
+    } 
 
-    if (this.expandedPart()?.isCollection) {
-      if (!this.selectedPart() || !this.expandedPart()?.parts) return;
+    this.editProductsService.removePartFromConnector();
 
-      this.expandedPart.update(item => {
-        item!.parts = item?.parts?.filter(
-          (part) => part.id !== this.selectedPart()?.id
-        );
-        return item;
-      })
+    if (connector?.isCollection) {
+      this.onSelectPartConnector(connector);
     } else {
-      this.expandedPart.update(item => {
-        item!.parts = [] as PartModel[];
-        return item;
-      })
+      this.onDeselectPartConnector(connector);
     }
-
-    this.selectedPart.set(undefined);
-    const url = this.getBaseUrl() + this.expandedPart()?.name + '/0';
-    this.router.navigate([url]);
-  }
-
-  private getBaseUrl(): string {
-    const url = this.router.url;
-    const index = url.lastIndexOf('parts');
-    let newUrl = url.substring(0, index);
-    newUrl += 'parts/';
-    return newUrl;
   }
 
   createProductNameWithIdentity(product: ProductModel | undefined, shortened: boolean = false, maxLength: number = 40): string {
     return this.editProductsService.createProductNameWithIdentity(product, shortened, maxLength);
   }
 }
-

--- a/src/Moryx.Products.Web/app/src/app/components/products-details-view/product-parts/product-parts.ts
+++ b/src/Moryx.Products.Web/app/src/app/components/products-details-view/product-parts/product-parts.ts
@@ -18,6 +18,8 @@ import { MatListModule } from '@angular/material/list';
 import { ProductPartsDetailsComponent } from './product-parts-details/product-parts-details';
 import { MatButtonModule } from '@angular/material/button';
 import { firstValueFrom } from 'rxjs';
+import { MatIcon } from '@angular/material/icon';
+import { MatTooltip } from "@angular/material/tooltip";
 
 @Component({
   selector: 'app-product-parts',
@@ -29,8 +31,10 @@ import { firstValueFrom } from 'rxjs';
     MatListModule,
     ProductPartsDetailsComponent,
     MatButtonModule,
-    TranslateModule
-  ]
+    TranslateModule,
+    MatIcon,
+    MatTooltip
+]
 })
 export class ProductParts {
   private editProductsService = inject(EditProductsService);
@@ -100,5 +104,13 @@ export class ProductParts {
     }
     const partNames = connector.parts.map(p => p.product ? this.createProductNameWithIdentity(p.product, true) : 'Unnamed Product');
     return partNames.join(', ');
+  }
+
+  openProduct(part: PartModel) {
+    if (this.isEditMode()) {
+      this.onSelectPartElement(part);
+      return;
+    }
+    this.router.navigate(['details', part.product?.id]);
   }
 }

--- a/src/Moryx.Products.Web/app/src/app/components/products-details-view/product-parts/product-parts.ts
+++ b/src/Moryx.Products.Web/app/src/app/components/products-details-view/product-parts/product-parts.ts
@@ -16,7 +16,6 @@ import { CommonModule } from '@angular/common';
 import { MatExpansionModule } from '@angular/material/expansion';
 import { MatListModule } from '@angular/material/list';
 import { ProductPartsDetailsComponent } from './product-parts-details/product-parts-details';
-import { DefaultView } from '../../default-view/default-view';
 import { MatButtonModule } from '@angular/material/button';
 import { firstValueFrom } from 'rxjs';
 
@@ -29,7 +28,6 @@ import { firstValueFrom } from 'rxjs';
     MatExpansionModule,
     MatListModule,
     ProductPartsDetailsComponent,
-    DefaultView,
     MatButtonModule,
     TranslateModule
   ]
@@ -56,7 +54,7 @@ export class ProductParts {
   }
 
   onSelectPartElement(part: PartModel) {
-    this.router.navigate(['details', this.currentProduct()!.id, 'parts', this.expandedPart()!.name, part.id]);
+    this.router.navigate(['details', this.currentProduct()!.id, 'parts', this.expandedPart()!.name, part.id], { queryParamsHandling: 'preserve' });
   }
 
   async addPart() {
@@ -81,7 +79,7 @@ export class ProductParts {
     const connector = this.expandedPart();
     if (!connector) {
       return;
-    } 
+    }
 
     this.editProductsService.removePartFromConnector();
 
@@ -94,5 +92,13 @@ export class ProductParts {
 
   createProductNameWithIdentity(product: ProductModel | undefined, shortened: boolean = false, maxLength: number = 40): string {
     return this.editProductsService.createProductNameWithIdentity(product, shortened, maxLength);
+  }
+
+  getConnectorPreview(connector: PartConnector): string {
+    if (!connector.parts || connector.parts.length === 0) {
+      return '';
+    }
+    const partNames = connector.parts.map(p => p.product ? this.createProductNameWithIdentity(p.product, true) : 'Unnamed Product');
+    return partNames.join(', ');
   }
 }

--- a/src/Moryx.Products.Web/app/src/app/components/products-details-view/product-parts/product-parts.ts
+++ b/src/Moryx.Products.Web/app/src/app/components/products-details-view/product-parts/product-parts.ts
@@ -129,9 +129,7 @@ export class ProductParts implements OnInit {
 
   addPart() {
     const dialogRef = this.dialog.open(DialogAddPart, {
-      data: this.expandedPart(),
-      // ToDo: Remove hardcoded width and define centrally
-      width: '500px'
+      data: this.expandedPart()
     });
 
     dialogRef.afterClosed().subscribe((product) => {

--- a/src/Moryx.Products.Web/app/src/app/components/products-details-view/product-parts/product-parts.ts
+++ b/src/Moryx.Products.Web/app/src/app/components/products-details-view/product-parts/product-parts.ts
@@ -45,8 +45,9 @@ export class ProductParts implements OnInit {
   selectedPart = signal<PartModel | undefined>(undefined);
   TranslationConstants = TranslationConstants;
 
+  // ToDo: Add resolver for parts and move init there
   constructor() {
-    this.editProductsService.currentProduct.subscribe((product) => {
+    this.editProductsService.currentProduct$.subscribe((product) => {
       this.currentProduct.set(product);
       this.init();
     });
@@ -129,6 +130,7 @@ export class ProductParts implements OnInit {
   addPart() {
     const dialogRef = this.dialog.open(DialogAddPart, {
       data: this.expandedPart(),
+      // ToDo: Remove hardcoded width and define centrally
       width: '500px'
     });
 

--- a/src/Moryx.Products.Web/app/src/app/components/products-details-view/product-properties/product-properties.html
+++ b/src/Moryx.Products.Web/app/src/app/components/products-details-view/product-properties/product-properties.html
@@ -1,13 +1,2 @@
-@if (properties() !== undefined) {
-  <navigable-entry-editor
-    [entry]="properties()!"
-    queryParam="productProperty"
-    [disabled]="!isEditMode()"
-    class="property-navigation"
-  ></navigable-entry-editor>
-} @else {
-  <div class="properties-loading-screen">
-    <mat-progress-spinner mode="indeterminate"></mat-progress-spinner>
-  </div>
-}
-
+<navigable-entry-editor [entry]="properties()!" queryParam="productProperty" [disabled]="!isEditMode()"
+  class="property-navigation"></navigable-entry-editor>

--- a/src/Moryx.Products.Web/app/src/app/components/products-details-view/product-properties/product-properties.ts
+++ b/src/Moryx.Products.Web/app/src/app/components/products-details-view/product-properties/product-properties.ts
@@ -3,67 +3,21 @@
  * Licensed under the Apache License, Version 2.0
 */
 
-import {
-  Component,
-  effect,
-  inject,
-  input,
-  OnDestroy,
-  signal,
-  untracked,
-} from "@angular/core";
+import { Component, inject } from "@angular/core";
 import { toSignal } from "@angular/core/rxjs-interop";
-import { Entry, NavigableEntryEditor } from "@moryx/ngx-web-framework/entry-editor";
+import { NavigableEntryEditor } from "@moryx/ngx-web-framework/entry-editor";
 import { EditProductsService } from "../../../services/edit-products.service";
-
-import { MatProgressBarModule } from "@angular/material/progress-bar";
-import { MatProgressSpinnerModule } from "@angular/material/progress-spinner";
-import { Subscription } from 'rxjs';
+import { map } from 'rxjs';
 
 @Component({
   selector: "app-product-properties",
   templateUrl: "./product-properties.html",
   styleUrls: ["./product-properties.scss"],
-  imports: [
-    NavigableEntryEditor,
-    MatProgressBarModule,
-    MatProgressBarModule,
-    MatProgressSpinnerModule
-  ]
+  imports: [NavigableEntryEditor]
 })
-export class ProductProperties implements OnDestroy {
+export class ProductProperties {
   private editProductsService = inject(EditProductsService);
 
   isEditMode = toSignal(this.editProductsService.edit$, { initialValue: false });
-  properties = signal<Entry | undefined>(undefined);
-  id = input.required<number>();
-  subscriptions: Subscription[] = [];
-
-  constructor() {
-    effect(() => {
-      const id = this.id();
-      untracked(async () => {
-        await this.initialize(id);
-      });
-    });
-  }
-
-  ngOnDestroy(): void {
-    for (let subscription of this.subscriptions) {
-      subscription.unsubscribe();
-    }
-  }
-
-  async initialize(id: number) {
-    if (id == null) return;
-    const subscription = this.editProductsService.currentProduct.subscribe({
-      next: product => {
-        if (Number(id) === product?.id) {
-          this.properties.set(product.properties);
-        }
-      }
-    });
-    this.subscriptions.push(subscription);
-  }
+  properties = toSignal(this.editProductsService.currentProduct$.pipe(map(product => product?.properties)));
 }
-

--- a/src/Moryx.Products.Web/app/src/app/components/products-details-view/product-recipes/product-recipes-details/product-recipes-details-header/product-recipes-details-header.html
+++ b/src/Moryx.Products.Web/app/src/app/components/products-details-view/product-recipes/product-recipes-details/product-recipes-details-header/product-recipes-details-header.html
@@ -1,3 +1,10 @@
+@let edit = this.isEditMode();
+@let recipe = this.currentRecipe();
+
+@if (!recipe) {
+  <empty-state [icon]="'error'" [header]="'Undefined State'" [message]="''"></empty-state>
+}
+@else {
 <mat-form-field appearance="outline">
   <mat-label>{{
     TranslationConstants.SHARED.IDENTIFIER | translate
@@ -5,16 +12,16 @@
   <input
     matInput
     aria-label="Recipe Name"
-    [disabled]="edit() === false"
-    [(ngModel)]="recipe().name"
+    [disabled]="edit === false"
+    [(ngModel)]="recipe.name"
     />
 </mat-form-field>
 @if (hasWorkplans()) {
   <mat-form-field appearance="outline">
     <mat-label>{{ TranslationConstants.SHARED.WORKPLAN | translate }}</mat-label>
     <mat-select
-      [(ngModel)]="recipe().workplanModel"
-      [disabled]="edit() === false"
+      [(ngModel)]="recipe.workplanModel"
+      [disabled]="edit === false"
       [compareWith]="byWorkplanId"
       required
       >
@@ -30,7 +37,7 @@
   <mat-label>{{
     TranslationConstants.SHARED.CLASSIFICATION | translate
   }}</mat-label>
-  <mat-select [(ngModel)]="recipe().classification" [disabled]="edit() === false" [formControl]="recipeControl" restrictKeywordValidator="Unset">
+  <mat-select [(ngModel)]="recipe.classification" [disabled]="!edit" [formControl]="recipeControl" restrictKeywordValidator="Unset">
     @for (classification of recipeClassifications(); track classification) {
       <mat-option
         [value]="classification"
@@ -46,3 +53,4 @@
     <mat-hint>{{recipeControl.value !== 'Unset' ? recipeControl.value : TranslationConstants.DETAILS.RECIPS.CHOOSE_OTHER | translate }}</mat-hint>
   }
 </mat-form-field>
+}

--- a/src/Moryx.Products.Web/app/src/app/components/products-details-view/product-recipes/product-recipes-details/product-recipes-details-header/product-recipes-details-header.ts
+++ b/src/Moryx.Products.Web/app/src/app/components/products-details-view/product-recipes/product-recipes-details/product-recipes-details-header/product-recipes-details-header.ts
@@ -3,7 +3,7 @@
  * Licensed under the Apache License, Version 2.0
 */
 
-import { Component, computed, effect, inject, signal, untracked } from "@angular/core";
+import { Component, computed, effect, inject, linkedSignal, signal, untracked } from "@angular/core";
 import { FormsModule, ReactiveFormsModule, UntypedFormControl } from "@angular/forms";
 import { TranslateModule } from "@ngx-translate/core";
 import { TranslationConstants } from "src/app/extensions/translation-constants.extensions";
@@ -37,7 +37,7 @@ export class ProductRecipesDetailsHeader {
   private editProductsService = inject(EditProductsService);
 
   isEditMode = toSignal(this.editProductsService.edit$, { initialValue: false });
-  currentRecipe = toSignal(this.editProductsService.currentRecipe$, { initialValue: undefined });
+  currentRecipe = linkedSignal(this.editProductsService.currentRecipe);
   
   hasWorkplans = computed(() => {
     if (this.currentRecipe()?.workplanModel === undefined) return false;

--- a/src/Moryx.Products.Web/app/src/app/components/products-details-view/product-recipes/product-recipes-details/product-recipes-details-header/product-recipes-details-header.ts
+++ b/src/Moryx.Products.Web/app/src/app/components/products-details-view/product-recipes/product-recipes-details/product-recipes-details-header/product-recipes-details-header.ts
@@ -3,16 +3,19 @@
  * Licensed under the Apache License, Version 2.0
 */
 
-import { Component, computed, effect, inject, input, signal, untracked } from "@angular/core";
+import { Component, computed, effect, inject, signal, untracked } from "@angular/core";
 import { FormsModule, ReactiveFormsModule, UntypedFormControl } from "@angular/forms";
 import { TranslateModule } from "@ngx-translate/core";
 import { TranslationConstants } from "src/app/extensions/translation-constants.extensions";
-import { RecipeClassificationModel, RecipeModel, WorkplanModel } from "../../../../../api/models";
+import { RecipeClassificationModel, WorkplanModel } from "../../../../../api/models";
 import { CacheProductsService } from "../../../../../services/cache-products.service";
 
 import { MatInput, MatInputModule } from "@angular/material/input";
 import { MatOptionModule } from "@angular/material/core";
 import { MatSelectModule } from "@angular/material/select";
+import { EditProductsService } from "src/app/services/edit-products.service";
+import { toSignal } from "@angular/core/rxjs-interop";
+import { EmptyState } from "@moryx/ngx-web-framework/empty-state";
 
 @Component({
   selector: "app-product-recipes-details-header",
@@ -25,19 +28,22 @@ import { MatSelectModule } from "@angular/material/select";
     MatOptionModule,
     ReactiveFormsModule,
     MatInput,
-    MatSelectModule
+    MatSelectModule,
+    EmptyState
   ]
 })
 export class ProductRecipesDetailsHeader {
   private cacheService = inject(CacheProductsService);
+  private editProductsService = inject(EditProductsService);
 
-  edit = input.required<boolean>();
-  recipe = input.required<RecipeModel>();
+  isEditMode = toSignal(this.editProductsService.edit$, { initialValue: false });
+  currentRecipe = toSignal(this.editProductsService.currentRecipe$, { initialValue: undefined });
+  
   hasWorkplans = computed(() => {
-    if (this.recipe().workplanModel === undefined) return false;
+    if (this.currentRecipe()?.workplanModel === undefined) return false;
     return true;
   });
-  possibleWorkplans = signal<WorkplanModel[]>([]);
+  possibleWorkplans = toSignal(this.cacheService.workplans, { initialValue: [] });
   recipeClassifications = signal(Object.keys(RecipeClassificationModel));
 
   recipeControl = new UntypedFormControl({
@@ -47,16 +53,13 @@ export class ProductRecipesDetailsHeader {
 
   constructor() {
     effect(() => {
-      const edit = this.edit();
+      const edit = this.isEditMode();
       untracked(() => {
         if (edit)
           this.recipeControl.enable();
         else
           this.recipeControl.disable();
       })
-    })
-    this.cacheService.workplans.subscribe((workplans) => {
-      this.possibleWorkplans.update((_) => workplans ?? []);
     });
   }
 

--- a/src/Moryx.Products.Web/app/src/app/components/products-details-view/product-recipes/product-recipes-details/product-recipes-details.html
+++ b/src/Moryx.Products.Web/app/src/app/components/products-details-view/product-recipes/product-recipes-details/product-recipes-details.html
@@ -1,17 +1,14 @@
 @let recipe = currentRecipe();
 
 @if (recipe) {
-  <!-- ToDo remove div and add styling to host -->
-  <div class="product-recipes-details">
-    <app-product-recipes-details-header />
-    @if (recipe.properties !== undefined) {
-      <navigable-entry-editor
-        class="product-recipes-details-properties"
-        queryParam="productRecipe"
-        [entry]="currentRecipe()?.properties!"
-        (entryChange)="updateRecipe($event)"
-        [disabled]="!isEditMode()"
-      ></navigable-entry-editor>
-    }
-  </div>
+  <app-product-recipes-details-header />
+  @if (recipe.properties !== undefined) {
+    <navigable-entry-editor
+      class="product-recipes-details-properties"
+      queryParam="productRecipe"
+      [entry]="currentRecipe()?.properties!"
+      (entryChange)="updateRecipe($event)"
+      [disabled]="!isEditMode()"
+    />
+  }
 }

--- a/src/Moryx.Products.Web/app/src/app/components/products-details-view/product-recipes/product-recipes-details/product-recipes-details.html
+++ b/src/Moryx.Products.Web/app/src/app/components/products-details-view/product-recipes/product-recipes-details/product-recipes-details.html
@@ -1,18 +1,17 @@
-@if (currentRecipe()) {
+@let recipe = currentRecipe();
+
+@if (recipe) {
+  <!-- ToDo remove div and add styling to host -->
   <div class="product-recipes-details">
-    <app-product-recipes-details-header
-      [recipe]="currentRecipe()!"
-      [edit]="isEditMode()"
-      >
-    </app-product-recipes-details-header>
-    @if (currentRecipe()?.properties !== undefined) {
+    <app-product-recipes-details-header />
+    @if (recipe.properties !== undefined) {
       <navigable-entry-editor
         class="product-recipes-details-properties"
         queryParam="productRecipe"
         [entry]="currentRecipe()?.properties!"
+        (entryChange)="updateRecipe($event)"
         [disabled]="!isEditMode()"
       ></navigable-entry-editor>
     }
-    <div></div>
   </div>
 }

--- a/src/Moryx.Products.Web/app/src/app/components/products-details-view/product-recipes/product-recipes-details/product-recipes-details.scss
+++ b/src/Moryx.Products.Web/app/src/app/components/products-details-view/product-recipes/product-recipes-details/product-recipes-details.scss
@@ -1,6 +1,6 @@
 @use "@moryx/ngx-web-framework/styles/variables" as *; 
 
-.product-recipes-details {
+:host {
   display: flex;
   flex-flow: column nowrap;
   justify-content: flex-start;

--- a/src/Moryx.Products.Web/app/src/app/components/products-details-view/product-recipes/product-recipes-details/product-recipes-details.ts
+++ b/src/Moryx.Products.Web/app/src/app/components/products-details-view/product-recipes/product-recipes-details/product-recipes-details.ts
@@ -40,7 +40,7 @@ export class ProductRecipesDetails {
     this.editProductsService.currentProduct.subscribe((product) => {
       this.currentProduct.set(product);
       this.setCurrentRecipe();
-      if (this.currentRecipe === undefined) {
+      if (this.currentRecipe() === undefined) {
         let url = this.router.url;
         // If the current route is a child child route, move to the parent route first
         // in order to have no "Cannot match any routes. URL Segment:" error

--- a/src/Moryx.Products.Web/app/src/app/components/products-details-view/product-recipes/product-recipes-details/product-recipes-details.ts
+++ b/src/Moryx.Products.Web/app/src/app/components/products-details-view/product-recipes/product-recipes-details/product-recipes-details.ts
@@ -37,7 +37,8 @@ export class ProductRecipesDetails {
   TranslationConstants = TranslationConstants;
 
   constructor() {
-    this.editProductsService.currentProduct.subscribe((product) => {
+    // ToDo: Add recipe resolver and map recipe directly to signal
+    this.editProductsService.currentProduct$.subscribe((product) => {
       this.currentProduct.set(product);
       this.setCurrentRecipe();
       if (this.currentRecipe() === undefined) {

--- a/src/Moryx.Products.Web/app/src/app/components/products-details-view/product-recipes/product-recipes-details/product-recipes-details.ts
+++ b/src/Moryx.Products.Web/app/src/app/components/products-details-view/product-recipes/product-recipes-details/product-recipes-details.ts
@@ -3,7 +3,7 @@
  * Licensed under the Apache License, Version 2.0
 */
 
-import { Component, inject } from '@angular/core';
+import { Component, inject, linkedSignal } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { TranslateModule } from '@ngx-translate/core';
 import { TranslationConstants } from 'src/app/extensions/translation-constants.extensions';
@@ -28,8 +28,8 @@ export class ProductRecipesDetails {
   private cacheService = inject(CacheProductsService);
 
   isEditMode = toSignal(this.editProductsService.edit$, { initialValue: false });
-  currentProduct = toSignal(this.editProductsService.currentProduct$, { initialValue: undefined });
-  currentRecipe = toSignal(this.editProductsService.currentRecipe$, { initialValue: undefined });
+  currentProduct = toSignal(this.editProductsService.currentProduct$);
+  currentRecipe = linkedSignal(this.editProductsService.currentRecipe);
   recipeDefinitions = toSignal(this.cacheService.recipeDefinitions, { initialValue: [] });
   TranslationConstants = TranslationConstants;
 

--- a/src/Moryx.Products.Web/app/src/app/components/products-details-view/product-recipes/product-recipes-details/product-recipes-details.ts
+++ b/src/Moryx.Products.Web/app/src/app/components/products-details-view/product-recipes/product-recipes-details/product-recipes-details.ts
@@ -3,16 +3,15 @@
  * Licensed under the Apache License, Version 2.0
 */
 
-import { Component, inject, signal } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
-import { ActivatedRoute, NavigationEnd, Router } from '@angular/router';
 import { TranslateModule } from '@ngx-translate/core';
 import { TranslationConstants } from 'src/app/extensions/translation-constants.extensions';
-import { ProductModel, RecipeDefinitionModel, RecipeModel } from '../../../../api/models';
 import { CacheProductsService } from '../../../../services/cache-products.service';
 import { EditProductsService } from '../../../../services/edit-products.service';
-import { NavigableEntryEditor } from '@moryx/ngx-web-framework/entry-editor';
+import { Entry, NavigableEntryEditor } from '@moryx/ngx-web-framework/entry-editor';
 import { ProductRecipesDetailsHeader } from './product-recipes-details-header/product-recipes-details-header';
+import { RecipeModel } from 'src/app/api/models';
 
 @Component({
   selector: 'app-product-recipes-details',
@@ -26,61 +25,16 @@ import { ProductRecipesDetailsHeader } from './product-recipes-details-header/pr
 })
 export class ProductRecipesDetails {
   private editProductsService = inject(EditProductsService);
-  private route = inject(ActivatedRoute);
-  private router = inject(Router);
   private cacheService = inject(CacheProductsService);
 
   isEditMode = toSignal(this.editProductsService.edit$, { initialValue: false });
-  currentProduct = signal<ProductModel | undefined>(undefined);
-  currentRecipe = signal<RecipeModel | undefined>(undefined);
-  recipeDefinitions = signal<RecipeDefinitionModel[] | undefined>([]);
+  currentProduct = toSignal(this.editProductsService.currentProduct$, { initialValue: undefined });
+  currentRecipe = toSignal(this.editProductsService.currentRecipe$, { initialValue: undefined });
+  recipeDefinitions = toSignal(this.cacheService.recipeDefinitions, { initialValue: [] });
   TranslationConstants = TranslationConstants;
 
-  constructor() {
-    // ToDo: Add recipe resolver and map recipe directly to signal
-    this.editProductsService.currentProduct$.subscribe((product) => {
-      this.currentProduct.set(product);
-      this.setCurrentRecipe();
-      if (this.currentRecipe() === undefined) {
-        let url = this.router.url;
-        // If the current route is a child child route, move to the parent route first
-        // in order to have no "Cannot match any routes. URL Segment:" error
-        const regexSpecificRecipe: RegExp = /(details\/\d*\/recipes\/\d*)/;
-        if (regexSpecificRecipe.test(url)) {
-          this.router
-            .navigate(['../../'], {relativeTo: this.route})
-            .then(() => {
-              this.routeToDefault(url);
-            });
-        } else {
-          this.routeToDefault(url);
-        }
-      }
-    });
-
-    this.router.events.subscribe((val) => {
-      if (val instanceof NavigationEnd) {
-        this.setCurrentRecipe();
-      }
-    });
-
-    this.cacheService.recipeDefinitions.subscribe((recipeDefitions) => {
-      this.recipeDefinitions.set(recipeDefitions);
-    });
-  }
-
-  ngOnInit(): void {
-  }
-
-  private routeToDefault(url: string) {
-    const index = url.lastIndexOf('recipes');
-    let newUrl = url.substring(0, index);
-    newUrl += 'recipes/';
-    this.router.navigate([newUrl]);
-  }
-
-  private setCurrentRecipe(): void {
-    const id = Number(this.route.snapshot.paramMap.get('recipeId'));
-    this.currentRecipe.set(this.currentProduct()?.recipes?.find((r) => r.id === id));
+  updateRecipe(properties: Entry | undefined) {
+    if (!properties) return;
+    this.editProductsService.updateCurrentRecipe({... this.currentRecipe()!, properties});
   }
 }

--- a/src/Moryx.Products.Web/app/src/app/components/products-details-view/product-recipes/product-recipes-details/recipe-details-view-resolver.ts
+++ b/src/Moryx.Products.Web/app/src/app/components/products-details-view/product-recipes/product-recipes-details/recipe-details-view-resolver.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2026 Phoenix Contact GmbH & Co. KG
+ * Licensed under the Apache License, Version 2.0
+*/
+
+import { inject } from '@angular/core';
+import { ActivatedRouteSnapshot, RedirectCommand, ResolveFn, Router } from '@angular/router';
+import { RecipeModel } from 'src/app/api/models';
+import { EditProductsService } from 'src/app/services/edit-products.service';
+import { toSignal } from '@angular/core/rxjs-interop';
+
+/**
+ * Sets the current recipe in the EditProductsService based on the recipeId route parameter. 
+ * If the recipe is not found, it redirects to the product details page.
+ */
+export const RecipeDetailsViewResolver: ResolveFn<RecipeModel> = async (route: ActivatedRouteSnapshot) => {
+  const editService = inject(EditProductsService);
+  const router = inject(Router);
+  const currentProduct = toSignal(editService.currentProduct$)
+  const recipeId = Number(route.paramMap.get('recipeId'));
+
+  const recipe = currentProduct()?.recipes?.find(r => r.id === recipeId);
+  editService.setRecipe(recipe);
+  if (recipe) {
+    return recipe;
+  }
+  else {
+    return new RedirectCommand(router.createUrlTree(['details', currentProduct()?.id]));
+  }
+};

--- a/src/Moryx.Products.Web/app/src/app/components/products-details-view/product-recipes/product-recipes-details/recipe-resolver.ts
+++ b/src/Moryx.Products.Web/app/src/app/components/products-details-view/product-recipes/product-recipes-details/recipe-resolver.ts
@@ -16,15 +16,19 @@ import { toSignal } from '@angular/core/rxjs-interop';
 export const RecipeResolver: ResolveFn<RecipeModel> = async (route: ActivatedRouteSnapshot) => {
   const editService = inject(EditProductsService);
   const router = inject(Router);
-  const currentProduct = toSignal(editService.currentProduct$)
+  const currentProduct = toSignal(editService.currentProduct$)();
   const recipeId = Number(route.paramMap.get('recipeId'));
 
-  const recipe = currentProduct()?.recipes?.find(r => r.id === recipeId);
+  if (!currentProduct) {
+    throw new Error('Invalid State: Tried to resolve product recipes without a current product');
+  }
+
+  const recipe = currentProduct.recipes?.find(r => r.id === recipeId);
   editService.setRecipe(recipe);
   if (recipe) {
     return recipe;
   }
   else {
-    return new RedirectCommand(router.createUrlTree(['details', currentProduct()?.id]));
+    return new RedirectCommand(router.createUrlTree(['details', currentProduct.id]));
   }
 };

--- a/src/Moryx.Products.Web/app/src/app/components/products-details-view/product-recipes/product-recipes-details/recipe-resolver.ts
+++ b/src/Moryx.Products.Web/app/src/app/components/products-details-view/product-recipes/product-recipes-details/recipe-resolver.ts
@@ -13,7 +13,7 @@ import { toSignal } from '@angular/core/rxjs-interop';
  * Sets the current recipe in the EditProductsService based on the recipeId route parameter. 
  * If the recipe is not found, it redirects to the product details page.
  */
-export const RecipeDetailsViewResolver: ResolveFn<RecipeModel> = async (route: ActivatedRouteSnapshot) => {
+export const RecipeResolver: ResolveFn<RecipeModel> = async (route: ActivatedRouteSnapshot) => {
   const editService = inject(EditProductsService);
   const router = inject(Router);
   const currentProduct = toSignal(editService.currentProduct$)

--- a/src/Moryx.Products.Web/app/src/app/components/products-details-view/product-recipes/product-recipes.html
+++ b/src/Moryx.Products.Web/app/src/app/components/products-details-view/product-recipes/product-recipes.html
@@ -3,7 +3,7 @@
     @for (recipe of recipes(); track recipe) {
       <mat-list-item
         (click)="onSelect(recipe)"
-        [ngClass]="{ 'moryx-selected': selectedRecipe()?.id == recipe.id }"
+        [class.moryx-selected]="selectedRecipe()?.id == recipe.id"
         class="recipes-overview-list-item"
         >
         <div class="recipes-overview-list-item-content">

--- a/src/Moryx.Products.Web/app/src/app/components/products-details-view/product-recipes/product-recipes.ts
+++ b/src/Moryx.Products.Web/app/src/app/components/products-details-view/product-recipes/product-recipes.ts
@@ -4,7 +4,7 @@
 */
 
 import { HttpErrorResponse } from "@angular/common/http";
-import { Component, inject } from "@angular/core";
+import { Component, inject, linkedSignal } from "@angular/core";
 import { toSignal } from "@angular/core/rxjs-interop";
 import { MatDialog } from "@angular/material/dialog";
 import { Router, RouterOutlet } from "@angular/router";
@@ -43,7 +43,7 @@ export class ProductRecipes {
 
   isEditMode = toSignal(this.editProductsService.edit$, { initialValue: false });
   recipes = toSignal(this.editProductsService.currentProduct$.pipe(map(p => p?.recipes ?? []) ), { initialValue: [] });
-  selectedRecipe = toSignal(this.editProductsService.currentRecipe$);
+  selectedRecipe = linkedSignal(this.editProductsService.currentRecipe);
   TranslationConstants = TranslationConstants;
 
   onAddRecipe() {

--- a/src/Moryx.Products.Web/app/src/app/components/products-details-view/product-recipes/product-recipes.ts
+++ b/src/Moryx.Products.Web/app/src/app/components/products-details-view/product-recipes/product-recipes.ts
@@ -49,10 +49,11 @@ export class ProductRecipes implements OnInit {
   TranslationConstants = TranslationConstants;
 
   ngOnInit(): void {
+    // ToDo: Add resipce resolver
     const productId = this.activatedRoute.parent?.snapshot.paramMap.get("id");
     if (productId == null) return;
 
-    this.editProductsService.currentProduct.subscribe((product) => {
+    this.editProductsService.currentProduct$.subscribe((product) => {
       if (Number(productId) === product?.id) {
         if (product.recipes === null) this.recipes.update((_) => []);
         else {

--- a/src/Moryx.Products.Web/app/src/app/components/products-details-view/product-recipes/product-recipes.ts
+++ b/src/Moryx.Products.Web/app/src/app/components/products-details-view/product-recipes/product-recipes.ts
@@ -4,29 +4,28 @@
 */
 
 import { HttpErrorResponse } from "@angular/common/http";
-import { Component, inject, OnInit, signal } from "@angular/core";
+import { Component, inject } from "@angular/core";
 import { toSignal } from "@angular/core/rxjs-interop";
 import { MatDialog } from "@angular/material/dialog";
-import { ActivatedRoute, Router, RouterOutlet } from "@angular/router";
+import { Router, RouterOutlet } from "@angular/router";
 import { SnackbarService, } from "@moryx/ngx-web-framework/services";
 import { TranslateModule } from "@ngx-translate/core";
 import { TranslationConstants } from "src/app/extensions/translation-constants.extensions";
-import { RecipeModel } from "../../../api/models";
+import { RecipeModel, WorkplanModel } from "../../../api/models";
 import { ProductManagementService } from "../../../api/services";
 import { DialogCreateRecipe } from "../../../dialogs/dialog-create-recipe/dialog-create-recipe";
 import { EditProductsService } from "../../../services/edit-products.service";
-import { CommonModule } from "@angular/common";
 import { MatListModule } from "@angular/material/list";
 import { MatIconModule } from "@angular/material/icon";
 import { MatButtonModule } from "@angular/material/button";
 import { MatExpansionModule } from "@angular/material/expansion";
+import { lastValueFrom, map } from "rxjs";
 
 @Component({
   selector: "app-product-recipes",
   templateUrl: "./product-recipes.html",
   styleUrls: ["./product-recipes.scss"],
   imports: [
-    CommonModule,
     MatListModule,
     MatIconModule,
     MatButtonModule,
@@ -35,52 +34,17 @@ import { MatExpansionModule } from "@angular/material/expansion";
     RouterOutlet
   ]
 })
-export class ProductRecipes implements OnInit {
+export class ProductRecipes {
   private editProductsService = inject(EditProductsService);
-  private activatedRoute = inject(ActivatedRoute);
   private router = inject(Router);
   private dialog = inject(MatDialog);
   private productManagementService = inject(ProductManagementService);
   private snackbarService = inject(SnackbarService);
 
   isEditMode = toSignal(this.editProductsService.edit$, { initialValue: false });
-  recipes = signal<Array<RecipeModel>>([]);
-  selectedRecipe = signal<undefined | RecipeModel>(undefined);
+  recipes = toSignal(this.editProductsService.currentProduct$.pipe(map(p => p?.recipes ?? []) ), { initialValue: [] });
+  selectedRecipe = toSignal(this.editProductsService.currentRecipe$);
   TranslationConstants = TranslationConstants;
-
-  ngOnInit(): void {
-    // ToDo: Add resipce resolver
-    const productId = this.activatedRoute.parent?.snapshot.paramMap.get("id");
-    if (productId == null) return;
-
-    this.editProductsService.currentProduct$.subscribe((product) => {
-      if (Number(productId) === product?.id) {
-        if (product.recipes === null) this.recipes.update((_) => []);
-        else {
-          this.recipes.update((_) => product.recipes ?? []);
-          let recipeId: String | null =
-            product.recipes?.[0]?.id?.toString() ?? "";
-          // Check if a recipe was already selected according to the activatedRoute
-          const regexSpecificRecipe: RegExp = /(details\/\d*\/recipes\/\d*)/;
-          if (!regexSpecificRecipe.test(this.router.url) && recipeId) {
-            this.setSelectedRecipe(recipeId);
-            let url = this.getBaseUrl();
-            url += recipeId;
-            this.router.navigate([url]);
-            return;
-          }
-          recipeId = this.activatedRoute.children[0].snapshot.paramMap.get("recipeId");
-          this.setSelectedRecipe(recipeId);
-        }
-      }
-    });
-  }
-
-  setSelectedRecipe(recipeId: String | null) {
-    this.selectedRecipe.update((_) =>
-      this.recipes().find((recipe) => recipe.id === Number(recipeId))
-    );
-  }
 
   onAddRecipe() {
     const dialogRef = this.dialog.open(DialogCreateRecipe, {});
@@ -89,49 +53,40 @@ export class ProductRecipes implements OnInit {
       if (!result) return;
       if (!result.selectedRecipe) return;
 
-      this.productManagementService
-        .createRecipe({recipeType: result.selectedRecipe.name})
-        .subscribe({
-          next: (recipe) => {
-            recipe.name = result.recipeName;
-            recipe.workplanModel = result.workplanModel;
-            this.editProductsService.currentRecipeNumber++;
-            recipe.id = this.editProductsService.currentRecipeNumber;
-            this.editProductsService.addRecipe(recipe);
-            this.selectedRecipe.update((_) => recipe);
-            let url = this.getBaseUrl();
-            url += recipe.id;
-            this.router.navigate([url]);
-          },
-          error: async (e: HttpErrorResponse) =>
-            await this.snackbarService.handleError(e)
-        });
+      this.createRecipe(result.recipeName, result.selectedRecipe.name, result.workplanModel);
     });
   }
 
-  onSelect(recipe: RecipeModel) {
-    if (this.selectedRecipe()?.id === recipe.id) return;
-
-    this.selectedRecipe.update((_) => recipe);
-    let url = this.getBaseUrl();
-    if (recipe && recipe.id) {
-      url += recipe.id;
+  // ToDo: Move to edit service
+  private async createRecipe(name: string, recipeType: string, workplanModel?: WorkplanModel) {
+    let recipe: RecipeModel = {};
+    try {
+      recipe = await lastValueFrom(this.productManagementService.createRecipe({ recipeType: recipeType }));
+    } catch (error) {
+      await this.snackbarService.handleError(error as HttpErrorResponse);
+      return;
     }
-    this.router.navigate([url]);
+
+    recipe.name = name;
+    recipe.workplanModel = workplanModel;
+    this.editProductsService.currentRecipeNumber++;
+    recipe.id = this.editProductsService.currentRecipeNumber;
+    this.editProductsService.addRecipe(recipe);
+    
+    this.router.navigate(['details', this.editProductsService.currentProductId(), 'recipes', recipe.id]);
+  }
+
+  onSelect(recipe: RecipeModel) {
+    if (this.selectedRecipe()?.id === recipe.id) {
+      return;
+    }
+
+    this.router.navigate(['details', this.editProductsService.currentProductId(), 'recipes', recipe.id]);
   }
 
   onDeleteRecipe(event: Event, recipe: RecipeModel) {
     event.stopPropagation();
     this.editProductsService.removeRecipe(recipe);
-  }
-
-  // Get activatedRoute up to details/{productId}/recipes/
-  private getBaseUrl(): string {
-    const url = this.router.url;
-    const index = url.lastIndexOf("recipes");
-    let newUrl = url.substring(0, index);
-    newUrl += "recipes/";
-    return newUrl;
+    this.router.navigate(['details', this.editProductsService.currentProductId(), 'recipes']);
   }
 }
-

--- a/src/Moryx.Products.Web/app/src/app/components/products-details-view/product-references/product-references.html
+++ b/src/Moryx.Products.Web/app/src/app/components/products-details-view/product-references/product-references.html
@@ -1,7 +1,9 @@
-@if (references() && references().length > 0) {
+@let refs = references();
+
+@if (refs && refs.length > 0) {
   <table
     mat-table
-    [dataSource]="references()"
+    [dataSource]="refs"
     class="mat-elevation-z8"
     >
     <!-- Identifier Column -->
@@ -32,7 +34,6 @@
     <tr
       mat-header-row
       *matHeaderRowDef="['identifier', 'revision', 'name']"
-      class="first-header-row"
     ></tr>
     <tr
       mat-header-row
@@ -42,16 +43,11 @@
     <tr
       mat-row
       *matRowDef="let row; columns: ['identifier', 'revision', 'name']"
+      (click)="referenceClicked(row)"
+      class="clickable-row"
     ></tr>
   </table>
 } @else {
-  @if (isLoading()) {
-    <div class="product-references-loading">
-      <mat-spinner></mat-spinner>
-    </div>
-  }
-  @if (!references().length) {
-    <empty-state header="{{ TranslationConstants.DETAILS.REFS.NO_REF_HEADER | translate }}" message="{{ TranslationConstants.DETAILS.REFS.NO_REF | translate }}"></empty-state>
-  }
+  <empty-state header="{{ TranslationConstants.DETAILS.REFS.NO_REF_HEADER | translate }}" message="{{ TranslationConstants.DETAILS.REFS.NO_REF | translate }}" />
 }
 

--- a/src/Moryx.Products.Web/app/src/app/components/products-details-view/product-references/product-references.html
+++ b/src/Moryx.Products.Web/app/src/app/components/products-details-view/product-references/product-references.html
@@ -43,7 +43,7 @@
     <tr
       mat-row
       *matRowDef="let row; columns: ['identifier', 'revision', 'name']"
-      (click)="referenceClicked(row)"
+      [routerLink]="['/details', row.id, 'properties']"
       class="clickable-row"
     ></tr>
   </table>

--- a/src/Moryx.Products.Web/app/src/app/components/products-details-view/product-references/product-references.scss
+++ b/src/Moryx.Products.Web/app/src/app/components/products-details-view/product-references/product-references.scss
@@ -1,10 +1,10 @@
-@use "@moryx/ngx-web-framework/styles/variables" as *; 
+@use "@moryx/ngx-web-framework/styles/variables" as *;
 
-.table-description-header-row{
+.table-description-header-row {
   height: 24px;
 }
 
-.table-description-header{
+.table-description-header {
   font-size: var(--mat-typography-caption-font-size);
   line-height: var(--mat-typography-caption-line-height);
   font-weight: var(--mat-typography-caption-font-weight);
@@ -12,10 +12,12 @@
   font-style: italic;
 }
 
-.product-references-loading {
-  flex: 1 1;
-  align-self: center;
-  display: flex;
-  flex-flow: column nowrap;
-  justify-content: center;
+.clickable-row {
+  cursor: pointer;
+}
+
+.clickable-row:hover .mat-mdc-cell,
+.clickable-row:focus-visible .mat-mdc-cell {
+  background-color: rgba(0, 0, 0, 0.04);
+  transition: background-color 120ms ease; 
 }

--- a/src/Moryx.Products.Web/app/src/app/components/products-details-view/product-references/product-references.ts
+++ b/src/Moryx.Products.Web/app/src/app/components/products-details-view/product-references/product-references.ts
@@ -36,13 +36,15 @@ export class ProductReferences {
   TranslationConstants = TranslationConstants;
 
   constructor() {
+    // ToDo: Remove loading indicator and use resolver for references
     this.isLoading.update(_ => true);
-    this.editProductsService.references.subscribe((references) => {
+    this.editProductsService.references$.subscribe((references) => {
       this.references.update(_ => references ?? []);
       this.isLoading.update(_ => false);
     });
   }
 
+  // ToDo: Add clickable indicator to reference list item
   referenceClicked(reference: ProductModel) {
     this.router.navigate(['/details', reference.id, 'properties'])
   }

--- a/src/Moryx.Products.Web/app/src/app/components/products-details-view/product-references/product-references.ts
+++ b/src/Moryx.Products.Web/app/src/app/components/products-details-view/product-references/product-references.ts
@@ -3,7 +3,7 @@
  * Licensed under the Apache License, Version 2.0
 */
 
-import { Component, inject, signal } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { TranslateModule } from '@ngx-translate/core';
 import { TranslationConstants } from 'src/app/extensions/translation-constants.extensions';
 import { ProductModel } from '../../../api/models';
@@ -14,6 +14,7 @@ import { EmptyState } from '@moryx/ngx-web-framework/empty-state';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { Router } from '@angular/router';
 import { MatCardModule } from '@angular/material/card';
+import { toSignal } from '@angular/core/rxjs-interop';
 
 @Component({
   selector: 'app-product-references',
@@ -28,25 +29,12 @@ import { MatCardModule } from '@angular/material/card';
   ]
 })
 export class ProductReferences {
-  private editProductsService = inject(EditProductsService);
   private router = inject(Router);
 
-  references = signal<ProductModel[]>([]);
-  isLoading = signal(false);
+  references = toSignal(inject(EditProductsService).references$, { initialValue: [] });
   TranslationConstants = TranslationConstants;
 
-  constructor() {
-    // ToDo: Remove loading indicator and use resolver for references
-    this.isLoading.update(_ => true);
-    this.editProductsService.references$.subscribe((references) => {
-      this.references.update(_ => references ?? []);
-      this.isLoading.update(_ => false);
-    });
-  }
-
-  // ToDo: Add clickable indicator to reference list item
   referenceClicked(reference: ProductModel) {
     this.router.navigate(['/details', reference.id, 'properties'])
   }
 }
-

--- a/src/Moryx.Products.Web/app/src/app/components/products-details-view/product-references/product-references.ts
+++ b/src/Moryx.Products.Web/app/src/app/components/products-details-view/product-references/product-references.ts
@@ -6,13 +6,11 @@
 import { Component, inject } from '@angular/core';
 import { TranslateModule } from '@ngx-translate/core';
 import { TranslationConstants } from 'src/app/extensions/translation-constants.extensions';
-import { ProductModel } from '../../../api/models';
 import { EditProductsService } from '../../../services/edit-products.service';
-
 import { MatTableModule } from '@angular/material/table';
 import { EmptyState } from '@moryx/ngx-web-framework/empty-state';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
-import { Router } from '@angular/router';
+import { RouterLink } from '@angular/router';
 import { MatCardModule } from '@angular/material/card';
 import { toSignal } from '@angular/core/rxjs-interop';
 
@@ -25,16 +23,11 @@ import { toSignal } from '@angular/core/rxjs-interop';
     TranslateModule,
     EmptyState,
     MatProgressSpinnerModule,
-    MatCardModule
-  ]
+    MatCardModule,
+    RouterLink
+]
 })
 export class ProductReferences {
-  private router = inject(Router);
-
   references = toSignal(inject(EditProductsService).references$, { initialValue: [] });
   TranslationConstants = TranslationConstants;
-
-  referenceClicked(reference: ProductModel) {
-    this.router.navigate(['/details', reference.id, 'properties'])
-  }
 }

--- a/src/Moryx.Products.Web/app/src/app/components/products-details-view/product-references/products-references-resolver.ts
+++ b/src/Moryx.Products.Web/app/src/app/components/products-details-view/product-references/products-references-resolver.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2026 Phoenix Contact GmbH & Co. KG
+ * Licensed under the Apache License, Version 2.0
+*/
+
+import { inject } from '@angular/core';
+import { RedirectCommand, ResolveFn, Router } from '@angular/router';
+import { firstValueFrom, lastValueFrom } from 'rxjs';
+import { ProductManagementService } from 'src/app/api/services';
+import { SnackbarService } from '@moryx/ngx-web-framework/services';
+import { HttpErrorResponse } from '@angular/common/http';
+import { EditProductsService } from 'src/app/services/edit-products.service';
+import { ProductModel, ProductQuery, RevisionFilter, Selector } from 'src/app/api/models';
+
+/**
+ * Retrieves the product details given the product id from the route before navigating to the details view.
+ * If an error occurs during retrieval, it handles the error and redirects to the default view.
+ *
+ * This ought to be the only place where the product details are retrieved from the API.
+ * The retrieved product is stored in the EditProductsService and can be accessed by all child components of the details view.
+ */
+export const ProductReferencesResolver: ResolveFn<ProductModel[]> = async () => {
+  const apiService = inject(ProductManagementService);
+  const editService = inject(EditProductsService);
+  const snackbarService = inject(SnackbarService);
+  const router = inject(Router);
+
+  const product = await firstValueFrom(editService.currentProduct$);
+  if (!product) {
+    throw new Error('Invalid State: Tried to resolve product references without a current product');
+  }
+
+  const body = <ProductQuery>{
+    includeDeleted: false,
+    identifier: product.identifier,
+    revision: product.revision,
+    revisionFilter: RevisionFilter.Specific,
+    selector: Selector.Parent,
+  };
+
+  try {
+    const references = await lastValueFrom(apiService.getTypes({body: body}));
+    editService.setReferences(references);
+    return references;
+  }
+  catch (error) {
+    await snackbarService.handleError(error as HttpErrorResponse);
+    return new RedirectCommand(router.parseUrl(`/details/${product.id}`));
+  }
+};
+

--- a/src/Moryx.Products.Web/app/src/app/components/products-details-view/product-references/references-resolver.ts
+++ b/src/Moryx.Products.Web/app/src/app/components/products-details-view/product-references/references-resolver.ts
@@ -19,7 +19,7 @@ import { ProductModel, ProductQuery, RevisionFilter, Selector } from 'src/app/ap
  * This ought to be the only place where the product details are retrieved from the API.
  * The retrieved product is stored in the EditProductsService and can be accessed by all child components of the details view.
  */
-export const ProductReferencesResolver: ResolveFn<ProductModel[]> = async () => {
+export const ReferencesResolver: ResolveFn<ProductModel[]> = async () => {
   const apiService = inject(ProductManagementService);
   const editService = inject(EditProductsService);
   const snackbarService = inject(SnackbarService);
@@ -48,4 +48,3 @@ export const ProductReferencesResolver: ResolveFn<ProductModel[]> = async () => 
     return new RedirectCommand(router.parseUrl(`/details/${product.id}`));
   }
 };
-

--- a/src/Moryx.Products.Web/app/src/app/components/products-details-view/products-details-header/products-details-header.html
+++ b/src/Moryx.Products.Web/app/src/app/components/products-details-view/products-details-header/products-details-header.html
@@ -1,44 +1,36 @@
-<div class="header">
-  <div class="header-information">
-    @if (currentProduct()) {
-      @if (editMode()) {
-        <div class="header-container">
-          <mat-form-field class="form-field" appearance="outline" require>
-            <mat-label>{{
-              TranslationConstants.SHARED.NAME | translate
-            }}</mat-label>
-            <input
-              matInput
-              aria-label="Product Name"
-              [ngModel]="currentProduct()!.name"
-              (ngModelChange)="updateCurrentProduct({ name: $event })"
-              />
-            <span matTextPrefix>{{ identifier() }}&nbsp;</span>
-          </mat-form-field>
-          <mat-form-field class="form-field" appearance="outline">
-            <mat-label>{{
-              TranslationConstants.SHARED.STATE | translate
-            }}</mat-label>
-            <mat-select
-              [ngModel]="currentProduct()!.state"
-              (ngModelChange)="updateCurrentProduct({ state: $event })"
-              >
-              @for (state of possibleStates(); track state) {
-                <mat-option [value]="state">
-                  {{ state }}
-                </mat-option>
-              }
-            </mat-select>
-          </mat-form-field>
-        </div>
-      } @else {
-        <div>
-          <h2 class="header-information-title">
-            {{ identifier() }}&nbsp;{{ currentProduct()!.name }}
-          </h2>
-          <p class="header-subtitle">{{ currentProduct()!.state }}</p>
-        </div>
-      }
-    }
-  </div>
-</div>
+@let product = this.currentProduct();
+
+@if (product) {
+  @if (editMode()) {
+    <mat-form-field class="form-field" appearance="outline" require>
+      <mat-label>{{
+        TranslationConstants.SHARED.NAME | translate
+      }}</mat-label>
+      <input
+        matInput
+        aria-label="Product Name"
+        [ngModel]="product.name"
+        (ngModelChange)="updateCurrentProduct({ name: $event })"
+        />
+      <span matTextPrefix>{{ identifier() }}&nbsp;</span>
+    </mat-form-field>
+    <mat-form-field class="form-field" appearance="outline">
+      <mat-label>{{
+        TranslationConstants.SHARED.STATE | translate
+      }}</mat-label>
+      <mat-select
+        [ngModel]="product.state"
+        (ngModelChange)="updateCurrentProduct({ state: $event })"
+        >
+        @for (state of possibleStates(); track state) {
+          <mat-option [value]="state">
+            {{ state }}
+          </mat-option>
+        }
+      </mat-select>
+    </mat-form-field>
+  } @else {
+    <h2 class="header-information-title">{{ identifier() }}&nbsp;{{ product.name }}</h2>
+    <p class="header-subtitle">{{ product.state }}</p>
+  }
+}

--- a/src/Moryx.Products.Web/app/src/app/components/products-details-view/products-details-header/products-details-header.scss
+++ b/src/Moryx.Products.Web/app/src/app/components/products-details-view/products-details-header/products-details-header.scss
@@ -1,8 +1,8 @@
 @use "@moryx/ngx-web-framework/styles/variables" as *; 
 
 
-.header {
-  padding: 16px 26px 4px 26px;
+:host {
+  padding: 24px 24px 4px 24px;
   background-color: $mat-background-light;
 }
 

--- a/src/Moryx.Products.Web/app/src/app/components/products-details-view/products-details-header/products-details-header.ts
+++ b/src/Moryx.Products.Web/app/src/app/components/products-details-view/products-details-header/products-details-header.ts
@@ -3,7 +3,7 @@
  * Licensed under the Apache License, Version 2.0
 */
 
-import { Component, effect, inject, input, signal, model } from "@angular/core";
+import { Component, inject, signal, linkedSignal } from "@angular/core";
 import { TranslateModule } from "@ngx-translate/core";
 import { TranslationConstants } from "src/app/extensions/translation-constants.extensions";
 import { EditProductsService } from "src/app/services/edit-products.service";
@@ -13,9 +13,9 @@ import { MatInputModule } from "@angular/material/input";
 import { FormsModule, ReactiveFormsModule } from "@angular/forms";
 import { MatOptionModule } from "@angular/material/core";
 import { MatDividerModule } from "@angular/material/divider";
-import { untracked } from "@angular/core/primitives/signals";
 import { MatFormFieldModule } from "@angular/material/form-field";
 import { MatSelectModule } from "@angular/material/select";
+import { toSignal } from "@angular/core/rxjs-interop";
 
 @Component({
   selector: "app-products-details-header",
@@ -34,40 +34,26 @@ import { MatSelectModule } from "@angular/material/select";
 })
 export class ProductsDetailsHeader {
   private editService = inject(EditProductsService);
-
-  currentProduct = model.required<ProductModel | undefined>();
-
-  identifier = signal<string | undefined>(undefined);
-  editMode = input.required<boolean>();
+  
+  currentProduct = toSignal(this.editService.currentProduct$);
+  editMode = toSignal(this.editService.edit$, { initialValue: false });
+  identifier = linkedSignal(() => {
+    const current = this.currentProduct();
+    if (!current) {
+      return;
+    }
+    return this.editService.createProductIdentity(current.identifier, current.revision);
+  });
   possibleStates = signal<string[]>(Object.values(ProductState));
 
   TranslationConstants = TranslationConstants;
 
-  constructor() {
-    effect(() => {
-      const product = this.currentProduct();
-
-      untracked(() => {
-        if (!product || product.revision === undefined) return;
-
-        if (product.identifier)
-          this.identifier.update((_) =>
-            this.editService.createProductIdentity(
-              product.identifier,
-              product.revision
-            )
-          );
-      });
-    });
-  }
-
   updateCurrentProduct(patch: Partial<ProductModel>) {
-    if (this.currentProduct()) {
-      this.currentProduct.update(currentProduct => ({
-        ...currentProduct,
-        ...patch
-      }));
+    const current = this.currentProduct();
+    if (!current) {
+      return;
     }
+
+    this.editService.updateCurrentProduct({ ...current, ...patch });
   }
 }
-

--- a/src/Moryx.Products.Web/app/src/app/components/products-details-view/products-details-view-resolver.ts
+++ b/src/Moryx.Products.Web/app/src/app/components/products-details-view/products-details-view-resolver.ts
@@ -4,21 +4,70 @@
 */
 
 import { inject } from '@angular/core';
-import { ActivatedRouteSnapshot, ResolveFn } from '@angular/router';
-import { defer } from 'rxjs';
-import { first} from 'rxjs/operators';
+import { ActivatedRouteSnapshot, RedirectCommand, ResolveFn, Router } from '@angular/router';
+import { lastValueFrom } from 'rxjs';
 import { EditProductsService } from '../../services/edit-products.service';
 import { ProductModel } from '../../api/models';
+import { ProductManagementService } from 'src/app/api/services';
+import { SnackbarService } from '@moryx/ngx-web-framework/services';
+import { HttpErrorResponse } from '@angular/common/http';
+import { SessionService } from 'src/app/services/session.service';
 
-export const ProductsDetailsViewResolver: ResolveFn<ProductModel> = (route: ActivatedRouteSnapshot) => {
+/**
+ * Retrieves the product details given the product id from the route before navigating to the details view.
+ * If an error occurs during retrieval, it handles the error and redirects to the default view.
+ *
+ * This ought to be the only place where the product details are retrieved from the API.
+ * The retrieved product is stored in the EditProductsService and can be accessed by all child components of the details view.
+ */
+export const ProductsDetailsViewResolver: ResolveFn<ProductModel> = async (route: ActivatedRouteSnapshot) => {
+  const apiService = inject(ProductManagementService);
+  const sessionService = inject(SessionService);
   const editService = inject(EditProductsService);
+  const snackbarService = inject(SnackbarService);
+  const router = inject(Router);
   const id = Number(route.paramMap.get('id'));
 
-  return defer(() => {
-    editService.loadProductById(id);
-    return editService.currentProduct.pipe(
-      first((product): product is ProductModel => product !== undefined && product.id === id)
-    );
-  });
+  // If there is a product that was work in progress and we are not navigating to a
+  // different product, use the product from the session storage instead of retrieving it again from the API.
+  const workInProgress = sessionService.popWipProduct();
+  if (workInProgress?.product.id === id) {
+    editService.setProductFromStorage(workInProgress);
+    return workInProgress.product;
+  }
+
+  try {
+    const product = await lastValueFrom(apiService.getTypeById({ id: id }));
+    editService.setProduct(product);
+    return product;
+  }
+  catch (error) {
+    await snackbarService.handleError(error as HttpErrorResponse);
+    editService.resetProduct();
+    return new RedirectCommand(router.parseUrl(''));
+  }
+
+  // ToDo: Move to resolvefn for references getReferencesOfCurrentProduct();
+
+  // private getReferencesOfCurrentProduct() {
+  //   const product = this.currentProduct.value;
+  //   if (!product) return;
+
+  //   const body = <ProductQuery>{
+  //     includeDeleted: false,
+  //     identifier: product.identifier,
+  //     revision: product.revision,
+  //     revisionFilter: RevisionFilter.Specific,
+  //     selector: Selector.Parent,
+  //   };
+  //   this.productManagementService.getTypes({body: body}).subscribe({
+  //     next: (references) => {
+  //       this.references.next(references);
+  //     },
+  //     error: async (e: HttpErrorResponse) => {
+  //       await this.snackbarService.handleError(e);
+  //     },
+  //   });
+  // }
 };
 

--- a/src/Moryx.Products.Web/app/src/app/components/products-details-view/products-details-view.html
+++ b/src/Moryx.Products.Web/app/src/app/components/products-details-view/products-details-view.html
@@ -11,6 +11,7 @@
       >{{ TranslationConstants.SHARED.PROPERTIES | translate }}</a
       >
     }
+    <!-- ToDo: Format -->
     @if (currentProduct()?.parts && currentProduct()?.parts?.length) {
       <a
         mat-tab-link

--- a/src/Moryx.Products.Web/app/src/app/components/products-details-view/products-details-view.html
+++ b/src/Moryx.Products.Web/app/src/app/components/products-details-view/products-details-view.html
@@ -1,3 +1,4 @@
+<!-- ToDo: Replace input with service reference -->
 <app-products-details-header
   class="product-details-header"
   [currentProduct]="currentProduct()"

--- a/src/Moryx.Products.Web/app/src/app/components/products-details-view/products-details-view.html
+++ b/src/Moryx.Products.Web/app/src/app/components/products-details-view/products-details-view.html
@@ -1,10 +1,4 @@
-<!-- ToDo: Replace input with service reference -->
-<app-products-details-header
-  class="product-details-header"
-  [currentProduct]="currentProduct()"
-  (currentProductChange)="onCurrentProductChangeFromHeader($event)"
-  [editMode]="isEditMode()"
-></app-products-details-header>
+<app-products-details-header />
 
 <mat-divider></mat-divider>
 

--- a/src/Moryx.Products.Web/app/src/app/components/products-details-view/products-details-view.html
+++ b/src/Moryx.Products.Web/app/src/app/components/products-details-view/products-details-view.html
@@ -1,40 +1,25 @@
+@let product = currentProduct();
+@let link = activeLink();
+
 <app-products-details-header />
 
 <mat-divider></mat-divider>
 
 <nav mat-tab-nav-bar class="product-details-navigation" [tabPanel]="tabPanel">
-  @if (currentProduct()?.properties !== undefined) {
-    <a
-      mat-tab-link
-      [active]="activeLink() == Tabs.Properties"
-      (click)="routeTo(Tabs.Properties)"
-      >{{ TranslationConstants.SHARED.PROPERTIES | translate }}</a
-      >
-    }
-    <!-- ToDo: Format -->
-    @if (currentProduct()?.parts && currentProduct()?.parts?.length) {
-      <a
-        mat-tab-link
-        [active]="activeLink() == Tabs.Parts"
-        (click)="routeTo(Tabs.Parts)"
-        >{{ TranslationConstants.DETAILS.PARTS | translate }}</a
-        >
-      }
-      <a
-        mat-tab-link
-        [active]="activeLink() == Tabs.Recipes"
-        (click)="routeTo(Tabs.Recipes)"
-        >{{ TranslationConstants.DETAILS.RECIPES | translate }}</a
-        >
-        <a
-          mat-tab-link
-          [active]="activeLink() == Tabs.References"
-          (click)="routeTo(Tabs.References)"
+  @if (product?.properties !== undefined) {
+  <a mat-tab-link [active]="link == Tabs.Properties" (click)="routeTo(Tabs.Properties)">{{
+    TranslationConstants.SHARED.PROPERTIES | translate }}</a>
+  }
+  @if (product?.parts && product?.parts?.length) {
+  <a mat-tab-link [active]="link == Tabs.Parts" (click)="routeTo(Tabs.Parts)">{{
+    TranslationConstants.DETAILS.PARTS | translate }}</a>
+  }
+  <a mat-tab-link [active]="link == Tabs.Recipes" (click)="routeTo(Tabs.Recipes)">{{
+    TranslationConstants.DETAILS.RECIPES | translate }}</a>
+  <a mat-tab-link [active]="link == Tabs.References" (click)="routeTo(Tabs.References)">{{
+    TranslationConstants.DETAILS.REFERENCES | translate }}</a>
+</nav>
 
-          >{{ TranslationConstants.DETAILS.REFERENCES | translate }}</a
-          >
-        </nav>
-
-        <mat-tab-nav-panel class="product-details-information" #tabPanel>
-          <router-outlet></router-outlet>
-        </mat-tab-nav-panel>
+<mat-tab-nav-panel class="product-details-information" #tabPanel>
+  <router-outlet></router-outlet>
+</mat-tab-nav-panel>

--- a/src/Moryx.Products.Web/app/src/app/components/products-details-view/products-details-view.ts
+++ b/src/Moryx.Products.Web/app/src/app/components/products-details-view/products-details-view.ts
@@ -13,6 +13,7 @@ import { ProductsDetailsHeader } from './products-details-header/products-detail
 
 import { MatDividerModule } from '@angular/material/divider';
 import { MatTabsModule } from '@angular/material/tabs';
+import { ProductModel } from 'src/app/api/models';
 
 @Component({
   selector: 'app-products-details-view',
@@ -94,7 +95,7 @@ export class ProductsDetailsView {
 
   onCurrentProductChangeFromHeader(product: ProductModel | undefined) {
     if (this.isEditMode() && product) {
-      this.editProductsService.currentProduct.next(product);
+      this.editProductsService.updateCurrentProduct(product);
     }
   }
 }

--- a/src/Moryx.Products.Web/app/src/app/components/products-details-view/products-details-view.ts
+++ b/src/Moryx.Products.Web/app/src/app/components/products-details-view/products-details-view.ts
@@ -64,6 +64,7 @@ export class ProductsDetailsView {
     const url = this.router.url;
     const regexSpecificRecipe: RegExp = /(details\/\d*\/recipes\/\d*)/;
     const regexParts: RegExp = /(details\/\d*\/parts)/;
+    // ToDo: Simplify, no need for 2 navigations
     if (regexSpecificRecipe.test(url) || regexParts.test(url)) {
       this.router.navigate(['../../'], { relativeTo: this.activatedRoute }).then(() => {
         this.routeToTab(target);

--- a/src/Moryx.Products.Web/app/src/app/components/products-details-view/products-details-view.ts
+++ b/src/Moryx.Products.Web/app/src/app/components/products-details-view/products-details-view.ts
@@ -8,8 +8,6 @@ import { toSignal } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, NavigationCancel, NavigationEnd, Router, RouterOutlet } from '@angular/router';
 import { TranslateModule } from '@ngx-translate/core';
 import { TranslationConstants } from 'src/app/extensions/translation-constants.extensions';
-import { SessionService } from 'src/app/services/session.service';
-import { ProductModel } from '../../api/models';
 import { EditProductsService } from '../../services/edit-products.service';
 import { ProductsDetailsHeader } from './products-details-header/products-details-header';
 
@@ -30,14 +28,11 @@ import { MatTabsModule } from '@angular/material/tabs';
 })
 export class ProductsDetailsView {
   private router = inject(Router);
-  private sessionService = inject(SessionService);
   private editProductsService = inject(EditProductsService);
   private activatedRoute = inject(ActivatedRoute);
 
   isEditMode = toSignal(this.editProductsService.edit$, { initialValue: false });
-  currentProduct = toSignal(this.editProductsService.currentProduct, { initialValue: undefined });
-
-  lastProductId = signal<number | undefined>(undefined);
+  currentProduct = toSignal(this.editProductsService.currentProduct$);
   activeLink = signal<Tabs>(Tabs.Unknown);
 
   Tabs = Tabs;
@@ -48,30 +43,6 @@ export class ProductsDetailsView {
   regexProperties: RegExp = /(details\/\d*\/properties)/;
 
   constructor() {
-    this.activatedRoute.data.subscribe(data => {
-      const product = data['product'];
-
-      if (this.lastProductId() === product?.id) return;
-
-      const wipProduct = this.sessionService.getWipProduct();
-
-      if (
-        this.lastProductId() !== undefined &&
-        product?.properties &&
-        !wipProduct
-      ) {
-        const newUrl = `details/${product?.id}/properties`;
-        this.router.navigate([newUrl]);
-      }
-
-      this.lastProductId.set(product?.id);
-
-      if (wipProduct) {
-        this.editProductsService.edit$.next(true);
-        this.sessionService.removeWipProduct();
-      }
-    });
-
     this.router.events.subscribe((val) => {
       if (val instanceof NavigationEnd || val instanceof NavigationCancel) {
         let url = this.router.url;

--- a/src/Moryx.Products.Web/app/src/app/components/products-details-view/products-resolver.ts
+++ b/src/Moryx.Products.Web/app/src/app/components/products-details-view/products-resolver.ts
@@ -20,7 +20,7 @@ import { SessionService } from 'src/app/services/session.service';
  * This ought to be the only place where the product details are retrieved from the API.
  * The retrieved product is stored in the EditProductsService and can be accessed by all child components of the details view.
  */
-export const ProductsDetailsViewResolver: ResolveFn<ProductModel> = async (route: ActivatedRouteSnapshot) => {
+export const ProductResolver: ResolveFn<ProductModel> = async (route: ActivatedRouteSnapshot) => {
   const apiService = inject(ProductManagementService);
   const sessionService = inject(SessionService);
   const editService = inject(EditProductsService);
@@ -46,28 +46,5 @@ export const ProductsDetailsViewResolver: ResolveFn<ProductModel> = async (route
     editService.resetProduct();
     return new RedirectCommand(router.parseUrl(''));
   }
-
-  // ToDo: Move to resolvefn for references getReferencesOfCurrentProduct();
-
-  // private getReferencesOfCurrentProduct() {
-  //   const product = this.currentProduct.value;
-  //   if (!product) return;
-
-  //   const body = <ProductQuery>{
-  //     includeDeleted: false,
-  //     identifier: product.identifier,
-  //     revision: product.revision,
-  //     revisionFilter: RevisionFilter.Specific,
-  //     selector: Selector.Parent,
-  //   };
-  //   this.productManagementService.getTypes({body: body}).subscribe({
-  //     next: (references) => {
-  //       this.references.next(references);
-  //     },
-  //     error: async (e: HttpErrorResponse) => {
-  //       await this.snackbarService.handleError(e);
-  //     },
-  //   });
-  // }
 };
 

--- a/src/Moryx.Products.Web/app/src/app/components/products-importer/products-importer.html
+++ b/src/Moryx.Products.Web/app/src/app/components/products-importer/products-importer.html
@@ -1,32 +1,38 @@
-<div class="importer-header">
-  <div class="importer-header-information">
-    <h2 class="importer-header-information-title">
-      {{ TranslationConstants.IMPORTER.TITLE | translate }}
-    </h2>
-    <p>{{ TranslationConstants.IMPORTER.SUB_TITLE | translate }}</p>
+@let properties = importerProperties();
+
+<mat-toolbar>
+  <mat-toolbar-row>
+    {{ TranslationConstants.IMPORTER.TITLE | translate }}
+  </mat-toolbar-row>
+  <mat-toolbar-row class="importer-subtitle">
+      {{ TranslationConstants.IMPORTER.SUB_TITLE | translate }}
+  </mat-toolbar-row>
+  <mat-toolbar-row>
     <mat-form-field appearance="outline" class="importer-selector">
       <mat-label>{{
         TranslationConstants.IMPORTER.TITLE | translate
       }}</mat-label>
-      <mat-select
-        [(ngModel)]="selectedImporter">
-        @for (importer of possibleImporters(); track importer) {
-          <mat-option
-            [value]="importer"
-            >
+      <mat-select [value]="selectedImporter()">
+        @for (importer of possibleImporters(); track importer.name) {
+          <mat-option [value]="importer" (click)="selectImporter(importer)">
             {{ importer.name }}
           </mat-option>
         }
       </mat-select>
     </mat-form-field>
-  </div>
-</div>
+  </mat-toolbar-row>
+</mat-toolbar>
+
+@if (showProgressBar()) {
+  <div class="progress-bar-container"><mat-progress-bar mode="indeterminate"></mat-progress-bar></div>
+}
+
 <mat-divider class="importer-header-border"></mat-divider>
 
-@if (importerProperties()) {
+@if (properties) {
   <div class="importer-properties">
     <navigable-entry-editor
-      [entry]="importerProperties()!"
+      [entry]="properties"
       queryParam="productImport"
       [disabled]="false"
     ></navigable-entry-editor>
@@ -48,6 +54,3 @@
     {{ TranslationConstants.IMPORTER.IMPORT | translate }}
   </button>
 </div>
-@if (showProgressBar()) {
-  <div class="progress-bar-container"><mat-progress-bar mode="indeterminate"></mat-progress-bar></div>
-}

--- a/src/Moryx.Products.Web/app/src/app/components/products-importer/products-importer.scss
+++ b/src/Moryx.Products.Web/app/src/app/components/products-importer/products-importer.scss
@@ -1,22 +1,14 @@
 @use "@moryx/ngx-web-framework/styles/variables" as *; 
 
-.importer-header {
-  display: flex;
-  margin-left: 10px;
-  flex-flow: row nowrap;
-  height: fit-content;
-  margin-top: 10px;
-  justify-content: flex-start;
+.importer-subtitle {
+  font-size: 14px;
+  letter-spacing: 0.1pt;
+  line-height: 20pt;
+  margin-top: -24px;
 }
+
 .importer-selector{
   margin-top: 10px;
-}
-.importer-header-information {
-  flex: 1 1 90%;
-  display: flex;
-  flex-flow: column nowrap;
-  height: fit-content;
-  justify-content: flex-start;
 }
 
 .importer-properties {
@@ -39,4 +31,5 @@
 .progress-bar-container{
   margin-left: 10px;
   margin-right: 10px;
+  margin-bottom: 16px;
 }

--- a/src/Moryx.Products.Web/app/src/app/components/products-importer/products-importer.ts
+++ b/src/Moryx.Products.Web/app/src/app/components/products-importer/products-importer.ts
@@ -3,7 +3,7 @@
  * Licensed under the Apache License, Version 2.0
 */
 
-import { Component, effect, inject, signal, untracked } from "@angular/core";
+import { Component, computed, effect, inject, signal, untracked } from "@angular/core";
 import { ActivatedRoute, Router } from "@angular/router";
 import { Entry, EntryValueType, NavigableEntryEditor } from "@moryx/ngx-web-framework/entry-editor";
 import { TranslateModule } from "@ngx-translate/core";
@@ -21,6 +21,10 @@ import { MatProgressBarModule } from "@angular/material/progress-bar";
 import { MatSelectModule } from "@angular/material/select";
 import { MatButtonModule } from "@angular/material/button";
 import { MatCardModule } from "@angular/material/card";
+import { toSignal } from "@angular/core/rxjs-interop";
+import { map } from "rxjs/operators";
+import { MatToolbarModule } from "@angular/material/toolbar";
+
 
 @Component({
   selector: "app-products-importer",
@@ -39,16 +43,24 @@ import { MatCardModule } from "@angular/material/card";
     MatProgressBarModule,
     MatSelectModule,
     MatButtonModule,
-    MatCardModule
-  ]
+    MatCardModule,
+    MatToolbarModule
+]
 })
 export class ProductsImporter {
   private cacheService = inject(CacheProductsService);
   private route = inject(ActivatedRoute);
   private router = inject(Router);
 
-  possibleImporters = signal<ProductImporter[]>([]);
-  selectedImporter = signal<ProductImporter | undefined>(undefined);
+  possibleImporters = toSignal(this.cacheService.importers$, { initialValue: [] });
+  currentImporterName = toSignal(this.route.paramMap.pipe(map((pm) => pm.get("importer"))), {
+    initialValue: this.route.snapshot.paramMap.get("importer"),
+  });
+  selectedImporter = computed(() => {
+    const name = this.currentImporterName();
+    const importers = this.possibleImporters() ?? [];
+    return importers.find((i) => i.name === name);
+  });
   importerProperties = signal<Entry>(<Entry>{value: {type: EntryValueType.Exception}});
   showProgressBar = signal(false);
 
@@ -56,18 +68,6 @@ export class ProductsImporter {
   Permissions = Permissions;
 
   constructor() {
-    this.cacheService.importers.subscribe((importers) => {
-      if (importers) {
-        this.possibleImporters.update((_) => importers);
-        const importerName = this.route.snapshot.paramMap.get("importer");
-        if (!importerName) return;
-
-        this.selectedImporter.update((_) =>
-          this.possibleImporters()?.find((i) => i.name === importerName)
-        );
-      }
-    });
-
     effect(() => {
       const importer = this.selectedImporter();
       untracked(() => {
@@ -77,27 +77,27 @@ export class ProductsImporter {
       });
     });
   }
+  
+  selectImporter(importer: ProductImporter) {
+    this.router.navigate(['import', importer.name]);
+  }
 
   onImporterChanged(importer: ProductImporter) {
     if (importer.parameters !== undefined) {
-      this.importerProperties.update((_) =>
-        structuredClone(importer.parameters!)
-      );
+      this.importerProperties.set(structuredClone(importer.parameters!));
     }
   }
 
-  import() {
-    this.showProgressBar.update((_) => true);
-    if (this.selectedImporter() && this.selectedImporter()?.name)
-      this.cacheService
-        .importProducts(this.selectedImporter()?.name!, this.importerProperties())
-        .then((resolved) => {
-          //refresh/go to default hom page
-          if (resolved) {
-            this.showProgressBar.update((_) => false);
-            this.router.navigate([``]);
-          }
-        });
+  async import() {
+    this.showProgressBar.set(true);
+    const importer = this.selectedImporter();
+    if (!importer?.name) {
+      return;
+    }
+    await this.cacheService.importProducts(importer.name, this.importerProperties());
+
+    this.showProgressBar.set(false);
+    this.router.navigate([``]);
   }
 
   cancelImport() {

--- a/src/Moryx.Products.Web/app/src/app/dialogs/dialog-add-part/dialog-add-part.ts
+++ b/src/Moryx.Products.Web/app/src/app/dialogs/dialog-add-part/dialog-add-part.ts
@@ -9,7 +9,7 @@ import { MatDialogRef, MAT_DIALOG_DATA, MatDialogModule } from '@angular/materia
 import { SnackbarService } from '@moryx/ngx-web-framework/services';
 import { TranslateModule } from '@ngx-translate/core';
 import { TranslationConstants } from 'src/app/extensions/translation-constants.extensions';
-import { PartConnector, ProductModel, RevisionFilter, Selector } from '../../api/models';
+import { PartConnector, ProductModel, ProductQuery, RevisionFilter, Selector } from '../../api/models';
 import { ProductManagementService } from '../../api/services';
 import { EditProductsService } from '../../services/edit-products.service';
 import { CommonModule } from '@angular/common';
@@ -58,24 +58,21 @@ export class DialogAddPart {
       includeDeleted: false,
       revisionFilter: RevisionFilter.All,
       selector: Selector.Direct,
-      type: this.data?.type,
-    };
+      typeName: this.data.type,
+    } as ProductQuery;
     this.productManagementService.getTypes({body: body}).subscribe({
       next: (products) => {
-        let possibleParts = [] as ProductModel[];
-        if (this.data && this.data.parts?.length && !this.data.isCollection) {
-          possibleParts = products.filter(
-            (p) => !this.data.parts?.some((s) => s.product?.id === p.id)
-          );
-        } else {
-          possibleParts = products;
+        let possibleParts = products;
+        const currentParts = this.data.parts;
+        if (currentParts?.length && !this.data.isCollection) {
+          possibleParts = possibleParts.filter((p) => currentParts[0]?.id !== p.id);
         }
-
+        
+        // Todo: Make possible parts a resource signal
         this.possibleParts.update(_ => possibleParts);
         this.filteredPossibleParts.update(_ => possibleParts);
       },
-      error: async (e: HttpErrorResponse) =>
-        await this.snackbarService.handleError(e)
+      error: async (e) => await this.snackbarService.handleError(e)
     });
   }
 

--- a/src/Moryx.Products.Web/app/src/app/dialogs/dialog-show-revisions/dialog-show-revisions.html
+++ b/src/Moryx.Products.Web/app/src/app/dialogs/dialog-show-revisions/dialog-show-revisions.html
@@ -9,7 +9,7 @@
         class="show-revisions-list-item"
         (click)="onOpen(product)">
         {{ createProductIdentity(product.identifier, product.revision) }}
-        {{ product.name | slice: 0:40 }}
+        {{ product.name }}
       </mat-list-item>
     }
   </mat-action-list>

--- a/src/Moryx.Products.Web/app/src/app/dialogs/dialog-show-revisions/dialog-show-revisions.scss
+++ b/src/Moryx.Products.Web/app/src/app/dialogs/dialog-show-revisions/dialog-show-revisions.scss
@@ -11,4 +11,7 @@
   -webkit-box-sizing: border-box;
   box-sizing: border-box;
   width: 100%;
+  overflow: hidden; 
+  white-space: nowrap; 
+  text-overflow: ellipsis;
 }

--- a/src/Moryx.Products.Web/app/src/app/dialogs/dialog-show-revisions/dialog-show-revisions.ts
+++ b/src/Moryx.Products.Web/app/src/app/dialogs/dialog-show-revisions/dialog-show-revisions.ts
@@ -76,7 +76,8 @@ export class DialogShowRevisions implements OnInit {
           .then(() => this.editService.loadProductById(product.id ?? 0));
       });
     } else {
-      this.router.navigate([`/details/${product.id}`]).then(() => this.editService.loadProduct());
+      this.router.navigate([`/details/${product.id}`])
+        .then(() => this.editService.loadProductById(product.id ?? 0));
     }
   }
 

--- a/src/Moryx.Products.Web/app/src/app/dialogs/dialog-show-revisions/dialog-show-revisions.ts
+++ b/src/Moryx.Products.Web/app/src/app/dialogs/dialog-show-revisions/dialog-show-revisions.ts
@@ -6,13 +6,14 @@
 import { HttpErrorResponse } from '@angular/common/http';
 import { Component, inject, OnInit, signal } from '@angular/core';
 import { MatDialogRef, MAT_DIALOG_DATA, MatDialogModule } from '@angular/material/dialog';
-import { ActivatedRoute, Router } from '@angular/router';
+import { Router } from '@angular/router';
 import { SnackbarService } from '@moryx/ngx-web-framework/services';
 import { TranslateModule } from '@ngx-translate/core';
 import { TranslationConstants } from 'src/app/extensions/translation-constants.extensions';
 import { ProductModel, RevisionFilter } from '../../api/models';
 import { ProductManagementService } from '../../api/services';
 import { EditProductsService } from '../../services/edit-products.service';
+// ToDo: Remove CommonModule
 import { CommonModule } from '@angular/common';
 import { MatActionList, MatListModule } from '@angular/material/list';
 import { MatButtonModule } from '@angular/material/button';
@@ -37,7 +38,6 @@ export class DialogShowRevisions implements OnInit {
   private editService = inject(EditProductsService);
   private managementService = inject(ProductManagementService);
   private router = inject(Router);
-  private route = inject(ActivatedRoute);
   private snackbarService = inject(SnackbarService);
 
   revisions = signal<ProductModel[]>([]);
@@ -68,17 +68,7 @@ export class DialogShowRevisions implements OnInit {
 
   onOpen(product: ProductModel) {
     this.dialogRef.close();
-    const regexSpecificRecipe: RegExp = /(details\/\d*\/recipes\/\d*)/;
-    if (regexSpecificRecipe.test(this.router.url)) {
-      this.router.navigate(['../../'], {relativeTo: this.route}).then(() => {
-        this.router
-          .navigate([`/details/${product.id}`])
-          .then(() => this.editService.loadProductById(product.id ?? 0));
-      });
-    } else {
-      this.router.navigate([`/details/${product.id}`])
-        .then(() => this.editService.loadProductById(product.id ?? 0));
-    }
+    this.router.navigate(['/details', product.id]);
   }
 
   createProductIdentity(identifier: string | undefined | null, revision: number | undefined): string {

--- a/src/Moryx.Products.Web/app/src/app/dialogs/dialog-show-revisions/dialog-show-revisions.ts
+++ b/src/Moryx.Products.Web/app/src/app/dialogs/dialog-show-revisions/dialog-show-revisions.ts
@@ -13,8 +13,6 @@ import { TranslationConstants } from 'src/app/extensions/translation-constants.e
 import { ProductModel, RevisionFilter } from '../../api/models';
 import { ProductManagementService } from '../../api/services';
 import { EditProductsService } from '../../services/edit-products.service';
-// ToDo: Remove CommonModule
-import { CommonModule } from '@angular/common';
 import { MatActionList, MatListModule } from '@angular/material/list';
 import { MatButtonModule } from '@angular/material/button';
 
@@ -23,7 +21,6 @@ import { MatButtonModule } from '@angular/material/button';
   templateUrl: './dialog-show-revisions.html',
   styleUrls: ['./dialog-show-revisions.scss'],
   imports: [
-    CommonModule,
     TranslateModule,
     MatActionList,
     MatListModule,

--- a/src/Moryx.Products.Web/app/src/app/extensions/translation-constants.extensions.ts
+++ b/src/Moryx.Products.Web/app/src/app/extensions/translation-constants.extensions.ts
@@ -70,10 +70,7 @@ export class TranslationConstants {
   public static readonly PARTS = {
     REMOVE: 'PARTS.REMOVE',
     ADD: 'PARTS.ADD',
-    REPLACE: 'PARTS.REPLACE',
-    DETAILS: {
-      TITLE: 'PARTS.DETAILS.TITLE',
-    },
+    REPLACE: 'PARTS.REPLACE'
   };
 
   public static readonly ADD_DIALOG = {

--- a/src/Moryx.Products.Web/app/src/app/extensions/translation-constants.extensions.ts
+++ b/src/Moryx.Products.Web/app/src/app/extensions/translation-constants.extensions.ts
@@ -70,7 +70,8 @@ export class TranslationConstants {
   public static readonly PARTS = {
     REMOVE: 'PARTS.REMOVE',
     ADD: 'PARTS.ADD',
-    REPLACE: 'PARTS.REPLACE'
+    REPLACE: 'PARTS.REPLACE',
+    OPEN: 'PARTS.OPEN'
   };
 
   public static readonly ADD_DIALOG = {
@@ -117,8 +118,7 @@ export class TranslationConstants {
   public static readonly SHOW_REVISION_DIALOG = {
     TITLE: 'SHOW_REVISION_DIALOG.TITLE',
     CANCEL: 'SHOW_REVISION_DIALOG.CANCEL',
-    ADD_REVISION: 'SHOW_REVISION_DIALOG.ADD_REVISION',
-    OPEN: 'SHOW_REVISION_DIALOG.OPEN',
+    ADD_REVISION: 'SHOW_REVISION_DIALOG.ADD_REVISION'
   };
 
   public static readonly SIDEBAR_BUTTONS = {

--- a/src/Moryx.Products.Web/app/src/app/services/cache-products.service.ts
+++ b/src/Moryx.Products.Web/app/src/app/services/cache-products.service.ts
@@ -7,7 +7,7 @@ import { inject, Injectable } from '@angular/core';
 import { Router } from '@angular/router';
 import { SnackbarService } from '@moryx/ngx-web-framework/services';
 import { Entry } from '@moryx/ngx-web-framework/entry-editor';
-import { BehaviorSubject } from 'rxjs';
+import { BehaviorSubject, lastValueFrom } from 'rxjs';
 import {
   ProductDefinitionModel,
   ProductImporter,
@@ -25,6 +25,7 @@ import '../extensions/observable.extensions';
 import { TranslateService } from '@ngx-translate/core';
 import { TranslationConstants } from '../extensions/translation-constants.extensions';
 import { HttpErrorResponse } from '@angular/common/http';
+import { Import$Params } from '../api/functions';
 
 @Injectable({
   providedIn: 'root',
@@ -38,7 +39,8 @@ export class CacheProductsService {
 
   definitions: BehaviorSubject<ProductDefinitionModel[] | undefined> = new BehaviorSubject<ProductDefinitionModel[] | undefined>(undefined);
   productsShownInTheTree: BehaviorSubject<ProductModel[] | undefined> = new BehaviorSubject<ProductModel[] | undefined>(undefined);
-  importers: BehaviorSubject<ProductImporter[] | undefined> = new BehaviorSubject<ProductImporter[] | undefined>(undefined);
+  private importers: BehaviorSubject<ProductImporter[] | undefined> = new BehaviorSubject<ProductImporter[] | undefined>(undefined);
+  importers$ = this.importers.asObservable();
   recipeDefinitions: BehaviorSubject<RecipeDefinitionModel[] | undefined> = new BehaviorSubject<RecipeDefinitionModel[] | undefined>(undefined);
   selected: ProductModel[] | undefined;
   workplans: BehaviorSubject<WorkplanModel[] | undefined> = new BehaviorSubject<WorkplanModel[] | undefined>(undefined);
@@ -199,35 +201,18 @@ export class CacheProductsService {
     }
   }
 
-  importProducts(importerName: string, importParameters: Entry | undefined) {
-    return new Promise<boolean>((resolve) => {
-      let body = {} as { importerName: string; body?: Entry | undefined };
-      if (importParameters) {
-        body = {
-          importerName: importerName,
-          body: importParameters,
-        };
-      } else {
-        body = {
-          importerName: importerName,
-        };
-      }
+  async importProducts(importerName: string, importParameters: Entry | undefined) {
+    const body = {
+      importerName: importerName,
+      body: importParameters,
+    } as Import$Params;
 
-      this.service.import(body).subscribe({
-        next: (products) => {
-          let newProductsOfTree = this.productsShownInTheTree.value ?? [];
-          for (let product of products) {
-            newProductsOfTree.push(product);
-          }
-          this.productsShownInTheTree.next(newProductsOfTree);
-        },
-        error: async (e: HttpErrorResponse) => {
-          await this.snackbarService.handleError(e);
-        },
-      });
-
-      resolve(true);
-    });
+    try {
+      await lastValueFrom(this.service.import(body));  
+      await this.loadProductsForTree();
+    } catch (error) {
+      await this.snackbarService.handleError(error as HttpErrorResponse);    
+    }
   }
 }
 

--- a/src/Moryx.Products.Web/app/src/app/services/cache-products.service.ts
+++ b/src/Moryx.Products.Web/app/src/app/services/cache-products.service.ts
@@ -76,6 +76,7 @@ export class CacheProductsService {
     });
   }
 
+  // ToDo Make async
   loadProductsForTree() {
     let body = <ProductQuery>{};
     if (this.filterOptions.name && this.filterOptions.identifier) {

--- a/src/Moryx.Products.Web/app/src/app/services/edit-products.service.ts
+++ b/src/Moryx.Products.Web/app/src/app/services/edit-products.service.ts
@@ -5,13 +5,13 @@
 
 import { formatNumber } from "@angular/common";
 import { HttpErrorResponse } from "@angular/common/http";
-import { inject, Injectable } from "@angular/core";
+import { inject, Injectable, linkedSignal } from "@angular/core";
 import { ActivatedRoute, Router } from "@angular/router";
 import { SnackbarService } from "@moryx/ngx-web-framework/services";
 import { PrototypeToEntryConverter } from "@moryx/ngx-web-framework/entry-editor";
 import { BehaviorSubject, lastValueFrom } from "rxjs";
 import { map } from "rxjs/operators";
-import { ProductModel, RecipeModel } from "../api/models";
+import { PartConnector, PartModel, ProductModel, RecipeModel } from "../api/models";
 import { ProductManagementService } from "../api/services/product-management.service";
 import { TranslationConstants } from "../extensions/translation-constants.extensions";
 import { DuplicateProductInfos } from "../models/DuplicateProductInfos";
@@ -26,7 +26,6 @@ export class EditProductsService {
   private productManagementService = inject(ProductManagementService);
   private router = inject(Router);
   private cacheProductsService = inject(CacheProductsService);
-  private activatedRoute = inject(ActivatedRoute);
   private snackbarService = inject(SnackbarService);
 
   public edit$: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(false);
@@ -44,6 +43,25 @@ export class EditProductsService {
   public currentRecipeNumber: number = 0;
   maximumAlreadySavedRecipeId: number = 0;
 
+  private productSignal = toSignal(this.currentProduct$, { initialValue: undefined });
+  private partConnector = linkedSignal<ProductModel | undefined, PartConnector | undefined>({
+    source: this.productSignal,
+    computation: (currentProduct, previous) => {
+    if (!currentProduct) {
+      return undefined;
+    }
+    return currentProduct.parts?.find(c => c.name === previous?.value?.name);
+  }});
+  public currentPartConnector = this.partConnector.asReadonly();
+  private part = linkedSignal<PartConnector | undefined, PartModel | undefined>({
+    source: this.partConnector,
+    computation: (partConnector, previous) => {
+      if (!partConnector) {
+        return undefined;
+      }
+      return partConnector.parts?.find(p => p.id === previous?.value?.id);
+    }});
+  public currentPart = this.part.asReadonly();
   public currentPartId: number = 0;
   maximumAlreadySavedPartId: number = 0;
   TranslationConstants = TranslationConstants;
@@ -234,7 +252,7 @@ export class EditProductsService {
 
   addRecipe(recipe: RecipeModel) {const currentProduct = this.currentProduct.value;
     if (!currentProduct) {
-      throw new Error("No current product set");
+      throw new Error("Invalid State: No current product set");
     }
     currentProduct.recipes!.push(recipe);
     this.currentProduct.next({...currentProduct, recipes: [...currentProduct.recipes!]});
@@ -250,15 +268,15 @@ export class EditProductsService {
       return;
     }
     if (currentRecipe?.id !== recipe.id) {
-      throw new Error("Tried to update recipe with id " + recipe.id + " but current recipe has id " + currentRecipe?.id);
+      throw new Error("Invalid State: Tried to update recipe with id " + recipe.id + " but current recipe has id " + currentRecipe?.id);
     }
     const currentProduct = this.currentProduct.value;
     if (!currentProduct) {
-      throw new Error("No current product set");
+      throw new Error("Invalid State: No current product set");
     }
     const recipeIndex = currentProduct.recipes?.findIndex(r => r.id === recipe.id);
     if (recipeIndex === undefined || recipeIndex < 0) {
-      throw new Error("Tried to update recipe with id " + recipe.id + " but it was not found in current product");
+      throw new Error("Invalid State: Tried to update recipe with id " + recipe.id + " but it was not found in current product");
     }
     this.currentRecipe.next(recipe);
     currentProduct.recipes![recipeIndex] = recipe;
@@ -272,6 +290,63 @@ export class EditProductsService {
       (r) => r.id !== recipe.id
     );
     this.currentProduct.next(currentProduct);
+  }
+
+  setPartConnector(partConnector: PartConnector | undefined) {
+    this.partConnector.set(partConnector);
+  }
+
+  setPart(part: PartModel | undefined) {
+    this.part.set(part);
+  }
+
+  addPartToConnector(newPart: PartModel) {
+    const product = this.currentProduct.value;
+    if (!product) {
+      throw new Error("Invalid State: No current product set");
+    }
+
+    const connector = this.partConnector();
+    if (!connector) {
+      throw new Error("Invalid State: No part connector selected");
+    }
+
+    // Add new Part to PartLink
+    newPart.id = ++this.currentPartId;
+    if (connector.isCollection) {
+      connector.parts = [...connector.parts!, newPart];
+    }
+    else {
+      connector.parts = [newPart];
+    }
+    
+    const updatedConnectors = product.parts?.map(c => c.name === connector.name ? {...connector} : c) ?? [];
+    this.currentProduct.next({...product, parts: updatedConnectors});
+    return newPart;
+  }
+
+  removePartFromConnector() {
+    const product = this.currentProduct.value;
+    if (!product) {
+      throw new Error("Invalid State: No current product set");
+    }
+
+    const connector = this.partConnector();
+    if (!connector) {
+      throw new Error("Invalid State: No part connector selected");
+    }
+    const part = this.part();    
+    
+    if (connector?.isCollection) {
+      if (!part) {
+        throw new Error("Invalid State: No part selected");
+      }
+      connector.parts = connector.parts?.filter((p) => p.id !== part.id);
+    } else {
+      connector.parts = [] as PartModel[];
+    }
+    const updatedConnectors = product.parts?.map(c => c.name === connector.name ? {...connector} : c) ?? [];
+    this.currentProduct.next({...product, parts: updatedConnectors});
   }
 }
 

--- a/src/Moryx.Products.Web/app/src/app/services/edit-products.service.ts
+++ b/src/Moryx.Products.Web/app/src/app/services/edit-products.service.ts
@@ -56,6 +56,10 @@ export class EditProductsService {
     }
   }
 
+  // ToDo: Remove the whole load product logic from this service, there is already a product details view resolver
+  // which loads products based on the route. This should be moved to an app wide resolver and the only place the
+  // current product is loaded. Also make the behaviour subject readonly then.
+  // NO ONE ELSE SHOULD LOAD OR MODIFY THE CURRENT PRODUCT THAN THE RESOLVER FROM THE ROUTE!
   loadProduct() {
     let id = 0;
     const navigation = this.router.currentNavigation();
@@ -229,15 +233,16 @@ export class EditProductsService {
   onDuplicate(infos: DuplicateProductInfos) {
     if (!infos.revision || !infos.identifier || !infos.product?.id) return;
 
+    const id = infos.product.id;
     const identifier = this.createProductIdentity(
       infos.identifier,
       infos.revision
     );
 
     this.productManagementService
-      .duplicate({id: infos.product.id, body: `"${identifier}"`})
+      .duplicate({id: id, body: `"${identifier}"`})
       .subscribe({
-        next: (product) => {
+        next: () => {
           this.cacheProductsService.loadProductsForTree();
           const regexSpecificRecipe: RegExp = /(details\/\d*\/recipes\/\d*)/;
           if (regexSpecificRecipe.test(this.router.url)) {
@@ -245,13 +250,13 @@ export class EditProductsService {
               .navigate(["../../"], {relativeTo: this.activatedRoute})
               .then(() => {
                 this.router
-                  .navigate([`/details/${product.id}`])
-                  .then(() => this.loadProduct());
+                  .navigate([`/details/${id}`])
+                  .then(() => this.loadProductById(id));
               });
           } else {
             this.router
-              .navigate([`/details/${product.id}`])
-              .then(() => this.loadProduct());
+              .navigate([`/details/${id}`])
+              .then(() => this.loadProductById(id));
           }
         },
         error: async (e: HttpErrorResponse) => {

--- a/src/Moryx.Products.Web/app/src/app/services/edit-products.service.ts
+++ b/src/Moryx.Products.Web/app/src/app/services/edit-products.service.ts
@@ -9,7 +9,7 @@ import { inject, Injectable } from "@angular/core";
 import { ActivatedRoute, Router } from "@angular/router";
 import { SnackbarService } from "@moryx/ngx-web-framework/services";
 import { PrototypeToEntryConverter } from "@moryx/ngx-web-framework/entry-editor";
-import { BehaviorSubject } from "rxjs";
+import { BehaviorSubject, lastValueFrom } from "rxjs";
 import { map } from "rxjs/operators";
 import { ProductModel, RecipeModel } from "../api/models";
 import { ProductManagementService } from "../api/services/product-management.service";
@@ -30,6 +30,7 @@ export class EditProductsService {
   private snackbarService = inject(SnackbarService);
 
   public edit$: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(false);
+
   private currentProduct: BehaviorSubject<ProductModel | undefined> = new BehaviorSubject<ProductModel | undefined>(undefined);
   public currentProduct$ = this.currentProduct.asObservable();
   public currentProductId = toSignal(this.currentProduct$.pipe(map((p) => p?.id)));
@@ -37,6 +38,9 @@ export class EditProductsService {
   private references: BehaviorSubject<ProductModel[] | undefined> = new BehaviorSubject<ProductModel[] | undefined>(undefined);
   public references$ = this.references.asObservable();
 
+  // ToDo: Could be changed to linked signal if product observable becomes signal
+  private currentRecipe: BehaviorSubject<RecipeModel | undefined> = new BehaviorSubject<RecipeModel | undefined>(undefined);
+  public currentRecipe$ = this.currentRecipe.asObservable();
   public currentRecipeNumber: number = 0;
   maximumAlreadySavedRecipeId: number = 0;
 
@@ -50,17 +54,32 @@ export class EditProductsService {
     this.maximumAlreadySavedPartId = productStorageObject.details.maximumAlreadySavedPartId;
     this.maximumAlreadySavedRecipeId = productStorageObject.details.maximumAlreadySavedRecipeId;
     this.currentProduct.next(productStorageObject.product);
+    this.currentRecipe.next(productStorageObject.product.recipes?.find(r => r.id === productStorageObject.details.currentRecipeNumber));
 
     this.edit$.next(true);
   }
 
   setProduct(product: ProductModel | undefined) {
     this.currentProduct.next(product);
+    this.references.next(undefined);
+    this.currentRecipe.next(undefined);
+  }
+
+  updateCurrentProduct(product: ProductModel) {
+    const current = this.currentProduct.value;
+    if (Object.is(product, current)) {
+      return;
+    }
+    if (current?.id !== product.id) {
+      throw new Error("Tried to update product with id " + product.id + " but current product has id " + current?.id);
+    }
+    this.currentProduct.next(product);
   }
 
   resetProduct() {
     this.currentProduct.next(undefined);
     this.references.next(undefined);
+    this.currentRecipe.next(undefined);
   }
 
   setReferences(references: ProductModel[] | undefined) {
@@ -133,6 +152,7 @@ export class EditProductsService {
         this.cacheProductsService.loadProductsForTree();
         this.productManagementService.getTypeById({id: result}).subscribe({
           next: (p) => {
+            // ToDo: Update recipes, references and parts
             this.currentProduct.next(p);
             this.edit$.next(false);
           },
@@ -145,14 +165,24 @@ export class EditProductsService {
 
   async onCancel() {
     this.edit$.next(false);
-    const currentId = this.currentProductId();
-    if (!currentId) return;
+    const currentProductId = this.currentProductId();
+    if (!currentProductId) return;
 
-    await this.productManagementService
-      .getTypeById({id: currentId})
-      .toAsync()
-      .then(product => this.currentProduct.next(product))
-      .catch(async (error) => await this.snackbarService.handleError(error));
+    let product: ProductModel = {};
+    try {
+      product = await lastValueFrom(this.productManagementService.getTypeById({id: currentProductId}));  
+    } catch (error) {
+      await this.snackbarService.handleError(error as HttpErrorResponse);
+      return;
+    }
+    this.currentProduct.next(product);
+
+    const currentRecipe = this.currentRecipe.value;
+    if (!currentRecipe) return;
+    const recipe = product.recipes?.find(r => r.id === currentRecipe.id);
+    this.currentRecipe.next(recipe);
+
+    // ToDo: Update references and parts
   }
 
   onDuplicate(infos: DuplicateProductInfos) {
@@ -218,12 +248,39 @@ export class EditProductsService {
     return productName;
   }
 
-  addRecipe(recipe: RecipeModel) {
-    const currentProduct = this.currentProduct.value;
-    currentProduct?.recipes?.push(recipe);
-    this.currentProduct.next(currentProduct);
+  addRecipe(recipe: RecipeModel) {const currentProduct = this.currentProduct.value;
+    if (!currentProduct) {
+      throw new Error("No current product set");
+    }
+    currentProduct.recipes!.push(recipe);
+    this.currentProduct.next({...currentProduct, recipes: [...currentProduct.recipes!]});
   }
 
+  setRecipe(recipe: RecipeModel | undefined) {
+    this.currentRecipe.next(recipe);
+  }
+  
+  updateCurrentRecipe(recipe: RecipeModel) {
+    const currentRecipe = this.currentRecipe.value;
+    if (Object.is(recipe, currentRecipe)) {
+      return;
+    }
+    if (currentRecipe?.id !== recipe.id) {
+      throw new Error("Tried to update recipe with id " + recipe.id + " but current recipe has id " + currentRecipe?.id);
+    }
+    const currentProduct = this.currentProduct.value;
+    if (!currentProduct) {
+      throw new Error("No current product set");
+    }
+    const recipeIndex = currentProduct.recipes?.findIndex(r => r.id === recipe.id);
+    if (recipeIndex === undefined || recipeIndex < 0) {
+      throw new Error("Tried to update recipe with id " + recipe.id + " but it was not found in current product");
+    }
+    this.currentRecipe.next(recipe);
+    currentProduct.recipes![recipeIndex] = recipe;
+    this.currentProduct.next({...currentProduct, recipes: [...currentProduct.recipes!]});
+  }
+  
   removeRecipe(recipe: RecipeModel) {
     const currentProduct = this.currentProduct.value;
     if (!currentProduct?.recipes) return;

--- a/src/Moryx.Products.Web/app/src/app/services/edit-products.service.ts
+++ b/src/Moryx.Products.Web/app/src/app/services/edit-products.service.ts
@@ -10,18 +10,14 @@ import { ActivatedRoute, Router } from "@angular/router";
 import { SnackbarService } from "@moryx/ngx-web-framework/services";
 import { PrototypeToEntryConverter } from "@moryx/ngx-web-framework/entry-editor";
 import { BehaviorSubject } from "rxjs";
-import {
-  ProductModel,
-  ProductQuery,
-  RecipeModel,
-  RevisionFilter,
-  Selector,
-} from "../api/models";
+import { map } from "rxjs/operators";
+import { ProductModel, RecipeModel } from "../api/models";
 import { ProductManagementService } from "../api/services/product-management.service";
 import { TranslationConstants } from "../extensions/translation-constants.extensions";
 import { DuplicateProductInfos } from "../models/DuplicateProductInfos";
 import { CacheProductsService } from "./cache-products.service";
-import { SessionService } from "./session.service";
+import { ProductStorageObject } from "./session.service";
+import { toSignal } from "@angular/core/rxjs-interop";
 
 @Injectable({
   providedIn: "root",
@@ -30,117 +26,45 @@ export class EditProductsService {
   private productManagementService = inject(ProductManagementService);
   private router = inject(Router);
   private cacheProductsService = inject(CacheProductsService);
-  private sessionService = inject(SessionService);
   private activatedRoute = inject(ActivatedRoute);
   private snackbarService = inject(SnackbarService);
 
   public edit$: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(false);
-  public currentProduct: BehaviorSubject<ProductModel | undefined> = new BehaviorSubject<ProductModel | undefined>(undefined);
-  public references: BehaviorSubject<ProductModel[] | undefined> = new BehaviorSubject<ProductModel[] | undefined>(undefined);
+  private currentProduct: BehaviorSubject<ProductModel | undefined> = new BehaviorSubject<ProductModel | undefined>(undefined);
+  public currentProduct$ = this.currentProduct.asObservable();
+  public currentProductId = toSignal(this.currentProduct$.pipe(map((p) => p?.id)));
+
+  private references: BehaviorSubject<ProductModel[] | undefined> = new BehaviorSubject<ProductModel[] | undefined>(undefined);
+  public references$ = this.references.asObservable();
+
   public currentRecipeNumber: number = 0;
   maximumAlreadySavedRecipeId: number = 0;
+
   public currentPartId: number = 0;
   maximumAlreadySavedPartId: number = 0;
-  currentProductId: number = 0;
   TranslationConstants = TranslationConstants;
 
-  loadFromStorage() {
-    const productStorageObject = this.sessionService.getWipProduct();
-    if (productStorageObject) {
-      this.currentProductId = productStorageObject.product.id!;
-      this.currentPartId = productStorageObject.details.currentPartId;
-      this.currentRecipeNumber = productStorageObject.details.currentRecipeNumber;
-      this.maximumAlreadySavedPartId = productStorageObject.details.maximumAlreadySavedPartId;
-      this.maximumAlreadySavedRecipeId = productStorageObject.details.maximumAlreadySavedRecipeId;
-      this.currentProduct.next(productStorageObject.product);
-    }
+  setProductFromStorage(productStorageObject: ProductStorageObject) {
+    this.currentPartId = productStorageObject.details.currentPartId;
+    this.currentRecipeNumber = productStorageObject.details.currentRecipeNumber;
+    this.maximumAlreadySavedPartId = productStorageObject.details.maximumAlreadySavedPartId;
+    this.maximumAlreadySavedRecipeId = productStorageObject.details.maximumAlreadySavedRecipeId;
+    this.currentProduct.next(productStorageObject.product);
+
+    this.edit$.next(true);
   }
 
-  // ToDo: Remove the whole load product logic from this service, there is already a product details view resolver
-  // which loads products based on the route. This should be moved to an app wide resolver and the only place the
-  // current product is loaded. Also make the behaviour subject readonly then.
-  // NO ONE ELSE SHOULD LOAD OR MODIFY THE CURRENT PRODUCT THAN THE RESOLVER FROM THE ROUTE!
-  loadProduct() {
-    let id = 0;
-    const navigation = this.router.currentNavigation();
-    if (
-      navigation &&
-      (navigation?.finalUrl?.root.children["primary"]?.segments?.length ??
-        0 > 1)
-    )
-      id = Number(
-        navigation.finalUrl?.root.children["primary"].segments[1].toString()
-      );
-    else {
-      const url = this.router.url;
-      const regexId: RegExp = /(details\/\d*)/;
-      if (!regexId.test(url)) {
-        this.currentProduct.next(undefined);
-        return;
-      }
-      id = Number(url.split("/")[2]);
-    }
-
-    this.currentProductId = id;
-
-    if (id === 0) {
-      this.unloadProduct();
-      return;
-    }
-    this.loadProductById(id);
+  setProduct(product: ProductModel | undefined) {
+    this.currentProduct.next(product);
   }
 
-  loadProductById(id: number) {
-    this.productManagementService.getTypeById({id: id}).subscribe({
-      next: (product) => {
-        this.currentProduct.next(product);
-        this.getReferencesOfCurrentProduct();
-      },
-      error: async (e: HttpErrorResponse) => {
-        await this.handleLoadError(e);
-        this.unloadProduct();
-      },
-    });
-  }
-
-  private async handleLoadError(error: HttpErrorResponse) {
-    if (error.status === 0) {
-      // Unknown errors occur most commonly when the server is not reachable.
-      // That is handled somewhere else, so there is no need to show that here.
-      return;
-    }
-
-    if (error.error?.title !== undefined) {
-      await this.snackbarService.showError(error.error?.title);
-    } else {
-      await this.snackbarService.handleError(error);
-    }
-  }
-
-  unloadProduct() {
+  resetProduct() {
     this.currentProduct.next(undefined);
-    this.router.navigate([""]);
+    this.references.next(undefined);
   }
 
-  private getReferencesOfCurrentProduct() {
-    const product = this.currentProduct.value;
-    if (!product) return;
-
-    const body = <ProductQuery>{
-      includeDeleted: false,
-      identifier: product.identifier,
-      revision: product.revision,
-      revisionFilter: RevisionFilter.Specific,
-      selector: Selector.Parent,
-    };
-    this.productManagementService.getTypes({body: body}).subscribe({
-      next: (references) => {
-        this.references.next(references);
-      },
-      error: async (e: HttpErrorResponse) => {
-        await this.snackbarService.handleError(e);
-      },
-    });
+  setReferences(references: ProductModel[] | undefined) {
+    this.references.next(references);
   }
 
   onEdit() {
@@ -221,10 +145,11 @@ export class EditProductsService {
 
   async onCancel() {
     this.edit$.next(false);
-    if (!this.currentProduct.value?.id) return;
+    const currentId = this.currentProductId();
+    if (!currentId) return;
 
     await this.productManagementService
-      .getTypeById({id: this.currentProduct.value.id})
+      .getTypeById({id: currentId})
       .toAsync()
       .then(product => this.currentProduct.next(product))
       .catch(async (error) => await this.snackbarService.handleError(error));
@@ -244,19 +169,18 @@ export class EditProductsService {
       .subscribe({
         next: () => {
           this.cacheProductsService.loadProductsForTree();
+          // ToDo: Verify why recipe regex and why different navigations
           const regexSpecificRecipe: RegExp = /(details\/\d*\/recipes\/\d*)/;
           if (regexSpecificRecipe.test(this.router.url)) {
             this.router
               .navigate(["../../"], {relativeTo: this.activatedRoute})
               .then(() => {
                 this.router
-                  .navigate([`/details/${id}`])
-                  .then(() => this.loadProductById(id));
+                  .navigate([`/details/${id}`]);
               });
           } else {
             this.router
-              .navigate([`/details/${id}`])
-              .then(() => this.loadProductById(id));
+              .navigate([`/details/${id}`]);
           }
         },
         error: async (e: HttpErrorResponse) => {

--- a/src/Moryx.Products.Web/app/src/app/services/edit-products.service.ts
+++ b/src/Moryx.Products.Web/app/src/app/services/edit-products.service.ts
@@ -179,17 +179,8 @@ export class EditProductsService {
 
   async onCancel() {
     this.edit$.next(false);
-    const currentProductId = this.currentProductId();
-    if (!currentProductId) return;
-
-    let product: ProductModel = {};
-    try {
-      product = await lastValueFrom(this.productManagementService.getTypeById({id: currentProductId}));  
-    } catch (error) {
-      await this.snackbarService.handleError(error as HttpErrorResponse);
-      return;
-    }
-    this.currentProduct.next(product);    
+    const to = this.router.url;
+    await this.router.navigate(['/cancel'], { queryParams: { to: encodeURIComponent(to) }, replaceUrl: true, });   
   }
 
   async onDuplicate(infos: DuplicateProductInfos) {

--- a/src/Moryx.Products.Web/app/src/app/services/edit-products.service.ts
+++ b/src/Moryx.Products.Web/app/src/app/services/edit-products.service.ts
@@ -33,17 +33,23 @@ export class EditProductsService {
   private currentProduct: BehaviorSubject<ProductModel | undefined> = new BehaviorSubject<ProductModel | undefined>(undefined);
   public currentProduct$ = this.currentProduct.asObservable();
   public currentProductId = toSignal(this.currentProduct$.pipe(map((p) => p?.id)));
+  private productSignal = toSignal(this.currentProduct$, { initialValue: undefined });
 
   private references: BehaviorSubject<ProductModel[] | undefined> = new BehaviorSubject<ProductModel[] | undefined>(undefined);
   public references$ = this.references.asObservable();
 
-  // ToDo: Could be changed to linked signal if product observable becomes signal
-  private currentRecipe: BehaviorSubject<RecipeModel | undefined> = new BehaviorSubject<RecipeModel | undefined>(undefined);
-  public currentRecipe$ = this.currentRecipe.asObservable();
+  private recipe = linkedSignal<ProductModel | undefined, RecipeModel | undefined>({
+    source: this.productSignal,
+    computation: (currentProduct, previous) => {
+    if (!currentProduct) {
+      return undefined;
+    }
+    return currentProduct.recipes?.find(r => r.id === previous?.value?.id);
+  }});
+  public currentRecipe = this.recipe.asReadonly();
   public currentRecipeNumber: number = 0;
   maximumAlreadySavedRecipeId: number = 0;
 
-  private productSignal = toSignal(this.currentProduct$, { initialValue: undefined });
   private partConnector = linkedSignal<ProductModel | undefined, PartConnector | undefined>({
     source: this.productSignal,
     computation: (currentProduct, previous) => {
@@ -63,7 +69,7 @@ export class EditProductsService {
     }});
   public currentPart = this.part.asReadonly();
   public currentPartId: number = 0;
-  maximumAlreadySavedPartId: number = 0;
+  public maximumAlreadySavedPartId: number = 0;
   TranslationConstants = TranslationConstants;
 
   setProductFromStorage(productStorageObject: ProductStorageObject) {
@@ -72,7 +78,7 @@ export class EditProductsService {
     this.maximumAlreadySavedPartId = productStorageObject.details.maximumAlreadySavedPartId;
     this.maximumAlreadySavedRecipeId = productStorageObject.details.maximumAlreadySavedRecipeId;
     this.currentProduct.next(productStorageObject.product);
-    this.currentRecipe.next(productStorageObject.product.recipes?.find(r => r.id === productStorageObject.details.currentRecipeNumber));
+    this.recipe.set(productStorageObject.product.recipes?.find(r => r.id === productStorageObject.details.currentRecipeNumber));
 
     this.edit$.next(true);
   }
@@ -80,7 +86,6 @@ export class EditProductsService {
   setProduct(product: ProductModel | undefined) {
     this.currentProduct.next(product);
     this.references.next(undefined);
-    this.currentRecipe.next(undefined);
   }
 
   updateCurrentProduct(product: ProductModel) {
@@ -97,7 +102,6 @@ export class EditProductsService {
   resetProduct() {
     this.currentProduct.next(undefined);
     this.references.next(undefined);
-    this.currentRecipe.next(undefined);
   }
 
   setReferences(references: ProductModel[] | undefined) {
@@ -130,7 +134,7 @@ export class EditProductsService {
     this.edit$.next(true);
   }
 
-  onSave() {
+  async onSave() {
     const productModel = this.currentProduct.value;
     if (!productModel || productModel.id === undefined) return;
 
@@ -138,47 +142,39 @@ export class EditProductsService {
     if (productModel.properties)
       PrototypeToEntryConverter.convertToEntry(productModel.properties);
 
-    if (productModel.recipes) {
-      for (let recipe of productModel.recipes) {
-        // Recipes with the id 0 will be created and saved as new recipes in the backend
-        if (!recipe.id) recipe.id = 0;
-        else if (recipe.id > this.maximumAlreadySavedRecipeId) recipe.id = 0;
-
-        if (recipe.properties)
-          PrototypeToEntryConverter.convertToEntry(recipe.properties);
+    for (let recipe of productModel.recipes ?? []) {
+      // Recipes with the id 0 will be created and saved as new recipes in the backend
+      if (!recipe.id || recipe.id > this.maximumAlreadySavedRecipeId) {
+        recipe.id = 0;
       }
+
+      if (recipe.properties)
+        PrototypeToEntryConverter.convertToEntry(recipe.properties);
     }
 
-    if (productModel?.parts?.length) {
-      for (let partConnector of productModel.parts) {
-        if (!partConnector.parts?.length) continue;
-        for (let part of partConnector.parts) {
-          if (!part.id) part.id = 0;
-          else if (part.id > this.maximumAlreadySavedPartId) part.id = 0;
-
-          if (part.properties)
-            PrototypeToEntryConverter.convertToEntry(part.properties);
+    for (let partConnector of productModel?.parts ?? []) {
+      for (let part of partConnector.parts ?? []) {
+        if (!part.id || part.id > this.maximumAlreadySavedPartId) {
+          part.id = 0;
         }
+
+        if (part.properties)
+          PrototypeToEntryConverter.convertToEntry(part.properties);
       }
     }
 
-    this.productManagementService
-      .updateType({id: productModel.id, body: productModel})
-      .subscribe((result) => {
-        if (result !== productModel?.id) return;
-
-        this.cacheProductsService.loadProductsForTree();
-        this.productManagementService.getTypeById({id: result}).subscribe({
-          next: (p) => {
-            // ToDo: Update recipes, references and parts
-            this.currentProduct.next(p);
-            this.edit$.next(false);
-          },
-          error: async (e: HttpErrorResponse) => {
-            await this.snackbarService.handleError(e);
-          },
-        });
-      });
+    let updated: ProductModel = {};
+    try {
+      await lastValueFrom(this.productManagementService.updateType({id: productModel.id, body: productModel}));
+      this.cacheProductsService.loadProductsForTree();
+      updated = await lastValueFrom(this.productManagementService.getTypeById({id: productModel.id}));  
+    } catch (error) {
+      await this.snackbarService.handleError(error as HttpErrorResponse);
+      return;
+    }
+    
+    this.currentProduct.next(updated);
+    this.edit$.next(false);
   }
 
   async onCancel() {
@@ -193,14 +189,7 @@ export class EditProductsService {
       await this.snackbarService.handleError(error as HttpErrorResponse);
       return;
     }
-    this.currentProduct.next(product);
-
-    const currentRecipe = this.currentRecipe.value;
-    if (!currentRecipe) return;
-    const recipe = product.recipes?.find(r => r.id === currentRecipe.id);
-    this.currentRecipe.next(recipe);
-
-    // ToDo: Update references and parts
+    this.currentProduct.next(product);    
   }
 
   async onDuplicate(infos: DuplicateProductInfos) {
@@ -259,11 +248,11 @@ export class EditProductsService {
   }
 
   setRecipe(recipe: RecipeModel | undefined) {
-    this.currentRecipe.next(recipe);
+    this.recipe.set(recipe);
   }
   
   updateCurrentRecipe(recipe: RecipeModel) {
-    const currentRecipe = this.currentRecipe.value;
+    const currentRecipe = this.recipe();
     if (Object.is(recipe, currentRecipe)) {
       return;
     }
@@ -278,7 +267,7 @@ export class EditProductsService {
     if (recipeIndex === undefined || recipeIndex < 0) {
       throw new Error("Invalid State: Tried to update recipe with id " + recipe.id + " but it was not found in current product");
     }
-    this.currentRecipe.next(recipe);
+    this.recipe.set(recipe);
     currentProduct.recipes![recipeIndex] = recipe;
     this.currentProduct.next({...currentProduct, recipes: [...currentProduct.recipes!]});
   }

--- a/src/Moryx.Products.Web/app/src/app/services/edit-products.service.ts
+++ b/src/Moryx.Products.Web/app/src/app/services/edit-products.service.ts
@@ -185,7 +185,7 @@ export class EditProductsService {
     // ToDo: Update references and parts
   }
 
-  onDuplicate(infos: DuplicateProductInfos) {
+  async onDuplicate(infos: DuplicateProductInfos) {
     if (!infos.revision || !infos.identifier || !infos.product?.id) return;
 
     const id = infos.product.id;
@@ -194,29 +194,13 @@ export class EditProductsService {
       infos.revision
     );
 
-    this.productManagementService
-      .duplicate({id: id, body: `"${identifier}"`})
-      .subscribe({
-        next: () => {
-          this.cacheProductsService.loadProductsForTree();
-          // ToDo: Verify why recipe regex and why different navigations
-          const regexSpecificRecipe: RegExp = /(details\/\d*\/recipes\/\d*)/;
-          if (regexSpecificRecipe.test(this.router.url)) {
-            this.router
-              .navigate(["../../"], {relativeTo: this.activatedRoute})
-              .then(() => {
-                this.router
-                  .navigate([`/details/${id}`]);
-              });
-          } else {
-            this.router
-              .navigate([`/details/${id}`]);
-          }
-        },
-        error: async (e: HttpErrorResponse) => {
-          await this.snackbarService.handleError(e);
-        },
-      });
+    try {
+      const product = await lastValueFrom(this.productManagementService.duplicate({id: id, body: `"${identifier}"`}));
+      this.cacheProductsService.loadProductsForTree();  
+      this.router.navigate(['details', product.id]);  
+    } catch (error) {
+      await this.snackbarService.handleError(error as HttpErrorResponse);
+    }
   }
 
   createProductIdentity(

--- a/src/Moryx.Products.Web/app/src/app/services/session.service.ts
+++ b/src/Moryx.Products.Web/app/src/app/services/session.service.ts
@@ -16,9 +16,8 @@ export class SessionService {
   private readonly PRODUCT_TREE_HIERARCHY: string = 'product-tree-hierarchy';
   private readonly WIP_PRODUCT: string = 'wip-product';
 
-  constructor() { }
-
-  setWipProduct(product: ProductModel, details: ProductStorageDetails) {
+  pushWipProduct(product: ProductModel, details: ProductStorageDetails) {
+    // ToDo Property values 0?
     const productStorageObject: ProductStorageObject = {product: product, details: details};
     sessionStorage.setItem(this.WIP_PRODUCT, JSON.stringify(productStorageObject));
   }
@@ -28,8 +27,10 @@ export class SessionService {
     return item ? JSON.parse(item) : undefined;
   }
 
-  removeWipProduct() {
+  popWipProduct(): ProductStorageObject | undefined {
+    const product = this.getWipProduct();
     sessionStorage.removeItem(this.WIP_PRODUCT);
+    return product;
   }
 
   getProductTreeHierarchy(): boolean {
@@ -60,15 +61,15 @@ export class SessionService {
         }
         expandedNodesString = expandedNodesString.slice(0, -1);
       }
-    } 
-    
+    }
+
     sessionStorage.setItem(this.PRODUCT_TREE, expandedNodesString);
   }
 
   expandNodesAccordingToStorage(treeControl: FlatTreeControl<FlatNode, FlatNode>) {
     const expandedNodes = sessionStorage.getItem(this.PRODUCT_TREE);
     if (!expandedNodes) return;
-  
+
     const expandedNodesArray = expandedNodes.split(',');
     for (let node of treeControl.dataNodes) {
       if (expandedNodesArray.includes(node.name)) {

--- a/src/Moryx.Products.Web/app/src/app/services/session.service.ts
+++ b/src/Moryx.Products.Web/app/src/app/services/session.service.ts
@@ -17,7 +17,6 @@ export class SessionService {
   private readonly WIP_PRODUCT: string = 'wip-product';
 
   pushWipProduct(product: ProductModel, details: ProductStorageDetails) {
-    // ToDo Property values 0?
     const productStorageObject: ProductStorageObject = {product: product, details: details};
     sessionStorage.setItem(this.WIP_PRODUCT, JSON.stringify(productStorageObject));
   }

--- a/src/Moryx.Products.Web/app/src/assets/languages/de.json
+++ b/src/Moryx.Products.Web/app/src/assets/languages/de.json
@@ -58,7 +58,8 @@
   "PARTS": {
     "REMOVE": "ENTFERNEN",
     "ADD": "HINZUFÜGEN",
-    "REPLACE": "ERSETZEN"
+    "REPLACE": "ERSETZEN",
+    "OPEN": "PRODUKT ÖFFNEN"
   },
   "ADD_DIALOG": {
     "TITLE": "Teil auswählen",

--- a/src/Moryx.Products.Web/app/src/assets/languages/de.json
+++ b/src/Moryx.Products.Web/app/src/assets/languages/de.json
@@ -58,10 +58,7 @@
   "PARTS": {
     "REMOVE": "ENTFERNEN",
     "ADD": "HINZUFÜGEN",
-    "REPLACE": "ERSETZEN",
-    "DETAILS": {
-      "TITLE": "Konfiguration für die Verbindung zwischen dem Produkt und seinem Teil"
-    }
+    "REPLACE": "ERSETZEN"
   },
   "ADD_DIALOG": {
     "TITLE": "Teil auswählen",

--- a/src/Moryx.Products.Web/app/src/assets/languages/en.json
+++ b/src/Moryx.Products.Web/app/src/assets/languages/en.json
@@ -58,10 +58,7 @@
   "PARTS": {
     "REMOVE": "REMOVE",
     "ADD": "ADD",
-    "REPLACE": "REPLACE",
-    "DETAILS": {
-      "TITLE": "Configuration for the connection between the product and its part"
-    }
+    "REPLACE": "REPLACE"
   },
   "ADD_DIALOG": {
     "TITLE": "Select Part",

--- a/src/Moryx.Products.Web/app/src/assets/languages/en.json
+++ b/src/Moryx.Products.Web/app/src/assets/languages/en.json
@@ -58,7 +58,8 @@
   "PARTS": {
     "REMOVE": "REMOVE",
     "ADD": "ADD",
-    "REPLACE": "REPLACE"
+    "REPLACE": "REPLACE",
+    "OPEN": "OPEN PRODUCT"
   },
   "ADD_DIALOG": {
     "TITLE": "Select Part",

--- a/src/Moryx.Products.Web/app/src/assets/languages/it.json
+++ b/src/Moryx.Products.Web/app/src/assets/languages/it.json
@@ -57,7 +57,8 @@
   "PARTS": {
     "REMOVE": "RIMUOVI",
     "ADD": "AGGIUNGI",
-    "REPLACE": "SOSTITUISCI"
+    "REPLACE": "SOSTITUISCI",
+    "OPEN": "PRODOTTO APERTO"
   },
   "ADD_DIALOG": {
     "TITLE": "Seleziona Pezzo",

--- a/src/Moryx.Products.Web/app/src/assets/languages/it.json
+++ b/src/Moryx.Products.Web/app/src/assets/languages/it.json
@@ -57,10 +57,7 @@
   "PARTS": {
     "REMOVE": "RIMUOVI",
     "ADD": "AGGIUNGI",
-    "REPLACE": "SOSTITUISCI",
-    "DETAILS": {
-      "TITLE": "Configurazione per la connessione tra il prodotto e i suoi pezzi"
-    }
+    "REPLACE": "SOSTITUISCI"
   },
   "ADD_DIALOG": {
     "TITLE": "Seleziona Pezzo",

--- a/src/Moryx.Products.Web/app/src/assets/languages/zh.json
+++ b/src/Moryx.Products.Web/app/src/assets/languages/zh.json
@@ -57,7 +57,8 @@
   "PARTS": {
     "REMOVE": "删除",
     "ADD": "添加",
-    "REPLACE": "替换"
+    "REPLACE": "替换",
+    "OPEN": "开放式产品"
   },
   "ADD_DIALOG": {
     "TITLE": "选择零件",

--- a/src/Moryx.Products.Web/app/src/assets/languages/zh.json
+++ b/src/Moryx.Products.Web/app/src/assets/languages/zh.json
@@ -57,10 +57,7 @@
   "PARTS": {
     "REMOVE": "删除",
     "ADD": "添加",
-    "REPLACE": "替换",
-    "DETAILS": {
-      "TITLE": "产品与零件之间的连接配置"
-    }
+    "REPLACE": "替换"
   },
   "ADD_DIALOG": {
     "TITLE": "选择零件",

--- a/src/Moryx.Products.Web/app/src/styles.scss
+++ b/src/Moryx.Products.Web/app/src/styles.scss
@@ -1,5 +1,6 @@
 @use "@moryx/ngx-web-framework/styles/theme"; 
-@use "@moryx/ngx-web-framework/styles/variables"; 
+@use "@moryx/ngx-web-framework/styles/variables";
+@use "@angular/material" as mat;
 
 html, body { 
   height: 100%;
@@ -105,4 +106,24 @@ app-product-importer{
   width: 100%;
   height: 100%;
   overflow: hidden;
+}
+
+:root {
+  @include mat.expansion-overrides((
+    header-description-color: rgba(0, 0, 0, 0.6)
+  ));
+}
+
+.mat-expansion-panel-header .mat-expansion-panel-header-title {
+  min-width: 0; 
+  overflow: hidden; 
+  text-overflow: ellipsis; 
+  white-space: nowrap; 
+}
+
+.mat-expansion-panel-header .mat-expansion-panel-header-description {  
+  min-width: 0; 
+  overflow: hidden; 
+  text-overflow: ellipsis; 
+  white-space: nowrap;
 }


### PR DESCRIPTION
## Summary
This PR resolves multiple issues in the context of the products user interface. Each of the following points is separated in commit and I recommend reviewing them one after another. Since the resulting improvement is a combined result of several of these changes, I did decide to not split them into separate PRs though.

### [Simplify minor signal related issues](https://github.com/PHOENIXCONTACT/MORYX-Framework/pull/1143/changes/210863cd4d4843f47919d8b05f1657c59d89dc36)

### [Unify product and references loading](https://github.com/PHOENIXCONTACT/MORYX-Framework/pull/1143/changes/de45265e7052cea074a950c48185ea2e8a938c63)  
Introduce ResolverFn implementations to trigger
loading of product information on navigation.
This removes distributed and duplicated loading
attempts. Also the logix to trigger loading and to
use session storage information was moved to the
same place. An implementation of CanActivateFn is
utilized to trigger redirects when necessary.

Also some unused code was removed and simplified.

### [Resolve several issues in recipes view](https://github.com/PHOENIXCONTACT/MORYX-Framework/pull/1143/changes/3f120556bbcd9ac9ade3998559ca164a54eaa2ec)
- Adds a RouteResolver for recipes defining a single point of truth for which recipe is currently handled
- Removes old, complex route analysis logic
- Fixes issues with recipe changes not stashed in the WIP product as object references of the signals hadn't changed
- Simplifies component structure by replacing some inputs with service references
- Simplifies some signals

### [Resolve several todos in products UI](https://github.com/PHOENIXCONTACT/MORYX-Framework/pull/1143/changes/5528925ea69d479b76c66ee5b81f4df1f7aed927)
- Simplified handling of successful product duplication just navigating to the new product
- Removed redundant divs from the dom and simplified the styling
- Replaced CommonModule with usage of simple css elipsis styling
- Unified naming of resolvers
- Removed unused code and imports
- Added clickable indicator for product references and actually linked the event

### [Add route resolver for product parts](https://github.com/PHOENIXCONTACT/MORYX-Framework/pull/1143/changes/4a58dd4b45ad2be81511b620c3c1b1b228465c47)
- Unifies handling of the currently active elements between references, recipes and parts
- Defines the route as the single point of truth for the selected partlink and part
- Simplifies routing logic in components

### [Fixes type filter for product parts adding dialog](https://github.com/PHOENIXCONTACT/MORYX-Framework/pull/1143/changes/fedd7505db6f2f5b59c9e83c4392f72c5e56b5a7)
The body wasn't cast to the actual body type leaving an error in a parameter name undetected. Hence all types where shown in the selection dialog.

### [Simplify and improve product parts UI](https://github.com/PHOENIXCONTACT/MORYX-Framework/pull/1143/changes/569fd187b4d131a2ed5a01b75f43fdfbc13dbfe2)
- Remove unnecessary divs
- Remove oversized headers for partlinks which did not provide additional information
- Remove unnecessary explainatory text which looked out of place on the ui anyway
- Added preview of configured partlinks to collapsed panels
- Removed duplicate rendering of default part views for collapsed panels
- Replaced input parameters for details view with service references
- Fixed issues with part link configuration and handling

### [Fix issue when cancelling product editing](https://github.com/PHOENIXCONTACT/MORYX-Framework/pull/1143/changes/f20bb4a4ee2267427c4f75ec4a932fe1fe303c81)
When editing a newly added recipe or part, cancelling caused the UI state to be reset by an api call outside of the route resolver (which was not nice in itself) but the route was left untouched leading to an inconsistent state and violating the route as single point of truth.
We add a cancellation component to fully reactivate the currently selected product. Other options were considered but not feasible.

### [Importing products correctly updates products tree](https://github.com/PHOENIXCONTACT/MORYX-Framework/pull/1143/changes/bfeb942b0e5583596ded26e6775509c23b8b1650)
Before the products tree was manipulated purely based on the return value of the API call itself. We now refresh the whole products tree which also allows to handle updates to products within an importer.

Also resolves a minor issue when cancelling/aborting edit mode.

### [Add direct link to product from parts](https://github.com/PHOENIXCONTACT/MORYX-Framework/pull/1143/changes/157f09e5aaba21b119d2f5497f85f326d7039c32)
Allows for navigating from a product part link directly to the referenced product. Works for lists of part links on each list element and as part of the actions row for single part links.

## Linked Issues
Works towards #1061

### Checklist for Submitter

- [x] I have tested these changes locally
- [ ] I have updated documentation as needed
- [ ] I have added or updated tests as appropriate
- [x] I have used clear and descriptive commit messages

### Review

**Typical tasks**

- [ ] Merge request is well described
- [ ] Critical sections are *documented in code*
- [ ] *Tests* are extended
- [ ] *Documentation* is created / updated
- [ ] Running in test environment
- [ ] Ports to other maintained versions are created

**Clean code**

- [ ] *All* unused references are removed
- [ ] Clean code rules are respected with passion (naming, ...)
- [ ] Avoid *copy and pasted* code snippets