### PR TITLE
Fix: Collection changed is not called when Resource References are changed through the UI

### DIFF
--- a/src/Moryx.AbstractionLayer.Resources.Endpoints/Converter/ModelToResourceConverter.cs
+++ b/src/Moryx.AbstractionLayer.Resources.Endpoints/Converter/ModelToResourceConverter.cs
@@ -8,6 +8,7 @@ namespace Moryx.AbstractionLayer.Resources.Endpoints;
 
 /// <summary>
 /// Converts ResourceModel to Resource
+/// TODO: Can this be removed? It does not appear to be used
 /// </summary>
 internal class ModelToResourceConverter
 {
@@ -93,34 +94,42 @@ internal class ModelToResourceConverter
             var property = type.GetProperty(reference.Name);
             if (property.GetValue(instance) is IReferenceCollection asCollection)
             {
+                bool collectionChanged = false;
                 var collection = asCollection.UnderlyingCollection;
-                // Add new items and update existing ones
-                foreach (var targetModel in reference.Targets)
+                lock (collection)
                 {
-                    Resource target;
-                    if (targetModel.Id == 0 || collection.All(r => r.Id != targetModel.Id))
+                    // Add new items and update existing ones
+                    foreach (var targetModel in reference.Targets)
                     {
-                        // New reference added to the collection
-                        target = FromModel(targetModel, resourcesToSave);
-                        collection.Add(target);
+                        Resource target;
+                        if (targetModel.Id == 0 || collection.All(r => r.Id != targetModel.Id))
+                        {
+                            // New reference added to the collection
+                            target = FromModel(targetModel, resourcesToSave);
+                            collection.Add(target);
+                            resourcesToSave.Add(instance);
+                        }
+                        else
+                        {
+                            // Element already exists in the collection
+                            target = (Resource)collection.First(r => r.Id == targetModel.Id);
+                            FromModel(targetModel, resourcesToSave, target);
+                        }
+                    }
+                    // Remove deleted items
+                    var targetIds = reference.Targets.Select(t => t.Id).Distinct().ToArray();
+                    var deletedItems = collection.Where(r => !targetIds.Contains(r.Id)).ToArray();
+                    foreach (var deletedItem in deletedItems)
+                        collection.Remove(deletedItem);
+
+                    if (deletedItems.Any())
+                    {
                         resourcesToSave.Add(instance);
                     }
-                    else
-                    {
-                        // Element already exists in the collection
-                        target = (Resource)collection.First(r => r.Id == targetModel.Id);
-                        FromModel(targetModel, resourcesToSave, target);
-                    }
                 }
-                // Remove deleted items
-                var targetIds = reference.Targets.Select(t => t.Id).Distinct().ToArray();
-                var deletedItems = collection.Where(r => !targetIds.Contains(r.Id)).ToArray();
-                foreach (var deletedItem in deletedItems)
-                    collection.Remove(deletedItem);
-
-                if (deletedItems.Any())
+                if(collectionChanged && asCollection is IReferenceCollectionExtended extended)
                 {
-                    resourcesToSave.Add(instance);
+                    extended.UnderlyingCollectionChanged();
                 }
             }
             else

--- a/src/Moryx.AbstractionLayer.Resources.Endpoints/Converter/ModelToResourceConverter.cs
+++ b/src/Moryx.AbstractionLayer.Resources.Endpoints/Converter/ModelToResourceConverter.cs
@@ -10,7 +10,7 @@ namespace Moryx.AbstractionLayer.Resources.Endpoints;
 /// Converts ResourceModel to Resource
 /// TODO: Can this be removed? It does not appear to be used
 /// </summary>
-internal class ModelToResourceConverter
+internal sealed class ModelToResourceConverter
 {
     /// <summary>
     /// Resource cache to avoid redundant conversions AND make use of WCFs "IsReference" feature
@@ -38,11 +38,15 @@ internal class ModelToResourceConverter
     {
         // Break recursion if we converted this instance already
         // Try to load by real id first
-        if (_resourceCache.ContainsKey(model.Id))
-            return _resourceCache[model.Id];
+        if (_resourceCache.TryGetValue(model.Id, out var value))
+        {
+            return value;
+        }
         // Otherwise by reference id
-        if (model.Id == 0 && _resourceCache.ContainsKey(model.ReferenceId))
-            return _resourceCache[model.ReferenceId];
+        if (model.Id == 0 && _resourceCache.TryGetValue(model.ReferenceId, out var referencedValue))
+        {
+            return referencedValue;
+        }
 
         // Only fetch resource object if it was not given
         if (resource == null)
@@ -54,17 +58,25 @@ internal class ModelToResourceConverter
 
         // Write to cache because following calls might only have an empty reference
         if (model.Id == 0)
+        {
             _resourceCache[model.ReferenceId] = resource;
+        }
         else
+        {
             _resourceCache[model.Id] = resource;
+        }
 
         // Do not copy values from partially loaded models
         if (model.PartiallyLoaded)
+        {
             return resource;
+        }
 
         // Add to list if object was created or modified
         if (model.Id == 0 || model.DifferentFrom(resource, _serialization))
+        {
             resourcesToSave.Add(resource);
+        }
 
         // Copy standard properties
         resource.Name = model.Name;
@@ -89,7 +101,9 @@ internal class ModelToResourceConverter
         {
             // Skip references that were not set
             if (reference.Targets == null)
+            {
                 continue;
+            }
 
             var property = type.GetProperty(reference.Name);
             if (property.GetValue(instance) is IReferenceCollection asCollection)
@@ -120,14 +134,16 @@ internal class ModelToResourceConverter
                     var targetIds = reference.Targets.Select(t => t.Id).Distinct().ToArray();
                     var deletedItems = collection.Where(r => !targetIds.Contains(r.Id)).ToArray();
                     foreach (var deletedItem in deletedItems)
+                    {
                         collection.Remove(deletedItem);
+                    }
 
                     if (deletedItems.Any())
                     {
                         resourcesToSave.Add(instance);
                     }
                 }
-                if(collectionChanged && asCollection is IReferenceCollectionExtended extended)
+                if (collectionChanged && asCollection is IReferenceCollectionExtended extended)
                 {
                     extended.UnderlyingCollectionChanged();
                 }
@@ -139,11 +155,17 @@ internal class ModelToResourceConverter
 
                 Resource target;
                 if (targetModel == null)
+                {
                     target = null;
+                }
                 else if (targetModel.Id == value?.Id)
+                {
                     target = FromModel(targetModel, resourcesToSave, value);
+                }
                 else
+                {
                     target = FromModel(targetModel, resourcesToSave);
+                }
 
                 if (target != value)
                 {

--- a/src/Moryx.AbstractionLayer.Resources.Endpoints/Converter/ModelToResourceConverter.cs
+++ b/src/Moryx.AbstractionLayer.Resources.Endpoints/Converter/ModelToResourceConverter.cs
@@ -8,62 +8,69 @@ namespace Moryx.AbstractionLayer.Resources.Endpoints;
 
 /// <summary>
 /// Converts ResourceModel to Resource
-/// TODO: Can this be removed? It does not appear to be used
 /// </summary>
 internal sealed class ModelToResourceConverter
 {
-    /// <summary>
-    /// Resource cache to avoid redundant conversions AND make use of WCFs "IsReference" feature
-    /// </summary>
-    private readonly Dictionary<long, Resource> _resourceCache = new();
-
-    private readonly IResourceGraph _resourceGraph;
     private readonly ICustomSerialization _serialization;
+
+    private readonly IResourceTypeTree _resourceTypeTree;
+
+    private readonly IResourceManagement _resourceManagement;
 
     /// <summary>
     /// Constructor
     /// </summary>
     /// <param name="resourceGraph"></param>
     /// <param name="serialization"></param>
-    public ModelToResourceConverter(IResourceGraph resourceGraph, ICustomSerialization serialization)
+    public ModelToResourceConverter(IResourceManagement resourceManagement, IResourceTypeTree resourceTypeTree, ICustomSerialization serialization)
     {
-        _resourceGraph = resourceGraph;
+        _resourceManagement = resourceManagement;
+        _resourceTypeTree = resourceTypeTree;
         _serialization = serialization;
     }
-
     /// <summary>
     /// Convert ResourceModel back to resource and/or update its properties
     /// </summary>
-    public Resource FromModel(ResourceModel model, HashSet<Resource> resourcesToSave, Resource resource = null)
+    public async Task<Resource> FromModel(ResourceModel model, HashSet<long> resourcesToSave, Dictionary<long, Resource> cache, Resource resource = null)
     {
         // Break recursion if we converted this instance already
         // Try to load by real id first
-        if (_resourceCache.TryGetValue(model.Id, out var value))
+        if (cache.TryGetValue(model.Id, out var value))
         {
             return value;
         }
         // Otherwise by reference id
-        if (model.Id == 0 && _resourceCache.TryGetValue(model.ReferenceId, out var referencedValue))
+        if (model.Id == 0 && cache.TryGetValue(model.ReferenceId, out var referencedValue))
         {
             return referencedValue;
         }
 
         // Only fetch resource object if it was not given
-        if (resource == null)
+        if (resource is null)
         {
-            resource = model.Id == 0
-                ? _resourceGraph.Instantiate(model.Type)
-                : _resourceGraph.Get(model.Id);
+            if (model.Id == 0 && model.PartiallyLoaded)
+            {
+                resource = (Resource)Activator.CreateInstance(_resourceTypeTree[model.Type].ResourceType);
+            }
+            else if (model.Id == 0)
+            {
+                var id = await _resourceManagement.CreateUnsafeAsync(_resourceTypeTree[model.Type].ResourceType, r => Task.CompletedTask);
+                resource = _resourceManagement.ReadUnsafe(id, r => r);
+            }
+            else
+            {
+                resource = _resourceManagement.ReadUnsafe(model.Id, r => r);
+            }
         }
 
         // Write to cache because following calls might only have an empty reference
         if (model.Id == 0)
         {
-            _resourceCache[model.ReferenceId] = resource;
+            cache[model.ReferenceId] = resource;
         }
         else
         {
-            _resourceCache[model.Id] = resource;
+            cache[model.Id] = resource;
         }
 
         // Do not copy values from partially loaded models
@@ -75,7 +82,7 @@ internal sealed class ModelToResourceConverter
         // Add to list if object was created or modified
         if (model.Id == 0 || model.DifferentFrom(resource, _serialization))
         {
-            resourcesToSave.Add(resource);
+            resourcesToSave.Add(resource.Id);
         }
 
         // Copy standard properties
@@ -86,7 +93,7 @@ internal sealed class ModelToResourceConverter
         EntryConvert.UpdateInstance(resource.Descriptor, model.Properties, _serialization);
 
         // Set all other references
-        UpdateReferences(resource, resourcesToSave, model);
+        await UpdateReferences(resource, resourcesToSave, cache, model);
 
         return resource;
     }
@@ -94,7 +101,7 @@ internal sealed class ModelToResourceConverter
     /// <summary>
     /// Updates the references of a resource
     /// </summary>
-    private void UpdateReferences(Resource instance, HashSet<Resource> resourcesToSave, ResourceModel model)
+    public async Task UpdateReferences(Resource instance, HashSet<long> resourcesToSave, Dictionary<long, Resource> cache, ResourceModel model)
     {
         var type = instance.GetType();
         foreach (var reference in model.References)
@@ -110,40 +117,46 @@ internal sealed class ModelToResourceConverter
             {
                 bool collectionChanged = false;
                 var collection = asCollection.UnderlyingCollection;
+
+                // TODO: find a way to synchronize collection acceess for adding as well
+                // currently we can't do it, because of the await statements.
+
+                // Add new items and update existing ones
+                foreach (var targetModel in reference.Targets)
+                {
+                    Resource target;
+                    if (targetModel.Id == 0 || collection.All(r => r.Id != targetModel.Id))
+                    {
+                        // New reference added to the collection
+                        target = await FromModel(targetModel, resourcesToSave, cache);
+                        collection.Add(target);
+                        collectionChanged = true;
+                        resourcesToSave.Add(target.Id);
+                    }
+                    else
+                    {
+                        // Element already exists in the collection
+                        target = (Resource)collection.First(r => r.Id == targetModel.Id);
+                        await FromModel(targetModel, resourcesToSave, cache, target);
+                    }
+                }
+                // Remove deleted items
+                var targetIds = reference.Targets.Select(t => t.Id).Distinct().ToArray();
                 lock (collection)
                 {
-                    // Add new items and update existing ones
-                    foreach (var targetModel in reference.Targets)
-                    {
-                        Resource target;
-                        if (targetModel.Id == 0 || collection.All(r => r.Id != targetModel.Id))
-                        {
-                            // New reference added to the collection
-                            target = FromModel(targetModel, resourcesToSave);
-                            collection.Add(target);
-                            resourcesToSave.Add(instance);
-                        }
-                        else
-                        {
-                            // Element already exists in the collection
-                            target = (Resource)collection.First(r => r.Id == targetModel.Id);
-                            FromModel(targetModel, resourcesToSave, target);
-                        }
-                    }
-                    // Remove deleted items
-                    var targetIds = reference.Targets.Select(t => t.Id).Distinct().ToArray();
                     var deletedItems = collection.Where(r => !targetIds.Contains(r.Id)).ToArray();
                     foreach (var deletedItem in deletedItems)
                     {
+                        collectionChanged = true;
                         collection.Remove(deletedItem);
                     }
 
                     if (deletedItems.Any())
                     {
-                        resourcesToSave.Add(instance);
+                        resourcesToSave.Add(instance.Id);
                     }
                 }
-                if (collectionChanged && asCollection is IReferenceCollectionExtended extended)
+                if (collectionChanged && collection is IReferenceCollectionExtended extended)
                 {
                     extended.UnderlyingCollectionChanged();
                 }
@@ -160,17 +173,17 @@ internal sealed class ModelToResourceConverter
                 }
                 else if (targetModel.Id == value?.Id)
                 {
-                    target = FromModel(targetModel, resourcesToSave, value);
+                    target = await FromModel(targetModel, resourcesToSave, cache, value);
                 }
                 else
                 {
-                    target = FromModel(targetModel, resourcesToSave);
+                    target = await FromModel(targetModel, resourcesToSave, cache);
                 }
 
                 if (target != value)
                 {
                     property.SetValue(instance, target);
-                    resourcesToSave.Add(instance);
+                    resourcesToSave.Add(instance.Id);
                 }
             }
         }

--- a/src/Moryx.AbstractionLayer.Resources.Endpoints/ResourceModificationController.cs
+++ b/src/Moryx.AbstractionLayer.Resources.Endpoints/ResourceModificationController.cs
@@ -1,21 +1,21 @@
 // Copyright (c) 2026 Phoenix Contact GmbH & Co. KG
 // Licensed under the Apache License, Version 2.0
 
+using System.ComponentModel.DataAnnotations;
 using System.Net;
 using System.Reflection;
+using System.Runtime.Serialization;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
-using Moryx.Serialization;
-using Moryx.Tools;
-using Moryx.Runtime.Modules;
-using Moryx.Configuration;
-using System.Runtime.Serialization;
-using System.ComponentModel.DataAnnotations;
 using Moryx.AbstractionLayer.Resources.Endpoints.Models;
 using Moryx.AbstractionLayer.Resources.Endpoints.Properties;
 using Moryx.AspNetCore;
+using Moryx.Configuration;
+using Moryx.Runtime.Modules;
+using Moryx.Serialization;
+using Moryx.Tools;
 
 namespace Moryx.AbstractionLayer.Resources.Endpoints;
 
@@ -63,7 +63,9 @@ public class ResourceModificationController : ControllerBase
         var converter = new ResourceToModelConverter(_resourceTypeTree, _serialization);
 
         if (ids is null || ids.Length == 0)
+        {
             ids = _resourceManagement.GetResources<IResource>().Select(r => r.Id).ToArray();
+        }
 
         return ids.Select(id => _resourceManagement.ReadUnsafe(id, r => converter.GetDetails(r)))
             .Where(details => details != null).ToArray();
@@ -93,9 +95,11 @@ public class ResourceModificationController : ControllerBase
     public ActionResult<ResourceModel> GetDetails(long id)
     {
         var converter = new ResourceToModelConverter(_resourceTypeTree, _serialization);
-        var resourceModel = _resourceManagement.ReadUnsafe(id, r => converter.GetDetails(r));
+        var resourceModel = _resourceManagement.ReadUnsafe(id, converter.GetDetails);
         if (resourceModel is null)
+        {
             return NotFound(new MoryxExceptionResponse { Title = string.Format(Strings.ResourceNotFoundException_ById_Message, id) });
+        }
 
         return resourceModel;
     }
@@ -110,7 +114,9 @@ public class ResourceModificationController : ControllerBase
     public async Task<ActionResult<Entry>> InvokeMethod(long id, string method, Entry parameters)
     {
         if (_resourceManagement.GetResourcesUnsafe<IResource>(r => r.Id == id) is null)
+        {
             return NotFound(new MoryxExceptionResponse { Title = string.Format(Strings.ResourceNotFoundException_ById_Message, id) });
+        }
 
         Entry entry = null;
         try
@@ -143,7 +149,9 @@ public class ResourceModificationController : ControllerBase
     {
         var trustedType = WebUtility.HtmlEncode(type);
         if (method is null)
+        {
             return Construct(trustedType);
+        }
 
         return Construct(trustedType, new MethodEntry { Name = method, Parameters = arguments });
     }
@@ -186,7 +194,10 @@ public class ResourceModificationController : ControllerBase
         catch (Exception e)
         {
             if (e is ArgumentException or SerializationException or ValidationException)
+            {
                 return BadRequest(e.Message);
+            }
+
             throw;
         }
     }
@@ -200,7 +211,10 @@ public class ResourceModificationController : ControllerBase
     public async Task<ActionResult<ResourceModel>> Save(ResourceModel model)
     {
         if (_resourceManagement.GetResourcesUnsafe<IResource>(r => r.Id == model.Id).Any())
+        {
             return Conflict($"The resource '{model.Id}' already exists.");
+        }
+
         try
         {
             var id = await _resourceManagement.CreateUnsafeAsync(_resourceTypeTree[model.Type].ResourceType, async (r) =>
@@ -219,7 +233,10 @@ public class ResourceModificationController : ControllerBase
         catch (Exception e)
         {
             if (e is ArgumentException or SerializationException or ValidationException)
+            {
                 return BadRequest(e.Message);
+            }
+
             throw;
         }
     }
@@ -231,37 +248,55 @@ public class ResourceModificationController : ControllerBase
     {
         // Break recursion if we converted this instance already
         // Try to load by real id first
-        if (cache.ContainsKey(model.Id))
-            return cache[model.Id];
+        if (cache.TryGetValue(model.Id, out var value))
+        {
+            return value;
+        }
         // Otherwise by reference id
-        if (model.Id == 0 && cache.ContainsKey(model.ReferenceId))
-            return cache[model.ReferenceId];
+        if (model.Id == 0 && cache.TryGetValue(model.ReferenceId, out var referencedValue))
+        {
+            return referencedValue;
+        }
 
         // Only fetch resource object if it was not given
         if (resource is null)
+        {
             if (model.Id == 0 && model.PartiallyLoaded)
+            {
                 resource = (Resource)Activator.CreateInstance(_resourceTypeTree[model.Type].ResourceType);
+            }
             else if (model.Id == 0)
             {
                 var id = await _resourceManagement.CreateUnsafeAsync(_resourceTypeTree[model.Type].ResourceType, r => Task.CompletedTask);
                 resource = _resourceManagement.ReadUnsafe(id, r => r);
             }
             else
+            {
                 resource = _resourceManagement.ReadUnsafe(model.Id, r => r);
+            }
+        }
 
         // Write to cache because following calls might only have an empty reference
         if (model.Id == 0)
+        {
             cache[model.ReferenceId] = resource;
+        }
         else
+        {
             cache[model.Id] = resource;
+        }
 
         // Do not copy values from partially loaded models
         if (model.PartiallyLoaded)
+        {
             return resource;
+        }
 
         // Add to list if object was created or modified
         if (model.Id == 0 || model.DifferentFrom(resource, _serialization))
+        {
             resourcesToSave.Add(resource.Id);
+        }
 
         // Copy standard properties
         resource.Name = model.Name;
@@ -286,7 +321,9 @@ public class ResourceModificationController : ControllerBase
         {
             // Skip references that were not set
             if (reference.Targets == null)
+            {
                 continue;
+            }
 
             var property = type.GetProperty(reference.Name);
             if (property.GetValue(instance) is IReferenceCollection asCollection)
@@ -344,11 +381,17 @@ public class ResourceModificationController : ControllerBase
 
                 Resource target;
                 if (targetModel == null)
+                {
                     target = null;
+                }
                 else if (targetModel.Id == value?.Id)
+                {
                     target = await FromModel(targetModel, resourcesToSave, cache, value);
+                }
                 else
+                {
                     target = await FromModel(targetModel, resourcesToSave, cache);
+                }
 
                 if (target != value)
                 {
@@ -369,7 +412,9 @@ public class ResourceModificationController : ControllerBase
     public ActionResult<ResourceModel> Update(long id, ResourceModel model)
     {
         if (_resourceManagement.GetResourcesUnsafe<IResource>(r => r.Id == id) is null)
+        {
             return NotFound(new MoryxExceptionResponse { Title = string.Format(Strings.ResourceNotFoundException_ById_Message, id) });
+        }
 
         try
         {
@@ -385,7 +430,10 @@ public class ResourceModificationController : ControllerBase
         catch (Exception e)
         {
             if (e is ArgumentException or SerializationException or ValidationException)
+            {
                 return BadRequest(e.Message);
+            }
+
             throw;
         }
 
@@ -402,16 +450,20 @@ public class ResourceModificationController : ControllerBase
     public async Task<ActionResult> Remove(long id)
     {
         if (_resourceManagement.GetResourcesUnsafe<IResource>(r => r.Id == id) is null)
+        {
             return NotFound(new MoryxExceptionResponse { Title = string.Format(Strings.ResourceNotFoundException_ById_Message, id) });
+        }
 
         var deleted = await _resourceManagement.DeleteAsync(id);
         if (!deleted)
+        {
             return Conflict($"Unable to delete {id}");
+        }
 
         return Accepted();
     }
 
-    private class ResourceQueryFilter
+    private sealed class ResourceQueryFilter
     {
         private readonly ResourceQuery _query;
         private readonly IReadOnlyList<IResourceTypeNode> _typeNodes;
@@ -428,19 +480,23 @@ public class ResourceModificationController : ControllerBase
         {
             // Check type of instance, if filter is set
             if (_typeNodes != null && _typeNodes.All(tn => !tn.ResourceType.IsInstanceOfType(instance)))
+            {
                 return false;
+            }
 
             // Next check for reference filters
             if (_query.ReferenceCondition == null)
+            {
                 return true;
+            }
 
             var node = _resourceTypeTree[instance.GetType().FullName];
 
             var referenceCondition = _query.ReferenceCondition;
             var references = (from property in node.PropertiesOfResourceType
-                let att = property.GetCustomAttribute<ResourceReferenceAttribute>()
-                where att != null
-                select new { property, att }).ToList();
+                              let att = property.GetCustomAttribute<ResourceReferenceAttribute>()
+                              where att != null
+                              select new { property, att }).ToList();
 
             // Find properties matching the condition
             PropertyInfo[] matches;
@@ -456,17 +512,25 @@ public class ResourceModificationController : ControllerBase
                     .Select(r => r.property).ToArray();
             }
             if (matches.Length != 1)
+            {
                 return false;
+            }
 
             if (referenceCondition.ValueConstraint == ReferenceValue.Irrelevant)
+            {
                 return true;
+            }
 
             var propertyValue = matches[0].GetValue(instance);
             if (referenceCondition.ValueConstraint == ReferenceValue.NullOrEmpty)
+            {
                 return propertyValue == null || (propertyValue as IReferenceCollection)?.UnderlyingCollection.Count == 0;
+            }
 
             if (referenceCondition.ValueConstraint == ReferenceValue.NotEmpty)
+            {
                 return (propertyValue as IReferenceCollection)?.UnderlyingCollection.Count > 0 || propertyValue != null;
+            }
 
             return true;
         }

--- a/src/Moryx.AbstractionLayer.Resources.Endpoints/ResourceModificationController.cs
+++ b/src/Moryx.AbstractionLayer.Resources.Endpoints/ResourceModificationController.cs
@@ -291,7 +291,12 @@ public class ResourceModificationController : ControllerBase
             var property = type.GetProperty(reference.Name);
             if (property.GetValue(instance) is IReferenceCollection asCollection)
             {
+                bool collectionChanged = false;
                 var collection = asCollection.UnderlyingCollection;
+
+                // TODO: find a way to synchronize collection acceess for adding as well
+                // currently we can't do it, because of the await statements.
+
                 // Add new items and update existing ones
                 foreach (var targetModel in reference.Targets)
                 {
@@ -301,6 +306,7 @@ public class ResourceModificationController : ControllerBase
                         // New reference added to the collection
                         target = await FromModel(targetModel, resourcesToSave, cache);
                         collection.Add(target);
+                        collectionChanged = true;
                         resourcesToSave.Add(target.Id);
                     }
                     else
@@ -312,13 +318,23 @@ public class ResourceModificationController : ControllerBase
                 }
                 // Remove deleted items
                 var targetIds = reference.Targets.Select(t => t.Id).Distinct().ToArray();
-                var deletedItems = collection.Where(r => !targetIds.Contains(r.Id)).ToArray();
-                foreach (var deletedItem in deletedItems)
-                    collection.Remove(deletedItem);
-
-                if (deletedItems.Any())
+                lock (collection)
                 {
-                    resourcesToSave.Add(instance.Id);
+                    var deletedItems = collection.Where(r => !targetIds.Contains(r.Id)).ToArray();
+                    foreach (var deletedItem in deletedItems)
+                    {
+                        collectionChanged = true;
+                        collection.Remove(deletedItem);
+                    }
+
+                    if (deletedItems.Any())
+                    {
+                        resourcesToSave.Add(instance.Id);
+                    }
+                    if (collectionChanged && collection is IReferenceCollectionExtended extended)
+                    {
+                        extended.UnderlyingCollectionChanged();
+                    }
                 }
             }
             else

--- a/src/Moryx.AbstractionLayer.Resources.Endpoints/ResourceModificationController.cs
+++ b/src/Moryx.AbstractionLayer.Resources.Endpoints/ResourceModificationController.cs
@@ -221,7 +221,8 @@ public class ResourceModificationController : ControllerBase
             {
                 var resourcesToSave = new HashSet<long>();
                 var resourceCache = new Dictionary<long, Resource>();
-                await FromModel(model, resourcesToSave, resourceCache, r);
+                var converter = new ModelToResourceConverter(_resourceManagement, _resourceTypeTree, _serialization);
+                await converter.FromModel(model, resourcesToSave, resourceCache, r);
                 foreach (var resource in resourcesToSave.Skip(1))
                 {
                     await _resourceManagement.ModifyUnsafeAsync(resource, r => Task.FromResult(true));
@@ -238,167 +239,6 @@ public class ResourceModificationController : ControllerBase
             }
 
             throw;
-        }
-    }
-
-    /// <summary>
-    /// Convert ResourceModel back to resource and/or update its properties
-    /// </summary>
-    private async Task<Resource> FromModel(ResourceModel model, HashSet<long> resourcesToSave, Dictionary<long, Resource> cache, Resource resource = null)
-    {
-        // Break recursion if we converted this instance already
-        // Try to load by real id first
-        if (cache.TryGetValue(model.Id, out var value))
-        {
-            return value;
-        }
-        // Otherwise by reference id
-        if (model.Id == 0 && cache.TryGetValue(model.ReferenceId, out var referencedValue))
-        {
-            return referencedValue;
-        }
-
-        // Only fetch resource object if it was not given
-        if (resource is null)
-        {
-            if (model.Id == 0 && model.PartiallyLoaded)
-            {
-                resource = (Resource)Activator.CreateInstance(_resourceTypeTree[model.Type].ResourceType);
-            }
-            else if (model.Id == 0)
-            {
-                var id = await _resourceManagement.CreateUnsafeAsync(_resourceTypeTree[model.Type].ResourceType, r => Task.CompletedTask);
-                resource = _resourceManagement.ReadUnsafe(id, r => r);
-            }
-            else
-            {
-                resource = _resourceManagement.ReadUnsafe(model.Id, r => r);
-            }
-        }
-
-        // Write to cache because following calls might only have an empty reference
-        if (model.Id == 0)
-        {
-            cache[model.ReferenceId] = resource;
-        }
-        else
-        {
-            cache[model.Id] = resource;
-        }
-
-        // Do not copy values from partially loaded models
-        if (model.PartiallyLoaded)
-        {
-            return resource;
-        }
-
-        // Add to list if object was created or modified
-        if (model.Id == 0 || model.DifferentFrom(resource, _serialization))
-        {
-            resourcesToSave.Add(resource.Id);
-        }
-
-        // Copy standard properties
-        resource.Name = model.Name;
-        resource.Description = model.Description;
-
-        // Copy extended properties
-        EntryConvert.UpdateInstance(resource.Descriptor, model.Properties, _serialization);
-
-        // Set all other references
-        await UpdateReferences(resource, resourcesToSave, cache, model);
-
-        return resource;
-    }
-
-    /// <summary>
-    /// Updates the references of a resource
-    /// </summary>
-    private async Task UpdateReferences(Resource instance, HashSet<long> resourcesToSave, Dictionary<long, Resource> cache, ResourceModel model)
-    {
-        var type = instance.GetType();
-        foreach (var reference in model.References)
-        {
-            // Skip references that were not set
-            if (reference.Targets == null)
-            {
-                continue;
-            }
-
-            var property = type.GetProperty(reference.Name);
-            if (property.GetValue(instance) is IReferenceCollection asCollection)
-            {
-                bool collectionChanged = false;
-                var collection = asCollection.UnderlyingCollection;
-
-                // TODO: find a way to synchronize collection acceess for adding as well
-                // currently we can't do it, because of the await statements.
-
-                // Add new items and update existing ones
-                foreach (var targetModel in reference.Targets)
-                {
-                    Resource target;
-                    if (targetModel.Id == 0 || collection.All(r => r.Id != targetModel.Id))
-                    {
-                        // New reference added to the collection
-                        target = await FromModel(targetModel, resourcesToSave, cache);
-                        collection.Add(target);
-                        collectionChanged = true;
-                        resourcesToSave.Add(target.Id);
-                    }
-                    else
-                    {
-                        // Element already exists in the collection
-                        target = (Resource)collection.First(r => r.Id == targetModel.Id);
-                        await FromModel(targetModel, resourcesToSave, cache, target);
-                    }
-                }
-                // Remove deleted items
-                var targetIds = reference.Targets.Select(t => t.Id).Distinct().ToArray();
-                lock (collection)
-                {
-                    var deletedItems = collection.Where(r => !targetIds.Contains(r.Id)).ToArray();
-                    foreach (var deletedItem in deletedItems)
-                    {
-                        collectionChanged = true;
-                        collection.Remove(deletedItem);
-                    }
-
-                    if (deletedItems.Any())
-                    {
-                        resourcesToSave.Add(instance.Id);
-                    }
-                    if (collectionChanged && collection is IReferenceCollectionExtended extended)
-                    {
-                        extended.UnderlyingCollectionChanged();
-                    }
-                }
-            }
-            else
-            {
-                var targetModel = reference.Targets.FirstOrDefault();
-                var value = (Resource)property.GetValue(instance);
-
-                Resource target;
-                if (targetModel == null)
-                {
-                    target = null;
-                }
-                else if (targetModel.Id == value?.Id)
-                {
-                    target = await FromModel(targetModel, resourcesToSave, cache, value);
-                }
-                else
-                {
-                    target = await FromModel(targetModel, resourcesToSave, cache);
-                }
-
-                if (target != value)
-                {
-                    property.SetValue(instance, target);
-                    resourcesToSave.Add(instance.Id);
-                }
-            }
         }
     }
 
@@ -422,7 +262,8 @@ public class ResourceModificationController : ControllerBase
             {
                 var resourcesToSave = new HashSet<long>();
                 var resourceCache = new Dictionary<long, Resource>();
-                await FromModel(model, resourcesToSave, resourceCache, r);
+                var converter = new ModelToResourceConverter(_resourceManagement, _resourceTypeTree, _serialization);
+                await converter.FromModel(model, resourcesToSave, resourceCache, r);
                 resourcesToSave.ForEach(id => _resourceManagement.ModifyUnsafeAsync(id, _ => Task.FromResult(true)));
                 return true;
             });

--- a/src/Moryx.AbstractionLayer/Resources/IReferenceCollection.cs
+++ b/src/Moryx.AbstractionLayer/Resources/IReferenceCollection.cs
@@ -21,6 +21,20 @@ public interface IReferenceCollection
     event EventHandler<ReferenceCollectionChangedEventArgs> CollectionChanged;
 }
 
+// TODO: Merge with IReferenceCollection in next major
+// TODO: Add a way to synchronize access to the underlying collection properly.
+//       Is not a best practice and not possible in an async context
+/// <summary>
+/// Temporary extension interface to include new functionality that should be merged into IReferenceCollection later
+/// </summary>
+public interface IReferenceCollectionExtended : IReferenceCollection
+{
+    /// <summary>
+    /// Notifies the collection that the UnderlyingCollection was changed directly
+    /// </summary>
+    void UnderlyingCollectionChanged();
+}
+
 /// <summary>
 /// Event args for the <see cref="IReferenceCollection.CollectionChanged"/> event
 /// </summary>

--- a/src/Moryx.Resources.Management/Resources/ReferenceCollection.cs
+++ b/src/Moryx.Resources.Management/Resources/ReferenceCollection.cs
@@ -48,7 +48,10 @@ internal class ReferenceCollection<TResource> : IReferences<TResource>, IReferen
     public void Add(TResource item)
     {
         lock (UnderlyingCollection)
+        {
             UnderlyingCollection.Add(item);
+        }
+
         RaiseCollectionChanged();
     }
 
@@ -59,10 +62,15 @@ internal class ReferenceCollection<TResource> : IReferences<TResource>, IReferen
     {
         var result = false;
         lock (UnderlyingCollection)
+        {
             result = UnderlyingCollection.Remove(item);
+        }
 
         if (result)
+        {
             RaiseCollectionChanged();
+        }
+
         return result;
     }
 
@@ -72,7 +80,10 @@ internal class ReferenceCollection<TResource> : IReferences<TResource>, IReferen
     public void Clear()
     {
         lock (UnderlyingCollection)
+        {
             UnderlyingCollection.Clear();
+        }
+
         RaiseCollectionChanged();
     }
 
@@ -82,7 +93,9 @@ internal class ReferenceCollection<TResource> : IReferences<TResource>, IReferen
     public bool Contains(TResource item)
     {
         lock (UnderlyingCollection)
+        {
             return UnderlyingCollection.Contains(item);
+        }
     }
 
     /// <summary>
@@ -91,7 +104,9 @@ internal class ReferenceCollection<TResource> : IReferences<TResource>, IReferen
     public void CopyTo(TResource[] array, int arrayIndex)
     {
         lock (UnderlyingCollection)
+        {
             UnderlyingCollection.CopyTo(array, arrayIndex);
+        }
     }
 
     /// <summary>
@@ -100,7 +115,9 @@ internal class ReferenceCollection<TResource> : IReferences<TResource>, IReferen
     public IEnumerator<TResource> GetEnumerator()
     {
         lock (UnderlyingCollection)
+        {
             return UnderlyingCollection.Cast<TResource>().ToList().GetEnumerator();
+        }
     }
 
     IEnumerator IEnumerable.GetEnumerator()

--- a/src/Moryx.Resources.Management/Resources/ReferenceCollection.cs
+++ b/src/Moryx.Resources.Management/Resources/ReferenceCollection.cs
@@ -10,7 +10,7 @@ namespace Moryx.Resources.Management;
 /// <summary>
 /// Collection that wraps another collection of references
 /// </summary>
-internal class ReferenceCollection<TResource> : IReferences<TResource>
+internal class ReferenceCollection<TResource> : IReferences<TResource>, IReferenceCollectionExtended
     where TResource : class, IResource
 {
     private readonly Resource _parent;
@@ -113,5 +113,11 @@ internal class ReferenceCollection<TResource> : IReferences<TResource>
         var args = new ReferenceCollectionChangedEventArgs(_parent, _property);
         CollectionChanged?.Invoke(this, args);
     }
+
+    public void UnderlyingCollectionChanged()
+    {
+        RaiseCollectionChanged();
+    }
+
     public event EventHandler<ReferenceCollectionChangedEventArgs> CollectionChanged;
 }

--- a/src/Moryx.Resources.Management/Resources/ResourceLinker.cs
+++ b/src/Moryx.Resources.Management/Resources/ResourceLinker.cs
@@ -11,6 +11,7 @@ using Moryx.Logging;
 using Moryx.Model;
 using Moryx.Model.Repositories;
 using Moryx.Resources.Management.Model;
+using Moryx.Tools;
 using static Moryx.Resources.Management.ResourceReferenceTools;
 
 namespace Moryx.Resources.Management;
@@ -55,9 +56,13 @@ internal class ResourceLinker : IResourceLinker
             {
                 // Get the reference collection
                 var value = (IReferenceCollection)property.GetValue(resource);
-                foreach (var referencedResource in resources)
+                lock (value.UnderlyingCollection)
                 {
-                    value.UnderlyingCollection.Add(referencedResource);
+                    value.UnderlyingCollection.AddRange(resources);
+                }
+                if (value is IReferenceCollectionExtended extended)
+                {
+                    extended.UnderlyingCollectionChanged();
                 }
             }
             // Link a single reference
@@ -323,8 +328,22 @@ internal class ResourceLinker : IResourceLinker
         {
             prop.SetValue(target, value);
         }
-        else if (prop.GetValue(target) is IReferenceCollection collection && !collection.UnderlyingCollection.Contains(value))
-            collection.UnderlyingCollection.Add(value);
+        else if (prop.GetValue(target) is IReferenceCollection collection)
+        {
+            bool collectionChanged = false;
+            lock (collection.UnderlyingCollection)
+            {
+                if (!collection.UnderlyingCollection.Contains(value))
+                {
+                    collectionChanged = true;
+                    collection.UnderlyingCollection.Add(value);
+                }
+            }
+            if(collectionChanged && collection is IReferenceCollectionExtended extended)
+            {
+                extended.UnderlyingCollectionChanged();
+            }
+        }
 
         var backAttr = prop.GetCustomAttribute<ResourceReferenceAttribute>();
         UpdateRelationEntity(relationEntity, backAttr);
@@ -344,9 +363,17 @@ internal class ResourceLinker : IResourceLinker
         {
             prop.SetValue(target, null);
         }
-        else
+        else if (propValue is IReferenceCollection collection)
         {
-            (propValue as IReferenceCollection)?.UnderlyingCollection.Remove(value);
+            bool changed;
+            lock (collection.UnderlyingCollection)
+            {
+                changed = collection.UnderlyingCollection.Remove(value);
+            }
+            if(changed && collection is IReferenceCollectionExtended extended)
+            {
+                extended.UnderlyingCollectionChanged();
+            }
         }
     }
 
@@ -439,10 +466,24 @@ internal class ResourceLinker : IResourceLinker
             return;
 
         // Remove the reference from the property
+        // TODO: Should we really test for IEnumerable and then cast to other types?
+        // This looks like a bad idea to me. Why don't we test for IReferenceCollection?
         if (typeof(IEnumerable<IResource>).IsAssignableFrom(backReference.PropertyType))
         {
-            var referenceCollection = (IReferenceCollection)backReference.GetValue(reference);
-            referenceCollection.UnderlyingCollection.Remove(deletedInstance);
+            var value = backReference.GetValue(reference);
+            
+            if (value is IReferenceCollection referenceCollection)
+            {
+                bool result;
+                lock (referenceCollection.UnderlyingCollection)
+                {
+                    result = referenceCollection.UnderlyingCollection.Remove(deletedInstance);
+                }
+                if (result && referenceCollection is IReferenceCollectionExtended extended)
+                {
+                    extended.UnderlyingCollectionChanged();
+                }
+            }
         }
         else
         {

--- a/src/Moryx.Resources.Management/Resources/ResourceLinker.cs
+++ b/src/Moryx.Resources.Management/Resources/ResourceLinker.cs
@@ -69,11 +69,17 @@ internal class ResourceLinker : IResourceLinker
             else
             {
                 if (resources.Count == 1)
+                {
                     property.SetValue(resource, resources[0]);
+                }
                 else if (resources.Count > 1)
+                {
                     Logger.Log(LogLevel.Warning, "Inconclusive relation: Can not assign property {0} on {1}:{2} from [{3}]. Too many matches!", property.Name, resource.Id, resource.Name, string.Join(",", matches.Select(m => m.ReferenceId)));
+                }
                 else if (matches.Any(m => referenceProperties.All(p => !PropertyMatchesRelation(p, m, Graph.Get(m.ReferenceId)))))
+                {
                     Logger.Log(LogLevel.Warning, "Incompatible relation: Resources from [{0}] with relation type {1} can not be assigned to a property on {2}:{3}.", string.Join(",", matches.Select(m => m.ReferenceId)), matches[0].RelationType, resource.Id, resource.Name);
+                }
             }
         }
     }
@@ -96,8 +102,7 @@ internal class ResourceLinker : IResourceLinker
     private async Task SaveReferences(ReferenceSaverContext context, Resource instance, Dictionary<Resource, ResourceEntity> dict = null)
     {
         var entity = await GetOrCreateEntity(context, instance);
-        if (dict != null)
-            dict.Add(instance, entity);
+        dict?.Add(instance, entity);
 
         var referenceAccessors = (await ResourceRelationAccessor.FromEntity(context.UnitOfWork, entity))
             .Union(ResourceRelationAccessor.FromQueryable(context.CreatedRelations.AsQueryable(), entity))
@@ -119,13 +124,17 @@ internal class ResourceLinker : IResourceLinker
                 // Save a single reference
                 var createdResource = await UpdateSingleReference(context, entity, instance, referenceProperty, typeMatches);
                 if (createdResource != null)
+                {
                     createdResources.Add(createdResource);
+                }
             }
         }
 
         // Recursively save references for new resources
         foreach (var resource in createdResources)
+        {
             await SaveReferences(context, resource, dict);
+        }
     }
 
     /// <inheritdoc />
@@ -140,7 +149,9 @@ internal class ResourceLinker : IResourceLinker
         var created = await UpdateCollectionReference(context, entity, instance, property, typeMatches);
 
         foreach (var resource in created)
+        {
             await SaveReferences(context, resource);
+        }
 
         return context.EntityCache.Keys.Where(i => i.Id == 0).ToList();
     }
@@ -153,7 +164,7 @@ internal class ResourceLinker : IResourceLinker
     /// [ResourceReference(ResourceRelationType.TransportRoute, ResourceReferenceRole.Source)]
     /// public Resource FriendResource { get; set; }
     /// </example>
-    private async Task<Resource> UpdateSingleReference(ReferenceSaverContext context, ResourceEntity entity, Resource resource, PropertyInfo referenceProperty, IReadOnlyList<ResourceRelationAccessor> matches)
+    private static async Task<Resource> UpdateSingleReference(ReferenceSaverContext context, ResourceEntity entity, Resource resource, PropertyInfo referenceProperty, IReadOnlyList<ResourceRelationAccessor> matches)
     {
         var relationRepo = context.UnitOfWork.GetRepository<IResourceRelationRepository>();
 
@@ -161,25 +172,31 @@ internal class ResourceLinker : IResourceLinker
         var referencedResource = value as Resource;
         // Validate if object assigned to the property is a resource
         if (value != null && referencedResource == null)
+        {
             throw new ArgumentException($"Value of property {referenceProperty.Name} on resource {resource.Id}:{resource.GetType().Name} must be a Resource");
+        }
 
         var referenceAtt = referenceProperty.GetCustomAttribute<ResourceReferenceAttribute>();
 
         // Validate if required property is set
         if (referencedResource == null && referenceAtt.IsRequired)
+        {
             throw new ValidationException($"Property {referenceProperty.Name} is flagged 'Required' and was null!");
+        }
 
         // Check if there is a relation that represents this reference
         if (referencedResource != null && matches.Any(m => referencedResource == context.ResolveReferencedResource(m)))
+        {
             return null;
+        }
 
         // Get all references of this resource with the same relation information
         var currentReferences = CurrentReferences(resource, referenceAtt);
 
         // Try to find a match that is not used in any reference
         var relMatch = (from match in matches
-            where currentReferences.All(cr => cr != context.ResolveReferencedResource(match))
-            select match).FirstOrDefault();
+                        where currentReferences.All(cr => cr != context.ResolveReferencedResource(match))
+                        select match).FirstOrDefault();
         var relEntity = relMatch?.Entity;
         if (relEntity == null && referencedResource != null)
         {
@@ -223,7 +240,7 @@ internal class ResourceLinker : IResourceLinker
     /// [ResourceReference(ResourceRelationType.TransportRoute, ResourceReferenceRole.Source)]
     /// public IReferences&lt;Resource&gt; FriendResources { get; set; }
     /// </example>
-    private async Task<IEnumerable<Resource>> UpdateCollectionReference(ReferenceSaverContext context, ResourceEntity entity, Resource resource, PropertyInfo referenceProperty, IReadOnlyList<ResourceRelationAccessor> relationTemplates)
+    private static async Task<IEnumerable<Resource>> UpdateCollectionReference(ReferenceSaverContext context, ResourceEntity entity, Resource resource, PropertyInfo referenceProperty, IReadOnlyList<ResourceRelationAccessor> relationTemplates)
     {
         var relationRepo = context.UnitOfWork.GetRepository<IResourceRelationRepository>();
         var referenceAtt = referenceProperty.GetCustomAttribute<ResourceReferenceAttribute>();
@@ -234,7 +251,9 @@ internal class ResourceLinker : IResourceLinker
 
         // Check required attribute against empty collections
         if (referencedResources.Count == 0 && referenceAtt.IsRequired)
+        {
             throw new ValidationException($"Property {referenceProperty.Name} is flagged 'Required' and was empty!");
+        }
 
         // First delete references that are not used by ANY property of the same configuration
         var currentReferences = CurrentReferences(resource, referenceAtt);
@@ -265,11 +284,11 @@ internal class ResourceLinker : IResourceLinker
     {
         // Get all references of this resource with the same relation information
         var currentReferences = (from property in ReferenceProperties(instance.GetType(), false)
-            let att = property.GetCustomAttribute<ResourceReferenceAttribute>()
-            where att.RelationType == referenceAtt.RelationType
-                  && att.Name == referenceAtt.Name
-                  && att.Role == referenceAtt.Role
-            select property.GetValue(instance)).SelectMany(ExtractAllFromProperty);
+                                 let att = property.GetCustomAttribute<ResourceReferenceAttribute>()
+                                 where att.RelationType == referenceAtt.RelationType
+                                       && att.Name == referenceAtt.Name
+                                       && att.Role == referenceAtt.Role
+                                 select property.GetValue(instance)).SelectMany(ExtractAllFromProperty);
         return new HashSet<IResource>(currentReferences);
     }
 
@@ -280,11 +299,15 @@ internal class ResourceLinker : IResourceLinker
     {
         // Check if it is a single reference
         if (propertyValue is IResource asResource)
+        {
             return [asResource];
+        }
 
         // Otherwise it must be a collection
         if (propertyValue is IEnumerable asEnumerable)
+        {
             return asEnumerable.Cast<IResource>();
+        }
 
         return [];
     }
@@ -296,11 +319,11 @@ internal class ResourceLinker : IResourceLinker
     private static PropertyInfo FindBackLink(Resource target, Resource value, ResourceReferenceAttribute referenceAtt)
     {
         var propOnTarget = (from prop in ReferenceProperties(target.GetType(), false)
-            where IsInstanceOfReference(prop, value)
-            let backAtt = prop.GetCustomAttribute<ResourceReferenceAttribute>()
-            where backAtt.RelationType == referenceAtt.RelationType // Compare relation type
-                  && backAtt.Role != referenceAtt.Role // Validate inverse role
-            select prop).FirstOrDefault();
+                            where IsInstanceOfReference(prop, value)
+                            let backAtt = prop.GetCustomAttribute<ResourceReferenceAttribute>()
+                            where backAtt.RelationType == referenceAtt.RelationType // Compare relation type
+                                  && backAtt.Role != referenceAtt.Role // Validate inverse role
+                            select prop).FirstOrDefault();
         return propOnTarget;
     }
 
@@ -311,7 +334,10 @@ internal class ResourceLinker : IResourceLinker
     {
         var typeLimit = property.PropertyType;
         if (property.PropertyType.IsGenericType && property.PropertyType.GetGenericTypeDefinition() == typeof(IReferences<>))
+        {
             typeLimit = property.PropertyType.GetGenericArguments()[0];
+        }
+
         return typeLimit.IsInstanceOfType(value);
     }
 
@@ -322,7 +348,9 @@ internal class ResourceLinker : IResourceLinker
     {
         var prop = FindBackLink(target, value, referenceAtt);
         if (prop == null)
+        {
             return; // No back-link -> nothing to do
+        }
         // Update back-link property
         if (prop.PropertyType.IsInstanceOfType(value))
         {
@@ -339,7 +367,7 @@ internal class ResourceLinker : IResourceLinker
                     collection.UnderlyingCollection.Add(value);
                 }
             }
-            if(collectionChanged && collection is IReferenceCollectionExtended extended)
+            if (collectionChanged && collection is IReferenceCollectionExtended extended)
             {
                 extended.UnderlyingCollectionChanged();
             }
@@ -356,7 +384,9 @@ internal class ResourceLinker : IResourceLinker
     {
         var prop = FindBackLink(target, value, referenceAtt);
         if (prop == null)
+        {
             return; // No back-link -> nothing to do
+        }
         // Update property ONLY if it currently points to our resource
         var propValue = prop.GetValue(target);
         if (propValue == value)
@@ -370,7 +400,7 @@ internal class ResourceLinker : IResourceLinker
             {
                 changed = collection.UnderlyingCollection.Remove(value);
             }
-            if(changed && collection is IReferenceCollectionExtended extended)
+            if (changed && collection is IReferenceCollectionExtended extended)
             {
                 extended.UnderlyingCollectionChanged();
             }
@@ -384,7 +414,9 @@ internal class ResourceLinker : IResourceLinker
     {
         // First check if the context contains an entity for the instance
         if (context.EntityCache.TryGetValue(instance, out var cached))
+        {
             return cached;
+        }
 
         ResourceEntity entity;
         if (instance.Id > 0)
@@ -445,9 +477,13 @@ internal class ResourceLinker : IResourceLinker
     private static void UpdateRelationEntity(ResourceRelationEntity relEntity, ResourceReferenceAttribute att)
     {
         if (att.Role == ResourceReferenceRole.Source)
+        {
             relEntity.SourceName = att.Name;
+        }
         else
+        {
             relEntity.TargetName = att.Name;
+        }
     }
 
     /// <inheritdoc />
@@ -456,14 +492,16 @@ internal class ResourceLinker : IResourceLinker
         // Try to find a property on the reference back-linking to the deleted instance
         var type = reference.GetType();
         var backReference = (from property in ReferenceProperties(type, false)
-            // Instead of comparing the resource type we simply look for the object reference
-            let value = property.GetValue(reference)
-            where value == deletedInstance || ((value as IEnumerable<IResource>)?.Contains(deletedInstance) ?? false)
-            select property).FirstOrDefault();
+                             // Instead of comparing the resource type we simply look for the object reference
+                             let value = property.GetValue(reference)
+                             where value == deletedInstance || ((value as IEnumerable<IResource>)?.Contains(deletedInstance) ?? false)
+                             select property).FirstOrDefault();
 
         // If the referenced resource does not define a back reference we don't have to do anything
         if (backReference == null)
+        {
             return;
+        }
 
         // Remove the reference from the property
         // TODO: Should we really test for IEnumerable and then cast to other types?
@@ -471,7 +509,7 @@ internal class ResourceLinker : IResourceLinker
         if (typeof(IEnumerable<IResource>).IsAssignableFrom(backReference.PropertyType))
         {
             var value = backReference.GetValue(reference);
-            
+
             if (value is IReferenceCollection referenceCollection)
             {
                 bool result;
@@ -498,10 +536,10 @@ internal class ResourceLinker : IResourceLinker
     {
         var attribute = property.GetCustomAttribute<ResourceReferenceAttribute>();
         var matches = from relation in relations
-            where relation.Role == attribute.Role
-            where relation.RelationType == attribute.RelationType
-            where relation.Name == attribute.Name
-            select relation;
+                      where relation.Role == attribute.Role
+                      where relation.RelationType == attribute.RelationType
+                      where relation.Name == attribute.Name
+                      select relation;
         return matches;
     }
 
@@ -525,9 +563,9 @@ internal class ResourceLinker : IResourceLinker
         Func<ResourceRelationAccessor, Resource> instanceResolver)
     {
         return from relation in relations
-            let other = instanceResolver(relation)
-            where IsInstanceOfReference(property, other)
-            select relation;
+               let other = instanceResolver(relation)
+               where IsInstanceOfReference(property, other)
+               select relation;
     }
 
     /// <summary>
@@ -548,7 +586,9 @@ internal class ResourceLinker : IResourceLinker
         {
             EntityCache[initialInstance] = entity;
             if (initialInstance.Id == 0)
+            {
                 ResourceLookup[entity] = initialInstance;
+            }
         }
 
         public ReferenceSaverContext(IUnitOfWork uow, IResourceGraph graph)


### PR DESCRIPTION
### Summary

<!-- 
Summarize the bug and how this PR fixes it. If applicable, map the PR to tickets (e.g., JIRA, GitHub Issues).
-->
Collection changed events on collections of resources are not called when manipulating the resource graph.
See the linked issue

NOTE: To see only the logic changes, view the first commit. The second one applies linting rules to the changed files which leads to a lot of noise in the changes.

### Linked Issues

<!-- 
Link to any related issues using GitHub keywords (e.g., Fixes #123, Closes #456).
-->
Fixes #524 

### Relevant logs and/or screenshots

<!-- 
Paste any relevant logs. Please use code blocks (```) to format console output, logs, and code.
-->

### Breaking Changes

<!-- 
Does this PR introduce any breaking changes? If yes, describe them.
-->

### Checklist for Submitter

- [x] I have tested these changes locally
- [ ] I have updated documentation as needed
- [ ] I have added or updated tests as appropriate
- [x] I have used clear and descriptive commit messages

### Review

**Typical tasks**

- [ ] Merge request is well described
- [ ] Critical sections are *documented in code*
- [ ] *Tests* are extended
- [ ] *Documentation* is created / updated
- [ ] Running in test environment
- [ ] Ports to other maintained versions are created

**Clean code**

- [ ] *All* unused references are removed
- [ ] Clean code rules are respected with passion (naming, ...)
- [ ] Avoid *copy and pasted* code snippets