### PR TITLE
Respect Disabled flag in SetupTrigerConfig

### DIFF
--- a/src/Moryx.ControlSystem.SetupProvider/Implementation/SetupManager.cs
+++ b/src/Moryx.ControlSystem.SetupProvider/Implementation/SetupManager.cs
@@ -3,7 +3,6 @@
 using Microsoft.Extensions.Logging;
 using Moryx.AbstractionLayer.Recipes;
 using Moryx.Container;
-using Moryx.ControlSystem.Cells;
 using Moryx.ControlSystem.Recipes;
 using Moryx.ControlSystem.Setups;
 using Moryx.Logging;
@@ -15,7 +14,7 @@ namespace Moryx.ControlSystem.SetupProvider;
 [Component(LifeCycle.Singleton, typeof(ISetupManager))]
 internal partial class SetupManager : ISetupManager, ILoggingComponent
 {
-    private readonly ICollection<ISetupTrigger> _triggers = new List<ISetupTrigger>();
+    private readonly List<ISetupTrigger> _triggers = [];
 
     #region Dependencies
     /// <summary>
@@ -41,9 +40,14 @@ internal partial class SetupManager : ISetupManager, ILoggingComponent
     {
         foreach (var triggerConfig in Config.SetupTriggers)
         {
+            if (triggerConfig.Disabled)
+            {
+                continue;
+            }
             var trigger = TriggerFactory.Create(triggerConfig);
             _triggers.Add(trigger);
         }
+        _triggers.Sort((t1, t2) => t1.SortOrder - t2.SortOrder);
     }
 
     /// <inheritdoc />
@@ -74,7 +78,9 @@ internal partial class SetupManager : ISetupManager, ILoggingComponent
             if (evaluation is SetupEvaluation.Change change)
             {
                 if (ShouldSkipForExecution(execution, targetSystem, change, trigger.GetType().Name))
+                {
                     continue;
+                }
             }
 
             triggers.Add(trigger);
@@ -89,7 +95,7 @@ internal partial class SetupManager : ISetupManager, ILoggingComponent
 
         // Create all necessary setup steps
         var stepGroups = new Dictionary<int, List<IWorkplanStep>>();
-        foreach (var trigger in triggers.OrderBy(t => t.SortOrder))
+        foreach (var trigger in triggers)
         {
             var index = trigger.SortOrder;
 
@@ -240,7 +246,6 @@ internal partial class SetupManager : ISetupManager, ILoggingComponent
         switch (execution)
         {
             case SetupExecution.BeforeProduction:
-            {
                 var targetCells = targetSystem.Cells(change.TargetCapabilities);
                 var hasTargetCaps = targetCells.Any();
 
@@ -251,10 +256,8 @@ internal partial class SetupManager : ISetupManager, ILoggingComponent
                     return true;
                 }
                 return false;
-            }
 
             case SetupExecution.AfterProduction:
-            {
                 var currentCells = targetSystem.Cells(change.CurrentCapabilities);
                 var hasCurrentCaps = currentCells.Any();
 
@@ -266,12 +269,10 @@ internal partial class SetupManager : ISetupManager, ILoggingComponent
                     return true;
                 }
                 return false;
-            }
             default:
                 return false;
         }
     }
-
 
     private static partial class Log
     {

--- a/src/Tests/Moryx.ControlSystem.SetupProvider.Tests/SetupManagerTests.cs
+++ b/src/Tests/Moryx.ControlSystem.SetupProvider.Tests/SetupManagerTests.cs
@@ -1,7 +1,6 @@
 // Copyright (c) 2026 Phoenix Contact GmbH & Co. KG
 // Licensed under the Apache License, Version 2.0
 
-using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
@@ -87,7 +86,9 @@ public class SetupManagerTests
         Assert.DoesNotThrow(delegate
         {
             foreach (var triggerConfigs in _setupManagerConfig.SetupTriggers)
+            {
                 _triggerFactoryMock.Verify(f => f.Create(triggerConfigs), Times.Once);
+            }
         });
     }
 
@@ -109,7 +110,9 @@ public class SetupManagerTests
             Assert.That(requiredSetup.Workplan.Steps.Count(), Is.EqualTo(steps));
         }
         else
+        {
             Assert.That(requiredSetup, Is.Null);
+        }
     }
 
     [Test(Description = "There should be only one SetupJob of type cleanup after the only production job. " +
@@ -131,6 +134,27 @@ public class SetupManagerTests
         // Temporary recipe not executable
         Assert.That(workplan.Steps.Count(), Is.EqualTo(4), "Workplan should have 4 steps: 2 setup steps, split and join");
         Assert.That(workplan.Connectors.Count(), Is.EqualTo(7), "Workplan should have 7 connectors: start, end, failed AND 2 step-in, 2 step-out");
+    }
+
+    [TestCase(SetupExecution.BeforeProduction)]
+    [TestCase(SetupExecution.AfterProduction)]
+    public void DisabledSetupTriggersProduceNoJobs(SetupExecution execution)
+    {
+        // Arrange
+        foreach (var triggerConfig in _setupManagerConfig.SetupTriggers)
+        {
+            triggerConfig.Disabled = true;
+        }
+        var manager = CreateSetupManager(_setupManagerConfig);
+
+        var recipe = CreateRecipe(1783, 42);
+
+        // Act
+        var setupRecipe = manager.RequiredSetup(execution, recipe, new CurrentResourceTarget(_resourceManagerMock.Object));
+
+        // Assert
+        Assert.That(setupRecipe, Is.Null);
+
     }
 
     /// <summary>


### PR DESCRIPTION


### Summary

<!-- 
Summarize the bug and how this PR fixes it. If applicable, map the PR to tickets (e.g., JIRA, GitHub Issues).
-->

Against expectations disabled setup triggers were run as normal. The disabled flag had no effect.

Now disabled SetupTriggers are ignored by not instantiating them.

As a small improvement on the side, I removed the unnecessary indirection caused by treating the list of triggers as an ICollection and removed the constant re-sorting of the triggers by their SortIndex.

### Linked Issues

<!-- 
Link to any related issues using GitHub keywords (e.g., Fixes #123, Closes #456).
-->

### Relevant logs and/or screenshots

<!-- 
Paste any relevant logs. Please use code blocks (```) to format console output, logs, and code.
-->

### Breaking Changes

<!-- 
Does this PR introduce any breaking changes? If yes, describe them.
-->

### Checklist for Submitter

- [x] I have tested these changes locally
- [ ] I have updated documentation as needed
- [x] I have added or updated tests as appropriate
- [x] I have used clear and descriptive commit messages

### Review

**Typical tasks**

- [ ] Merge request is well described
- [ ] Critical sections are *documented in code*
- [ ] *Tests* are extended
- [ ] *Documentation* is created / updated
- [ ] Running in test environment
- [ ] Ports to other maintained versions are created

**Clean code**

- [ ] *All* unused references are removed
- [ ] Clean code rules are respected with passion (naming, ...)
- [ ] Avoid *copy and pasted* code snippets