### PR TITLE
Recover activity re-dispatch behaviour for ReadyToWork sessions with process Id

### DIFF
--- a/src/Moryx.ControlSystem.ProcessEngine/Processes/Implementation/ActivityDispatcher.cs
+++ b/src/Moryx.ControlSystem.ProcessEngine/Processes/Implementation/ActivityDispatcher.cs
@@ -465,16 +465,28 @@ internal sealed class ActivityDispatcher : IActivityPoolListener, IActivityDispa
             }
         }
 
-        // If we found an activity, start it!
+        // If we found an activity, dispatch it!
         if (activity != null)
         {
-            StartActivity(cell, message, activity);
+            DispatchActivity(cell, message, activity);
         }
         // Otherwise respond with finish. All conditions for queueing were handled above
         else
         {
             Logger.Log(LogLevel.Debug, "Sending outfeed to resource '{0}'", cell.Name);
             CompleteProcessOnCell(process, message, cell);
+        }
+    }
+
+    private void DispatchActivity(ICell cell, ReadyToWork message, ActivityData activity)
+    {
+        if (activity.State == ActivityState.Running)
+        {
+            ReDispatchActivity(cell, message, activity);
+        }
+        else
+        {
+            StartActivity(cell, message, activity);
         }
     }
 
@@ -506,6 +518,17 @@ internal sealed class ActivityDispatcher : IActivityPoolListener, IActivityDispa
 
         // Start activity in cell after setting state
         var activityStart = message.StartActivity(activityData.Activity);
+        activityData.Session = activityStart;
+        Decouple(() => resource.StartActivity(activityStart), nameof(ICell.StartActivity), resource);
+    }
+
+    private void ReDispatchActivity(ICell resource, ReadyToWork message, ActivityData activityData)
+    {
+        Logger.Log(LogLevel.Debug, "Re-Dispatching running activity '{activity}' to resource '{id}'",
+            activityData, resource.Id);
+
+        var activityStart = message.StartActivity(activityData.Activity);
+        activityData.Resource = resource;
         activityData.Session = activityStart;
         Decouple(() => resource.StartActivity(activityStart), nameof(ICell.StartActivity), resource);
     }

--- a/src/Moryx.ControlSystem.ProcessEngine/Processes/Implementation/ActivityPool.cs
+++ b/src/Moryx.ControlSystem.ProcessEngine/Processes/Implementation/ActivityPool.cs
@@ -95,29 +95,29 @@ internal sealed class ActivityPool : ILoggingComponent, IActivityDataPool, IActi
     }
 
     public bool TryUpdateActivity(ActivityData activityData, ActivityState newState, Action<ActivityData> updateAction)
-        {
-            // Update the activity
-            _activitiesLock.EnterUpgradeableReadLock();
-            try
+    {
+        // Update the activity
+        _activitiesLock.EnterUpgradeableReadLock();
+        try
         {
             // Validate the change before performing it
             if (newState <= activityData.State)
             {
                 Logger.Log(LogLevel.Warning, "Activity states can only increase! Current state: {current} - New State: {new}", activityData.State, newState);
                 return false;
-                }
-
-                _activitiesLock.EnterWriteLock();
-                updateAction?.Invoke(activityData);
-                activityData.State = newState;
             }
-            finally
+
+            _activitiesLock.EnterWriteLock();
+            updateAction?.Invoke(activityData);
+            activityData.State = newState;
+        }
+        finally
+        {
+            if (_activitiesLock.IsWriteLockHeld)
             {
-                if (_activitiesLock.IsWriteLockHeld)
-                {
-                    _activitiesLock.ExitWriteLock();
-                }
-                _activitiesLock.ExitUpgradeableReadLock();
+                _activitiesLock.ExitWriteLock();
+            }
+            _activitiesLock.ExitUpgradeableReadLock();
         }
 
         // Update the _openActivities collection

--- a/src/Tests/Moryx.ControlSystem.ProcessEngine.Tests/Processes/ActivityDispatcherTests.cs
+++ b/src/Tests/Moryx.ControlSystem.ProcessEngine.Tests/Processes/ActivityDispatcherTests.cs
@@ -99,7 +99,24 @@ public class ActivityDispatcherTests : ProcessTestsBase
         AssertActivityDispatch(dummy, _serialCellMock);
     }
 
-    [Test]
+    [Test(Description = "Re-Dispatch running activity to pull RTW with process id")]
+    public void ReDispatchRunningActivityOnReadyToWorkPullWithProcessId()
+    {
+        // Arrange: Running activity in pool
+        var dummy = new DummyActivity();
+        var activityData = FillPool(dummy, _productionCellMock.Object);
+        DataPool.TryUpdateActivity(activityData, ActivityState.Configured);
+        DataPool.TryUpdateActivity(activityData, ActivityState.Running);
+        var rtw = Session.StartSession(ActivityClassification.Production, ReadyToWorkType.Push, ValidProcessId);
+
+        // Act
+        RaiseReadyToWork(_productionCellMock, rtw);
+
+        // Assert
+        AssertActivityDispatch(dummy, _productionCellMock);
+    }
+
+    [Test(Description = "Dispatch activity to cell added after component start")]
     public void DispatchActivityToNewCell()
     {
         // Arrange
@@ -172,6 +189,7 @@ public class ActivityDispatcherTests : ProcessTestsBase
         });
 
         Assert.That(ModifiedActivity, Is.Not.Null);
+        Assert.That(ModifiedActivity.Resource, Is.EqualTo(resourceMock.Object));
         Assert.That(ModifiedActivity.State, Is.EqualTo(ActivityState.Running));
     }
 
@@ -289,7 +307,7 @@ public class ActivityDispatcherTests : ProcessTestsBase
             "The activty should be not dispatched and no StartActivity call at the SerialCell should be occured");
     }
 
-    [Test]
+    [Test(Description = "Update activity state when receiving a result")]
     public void UpdateActivityOnCompletion()
     {
         // Arrange: Running activity in pool
@@ -310,7 +328,7 @@ public class ActivityDispatcherTests : ProcessTestsBase
         Assert.That(ModifiedActivity.State, Is.EqualTo(ActivityState.ResultReceived));
     }
 
-    [Test]
+    [Test(Description = "Replace RTW Push sessions from the same cell in session cache")]
     public void ReadyToWorkOverride()
     {
         // Arrange: Place a push message in the queue
@@ -382,7 +400,7 @@ public class ActivityDispatcherTests : ProcessTestsBase
             "There should be no SequenceCompleted call at the SerialCell.");
     }
 
-    [Test]
+    [Test(Description = "Call 'ProcessAborting' on active cells when process changes to Aborting state")]
     public void InformCellAboutProcessAbortion()
     {
         // Arrange
@@ -420,7 +438,7 @@ public class ActivityDispatcherTests : ProcessTestsBase
         Assert.That(result, Is.Empty, "There should be no more activities.");
     }
 
-    [Test(Description = "Do not dispatch dummy activity to cell 1 because of constrain.")]
+    [Test(Description = "Do not dispatch dummy activity to cell 1 because of constraint.")]
     public void NoActvitityDispatchingIfConstraintsNotFit()
     {
         // Arrange


### PR DESCRIPTION

### Summary
In 3a77f152ae8a1d3f6603f12bb0296cef5702df49 we prevented updates to activity data while the activity was transitioning. Accidently we removed the possibility to send a RTW for an already running activity providing the process ID. This behaviour was reintroduced and made more explicit in the code. Also added a unit test for the behavior.

### Linked Issues

Recovers behaviour removed in #939
Close #1083
Close #1082 

### Checklist for Submitter

- [x] I have tested these changes locally
- [ ] I have updated documentation as needed
- [x] I have added or updated tests as appropriate
- [x] I have used clear and descriptive commit messages

### Review

**Typical tasks**

- [ ] Merge request is well described
- [ ] Critical sections are *documented in code*
- [ ] *Tests* are extended
- [ ] *Documentation* is created / updated
- [ ] Running in test environment
- [ ] Ports to other maintained versions are created

**Clean code**

- [ ] *All* unused references are removed
- [ ] Clean code rules are respected with passion (naming, ...)
- [ ] Avoid *copy and pasted* code snippets