### PR TITLE
Add parameterless constructor to fix AxisMovement UI.

### DIFF
--- a/src/Moryx.AbstractionLayer/Drivers/Axis/AxisMovement.cs
+++ b/src/Moryx.AbstractionLayer/Drivers/Axis/AxisMovement.cs
@@ -44,4 +44,13 @@ public class AxisMovement
         Axis = axis;
         PredefinedPosition = predefinedPosition;
     }
+
+    /// <summary>
+    /// Creates an empty <see cref="AxisMovement"/> without <see cref="PredefinedPosition"/> or <see cref="TargetPosition"/>.
+    /// Required for deserialization.
+    /// </summary>
+    public AxisMovement()
+    {
+
+    }
 }


### PR DESCRIPTION
Added a parameterless constructor to AxisMovement so it can be instantiated by the UI.