### PR TITLE
Port: Enable delete for unused subproducts

### DIFF
--- a/src/Moryx.Products.Management/Implementation/Storage/ProductStorage.cs
+++ b/src/Moryx.Products.Management/Implementation/Storage/ProductStorage.cs
@@ -1018,7 +1018,7 @@ internal class ProductStorage : IProductStorage, IConfiguredTypesProvider
             select new
             {
                 entity,
-                parentCount = entity.Parents.Count
+                parentCount = entity.Parents.Count(pl => pl.Parent.Deleted == null)
             }).FirstOrDefault();
         // No match, nothing removed!
         if (queryResult == null)


### PR DESCRIPTION
If all parents are deleted we can delete the subproduct too.

(cherry picked from commit 2af969a38876fe9464091abcaac804e9dbec2f9c)

### Summary

If all parents are deleted we can delete the subproduct too.

### Linked Issues

Ported from https://github.com/PHOENIXCONTACT/MORYX-AbstractionLayer/pull/232

### Checklist for Submitter

- [x] I have tested these changes locally
- [ ] I have updated documentation as needed
- [ ] I have added or updated tests as appropriate
- [x] I have used clear and descriptive commit messages

### Review

**Typical tasks**

- [ ] Merge request is well described
- [ ] Critical sections are *documented in code*
- [ ] *Tests* are extended
- [ ] *Documentation* is created / updated
- [ ] Running in test environment
- [ ] Ports to other maintained versions are created

**Clean code**

- [ ] *All* unused references are removed
- [ ] Clean code rules are respected with passion (naming, ...)
- [ ] Avoid *copy and pasted* code snippets
