### PR TITLE
Allow loading of archived processes by id

### DIFF
--- a/src/Moryx.ControlSystem.ProcessEngine/Facades/ProcessControlFacade.cs
+++ b/src/Moryx.ControlSystem.ProcessEngine/Facades/ProcessControlFacade.cs
@@ -13,7 +13,7 @@ using Moryx.Threading;
 
 namespace Moryx.ControlSystem.ProcessEngine;
 
-internal class ProcessControlFacade : FacadeBase, IProcessControl
+internal class ProcessControlFacade : FacadeBase, IProcessControlExtended
 {
     #region Dependencies
 
@@ -73,6 +73,12 @@ internal class ProcessControlFacade : FacadeBase, IProcessControl
     {
         ValidateHealthState();
         return ActivityDataPool.GetProcess(process)?.NextTargets() ?? Array.Empty<ICell>();
+    }
+
+    public Task<Process> LoadArchivedProcessAsync(long id, CancellationToken cancellationToken = default)
+    {
+        ValidateHealthState();
+        return ProcessArchive.GetProcess(id, cancellationToken);
     }
 
     public IReadOnlyList<ICell> Targets(Activity activity)

--- a/src/Moryx.ControlSystem.ProcessEngine/Processes/Components/IProcessArchive.cs
+++ b/src/Moryx.ControlSystem.ProcessEngine/Processes/Components/IProcessArchive.cs
@@ -19,6 +19,11 @@ internal interface IProcessArchive : IPlugin
     Task<IReadOnlyList<Process>> GetProcesses(ProductInstance productInstance, CancellationToken cancellationToken);
 
     /// <summary>
+    /// Retrieve a process by its id.
+    /// </summary>
+    Task<Process> GetProcess(long id, CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Retrieve all processes in a certain range
     /// </summary>
     /// <param name="filterType">Type of filtering</param>

--- a/src/Moryx.ControlSystem.ProcessEngine/Processes/Implementation/ProcessArchive.cs
+++ b/src/Moryx.ControlSystem.ProcessEngine/Processes/Implementation/ProcessArchive.cs
@@ -62,25 +62,58 @@ internal class ProcessArchive : IProcessArchive
         var processRepo = uow.GetRepository<IProcessEntityRepository>();
 
         var query = (from processEntity in processRepo.Linq
-            where processEntity.ReferenceId == productInstance.Id
-            select new { processEntity.Id, processEntity.Job.RecipeId }).ToList(); // TODO use ToListAsync and fix tests
+        where processEntity.ReferenceId == productInstance.Id
+        select new { processEntity.Id, processEntity.Job.RecipeId }).ToList(); // TODO use ToListAsync and fix tests
 
         var processes = new List<Process>();
         foreach (var match in query)
         {
-            var recipe = (ProductionRecipe)await ProductManagement.LoadRecipeAsync(match.RecipeId);
-            var process = (ProductionProcess)recipe.CreateProcess();
-            process.Id = match.Id;
-            process.ProductInstance = productInstance;
-            var context = new ProcessWorkplanContext(process);
-            var taskMap = recipe.Workplan.Steps
-                .Select(step => step.CreateInstance(context))
-                .OfType<ITask>().ToDictionary(task => task.Id, task => task);
-            ProcessStorage.FillActivities(uow, process, taskMap);
+            var process = await CreateAndFillProcess(uow, match.Id, match.RecipeId, productInstance, cancellationToken);
             processes.Add(process);
         }
 
         return processes;
+    }
+
+    public async Task<Process> GetProcess(long id, CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        using var uow = UnitOfWorkFactory.Create();
+        var repo = uow.GetRepository<IProcessEntityRepository>();
+
+        var query = from processEntity in repo.Linq
+                    where processEntity.Id == id
+                    select new { processEntity.Id, processEntity.Job.RecipeId, processEntity.ReferenceId };
+
+        var entity = query.FirstOrDefault();
+
+        if (entity == null)
+        {
+            return null;
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var productInstance = await ProductManagement.LoadInstanceAsync(entity.ReferenceId, cancellationToken);
+        var process = await CreateAndFillProcess(uow, id, entity.RecipeId, productInstance, cancellationToken);
+
+        return process;
+    }
+
+    private async Task<ProductionProcess> CreateAndFillProcess(IUnitOfWork uow, long id, long recipeId, ProductInstance instance, CancellationToken cancellationToken)
+    {
+        var recipe = (ProductionRecipe)await ProductManagement.LoadRecipeAsync(recipeId, cancellationToken);
+        var process = (ProductionProcess)recipe.CreateProcess();
+        process.Id = id;
+        process.ProductInstance = instance;
+        var context = new ProcessWorkplanContext(process);
+        var taskMap = recipe.Workplan.Steps
+            .Select(step => step.CreateInstance(context))
+            .OfType<ITask>().ToDictionary(task => task.Id, task => task);
+        ProcessStorage.FillActivities(uow, process, taskMap);
+
+        return process;
     }
 
     public async IAsyncEnumerable<IProcessChunk> GetProcesses(ProcessRequestFilter filterType, DateTime start, DateTime end, long[] jobIds,
@@ -125,7 +158,7 @@ internal class ProcessArchive : IProcessArchive
         var processRepo = uow.GetRepository<IProcessEntityRepository>();
 
         // Otherwise load it on the fly
-        var recipe = (IWorkplanRecipe)await ProductManagement.LoadRecipeAsync(jobEntity.RecipeId);
+        var recipe = (IWorkplanRecipe)await ProductManagement.LoadRecipeAsync(jobEntity.RecipeId, cancellationToken);
         var job = new Job(recipe, jobEntity.Amount)
         {
             Id = jobEntity.Id,
@@ -155,7 +188,7 @@ internal class ProcessArchive : IProcessArchive
         {
             var process = (ProductionProcess)recipe.CreateProcess();
             process.Id = query[index].Id;
-            process.ProductInstance = await ProductManagement.LoadInstanceAsync(query[index].ReferenceId);
+            process.ProductInstance = await ProductManagement.LoadInstanceAsync(query[index].ReferenceId, cancellationToken);
             ProcessStorage.FillActivities(uow, process, taskMap);
             processes[index] = process;
         }

--- a/src/Moryx.ControlSystem/Processes/IProcessControlExtended.cs
+++ b/src/Moryx.ControlSystem/Processes/IProcessControlExtended.cs
@@ -1,0 +1,19 @@
+// Copyright (c) 2026 Phoenix Contact GmbH & Co. KG
+// Licensed under the Apache License, Version 2.0
+
+using Moryx.AbstractionLayer.Processes;
+using Moryx.ControlSystem.Processes;
+
+namespace Moryx.ControlSystem.ProcessEngine;
+
+// ToDo: Merge in MORYX 12
+/// <summary>
+/// Facade interface to get even more information from the process engine
+/// </summary>
+public interface IProcessControlExtended : IProcessControl
+{
+    /// <summary>
+    /// Retrieve a process by its id.
+    /// </summary>
+    Task<Process> LoadArchivedProcessAsync(long id, CancellationToken cancellationToken = default);
+}

--- a/src/Tests/Moryx.ControlSystem.ProcessEngine.Tests/Processes/ProcessArchiveTests.cs
+++ b/src/Tests/Moryx.ControlSystem.ProcessEngine.Tests/Processes/ProcessArchiveTests.cs
@@ -240,6 +240,21 @@ public class ProcessArchiveTests
         Assert.That(process.ProductInstance, Is.InstanceOf<DummyProductInstance>());
     }
 
+    [Test]
+    public async Task GetProcessesById()
+    {
+        // Arrange
+        var jobs = CreateJobEntities();
+        var entities = CreateProcessEntities(jobs);
+        CreateTestData(jobs, entities);
+
+        // Act
+        var process = await _processArchive.GetProcess(entities[0].ReferenceId, CancellationToken.None);
+
+        // Assert
+        Assert.That(process, Is.Not.Null);
+    }
+
     private void CreateTestData(IReadOnlyList<JobEntity> jobs, IReadOnlyList<ProcessEntity> processes)
     {
         var queryableJobEntityMock = new Mock<IQueryable<JobEntity>>();


### PR DESCRIPTION
### Summary

Extend process control facade to access even more (specific) information, the process control facade should be extended, e.g. for accessing an archived process by a given id.

### Checklist for Submitter

- [ ] I have tested these changes locally
- [ ] I have updated documentation as needed
- [x] I have added or updated tests as appropriate
- [x] I have used clear and descriptive commit messages

### Review

**Typical tasks**

- [x] Merge request is well described
- [x] Critical sections are *documented in code*
- [x] *Tests* are extended
- [ ] *Documentation* is created / updated
- [ ] Running in test environment
- [ ] Ports to other maintained versions are created

**Clean code**

- [x] *All* unused references are removed
- [x] Clean code rules are respected with passion (naming, ...)
- [x] Avoid *copy and pasted* code snippets
