### PR TITLE
Remove context menu on touch devices

### DIFF
--- a/src/Moryx.Products.Web/app/src/app/app.html
+++ b/src/Moryx.Products.Web/app/src/app/app.html
@@ -306,7 +306,6 @@
             <mat-tree-node
               *matTreeNodeDef="let node"
               (click)="onSelect(node.id)"
-              (press)="onOpenContextMenu($event, node.id)"
               (contextmenu)="onProductContext($event, node.id)"
               class="overview-tree-content-tree-items"
               [ngClass]="{
@@ -328,7 +327,6 @@
               *matTreeNodeDef="let node; when: hasChild"
               (click)="onSelect(node.id)"
               (contextmenu)="onProductContext($event, node.id)"
-              (press)="onOpenContextMenu($event, node.id)"
               class="overview-tree-content-tree-items"
               [ngClass]="{
                 'moryx-selected': selected()?.id == node.id

--- a/src/Moryx.Products.Web/app/src/app/app.scss
+++ b/src/Moryx.Products.Web/app/src/app/app.scss
@@ -1,5 +1,5 @@
 @use '@angular/material' as mat;
-@use "@moryx/ngx-web-framework/styles/variables" as *; 
+@use "@moryx/ngx-web-framework/styles/variables" as *;
 
 .overview {
   flex: 1;
@@ -74,6 +74,7 @@
   overflow-x: hidden;
   background-color: $mat-background-light;
   height: 100%;
+  touch-action: auto;
 }
 
 .overview-tree-content-tree-items {

--- a/src/Moryx.Products.Web/app/src/app/app.ts
+++ b/src/Moryx.Products.Web/app/src/app/app.ts
@@ -330,6 +330,10 @@ export class App implements OnInit, OnDestroy {
   }
 
   onProductContext(event: MouseEvent, productId: number) {
+    // Only handle right-click, not touch long-press
+    if ((event as any).pointerType === 'touch') {
+      return;
+    }
     event.preventDefault();
     if (productId === 0) return;
 
@@ -360,10 +364,6 @@ export class App implements OnInit, OnDestroy {
     if (id === this.selected()?.id) return;
 
     this.router.navigate(['/details', id]);
-  }
-
-  onOpenContextMenu(event: any, id: number) {
-    this.open(event.pointers[0].clientX, event.pointers[0].clientY, id);
   }
 
   async clickContainer(event: MouseEvent) {

--- a/src/Moryx.Resources.Web/app/src/app/app.html
+++ b/src/Moryx.Resources.Web/app/src/app/app.html
@@ -152,7 +152,6 @@
           [matTreeNodePaddingIndent]="10"
           (click)="selectResource(node.id)"
           (contextmenu)="openContextMenuByClicking($event, node.id)"
-          (press)="openContextMenuByPressing($event, node.id)"
           class="resources-tree-item"
           [ngClass]="{
             'moryx-selected': active?.id == node.id,
@@ -168,7 +167,6 @@
           [matTreeNodePaddingIndent]="10"
           (click)="selectResource(node.id)"
           (contextmenu)="openContextMenuByClicking($event, node.id)"
-          (press)="openContextMenuByPressing($event, node.id)"
           class="resources-tree-item"
           [ngClass]="{
             'moryx-selected': active?.id == node.id,

--- a/src/Moryx.Resources.Web/app/src/app/app.scss
+++ b/src/Moryx.Resources.Web/app/src/app/app.scss
@@ -42,6 +42,7 @@
   overflow-x: hidden;
   background-color: $mat-background-light;
   padding-bottom: 48px;
+  touch-action: auto;
 }
 .mat-toolbar-row{
   color: $mat-background-light;

--- a/src/Moryx.Resources.Web/app/src/app/app.ts
+++ b/src/Moryx.Resources.Web/app/src/app/app.ts
@@ -179,10 +179,6 @@ export class App implements OnInit, OnDestroy {
     this.treeStateIsInitialized = true;
   }
 
-  openContextMenuByPressing(event: any, id: number) {
-    this.openContextMenu(id, event.pointers[0].clientX, event.pointers[0].clientY);
-  }
-
   private openContextMenu(resourceId: number, xCoordinate: number, yCoordinate: number) {
     this.trigger().menuData = {id: resourceId};
     this.menuTopLeftPosition.update(() => {
@@ -201,6 +197,10 @@ export class App implements OnInit, OnDestroy {
   }
 
   openContextMenuByClicking(event: MouseEvent, resourceId: number) {
+    // Only handle right-click, not touch long-press
+    if ((event as any).pointerType === 'touch') {
+      return;
+    }
     event.preventDefault();
     this.openContextMenu(resourceId, event.clientX, event.clientY);
   }


### PR DESCRIPTION
### Summary

A long touch interaction triggers scrolling and contextmenu events. As the context menu event in the resource and products tree prevents defaults (to show a custom context menu), also the scrolling default behaviour is removed. To allow scrolling on touch displays we remove the context menu functionality on touch devices. All options from the context menu have been available on the toolbar before and still are.


### Linked Issues

### Checklist for Submitter

- [x] I have tested these changes locally
- [ ] I have updated documentation as needed
- [ ] I have added or updated tests as appropriate
- [x] I have used clear and descriptive commit messages

### Review

**Typical tasks**

- [ ] Merge request is well described
- [ ] Critical sections are *documented in code*
- [ ] *Tests* are extended
- [ ] *Documentation* is created / updated
- [ ] Running in test environment
- [ ] Ports to other maintained versions are created

**Clean code**

- [ ] *All* unused references are removed
- [ ] Clean code rules are respected with passion (naming, ...)
- [ ] Avoid *copy and pasted* code snippets

**ToDo:** 
- Test on actual touch device. Scrolling on touch emulation in chrome had worked before as well.
- Apply same changes to resources