### PR TITLE
fix/EntryConvert_ParseWithFallback

### DIFF
--- a/src/Moryx/Serialization/EntryConvert/EntryConvertGenerator.cs
+++ b/src/Moryx/Serialization/EntryConvert/EntryConvertGenerator.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0
 
 using System.Collections;
+using System.Globalization;
 
 namespace Moryx.Serialization;
 
@@ -17,6 +18,7 @@ public static partial class EntryConvert
     public static EntryValueType TransformType(Type propertyType)
     {
         var valueType = EntryValueType.String;
+
         if (propertyType == typeof(Byte))
         {
             valueType = EntryValueType.Byte;
@@ -73,6 +75,7 @@ public static partial class EntryConvert
         {
             valueType = EntryValueType.Class;
         }
+
         return valueType;
     }
 
@@ -90,7 +93,7 @@ public static partial class EntryConvert
         if (type == typeof(string))
         {
             result = value;
-        }
+        } 
         else if (type == typeof(Byte))
         {
             result = Byte.Parse(value, formatProvider);
@@ -98,7 +101,7 @@ public static partial class EntryConvert
         else if (type == typeof(Boolean))
         {
             result = Boolean.Parse(value);
-        }
+            }
         else if (type == typeof(Int16))
         {
             result = Int16.Parse(value, formatProvider);
@@ -125,11 +128,24 @@ public static partial class EntryConvert
         }
         else if (type == typeof(Single))
         {
-            result = Single.Parse(value, formatProvider);
+            result = ParseWithFallback<float>(
+                value, formatProvider, NumberStyles.Float,
+                Single.TryParse,
+                nameof(Single));
         }
         else if (type == typeof(Double))
         {
-            result = Double.Parse(value, formatProvider);
+            result = ParseWithFallback<double>(
+                value, formatProvider, NumberStyles.Float,
+                Double.TryParse,
+                nameof(Double));
+        }
+        else if (type == typeof(Decimal))
+        {
+            result = ParseWithFallback<decimal>(
+                value, formatProvider, NumberStyles.Number,
+                Decimal.TryParse,
+                nameof(Decimal));
         }
         else if (type.IsEnum)
         {
@@ -143,10 +159,25 @@ public static partial class EntryConvert
         return result;
     }
 
+    private delegate bool TryParseDelegate<T>(string s, NumberStyles style, IFormatProvider provider, out T result);
+
+    private static T ParseWithFallback<T>(
+    string s,
+    IFormatProvider provider,
+    NumberStyles styles,
+    TryParseDelegate<T> parser,
+    string typeName)
+    {
+        if (parser(s, styles, provider, out var v)) return v;
+
+        if (parser(s, styles, CultureInfo.InvariantCulture, out v)) return v;
+
+        throw new FormatException($"Cannot parse '{s}' to {typeName}.");
+    }
+
     private static DateTime? ConvertToUtc(DateTime? dateTime)
     {
         if (dateTime == null) return null;
-
         var nonNullDateTime = (DateTime)dateTime;
         if (nonNullDateTime.Kind == DateTimeKind.Utc)
             return nonNullDateTime;
@@ -165,43 +196,59 @@ public static partial class EntryConvert
     {
         // Traditional re-transformation
         object result = null;
+
         switch (type)
         {
             case EntryValueType.String:
                 result = value;
                 break;
+
             case EntryValueType.Byte:
                 result = Byte.Parse(value, formatProvider);
                 break;
+
             case EntryValueType.Boolean:
                 result = Boolean.Parse(value);
                 break;
+
             case EntryValueType.Int16:
                 result = Int16.Parse(value, formatProvider);
                 break;
+
             case EntryValueType.UInt16:
                 result = UInt16.Parse(value, formatProvider);
                 break;
+
             case EntryValueType.Int32:
                 result = Int32.Parse(value, formatProvider);
                 break;
+
             case EntryValueType.UInt32:
                 result = UInt32.Parse(value, formatProvider);
                 break;
+
             case EntryValueType.Int64:
                 result = Int64.Parse(value, formatProvider);
                 break;
+
             case EntryValueType.UInt64:
                 result = UInt64.Parse(value, formatProvider);
                 break;
+
             case EntryValueType.Single:
-                result = Single.Parse(value, formatProvider);
+                result = ParseWithFallback<float>(
+                    value, formatProvider, NumberStyles.Float,
+                    Single.TryParse,
+                    nameof(Single));
                 break;
+
             case EntryValueType.Double:
-                result = Double.Parse(value, formatProvider);
+                result = ParseWithFallback<double>(
+                    value, formatProvider, NumberStyles.Float,
+                    Double.TryParse,
+                    nameof(Double));
                 break;
         }
-
         return result;
     }
 }

--- a/src/Moryx/Serialization/EntryConvert/EntryConvertGenerator.cs
+++ b/src/Moryx/Serialization/EntryConvert/EntryConvertGenerator.cs
@@ -141,7 +141,7 @@ public static partial class EntryConvert
         else if (type == typeof(decimal))
         {
             result = ParseWithFallback<decimal>(
-                value, formatProvider, NumberStyles.Number,
+                value, formatProvider, NumberStyles.Float,
                 decimal.TryParse);
         }
         else if (type.IsEnum)
@@ -156,13 +156,9 @@ public static partial class EntryConvert
         return result;
     }
 
-    private delegate bool TryParseDelegate<T>(string s, NumberStyles style, IFormatProvider provider, out T result);
+    private delegate bool TryParseDelegate<T>(string input, NumberStyles style, IFormatProvider provider, out T result);
 
-    private static T ParseWithFallback<T>(
-    string input,
-    IFormatProvider provider,
-    NumberStyles styles,
-    TryParseDelegate<T> parser)
+    private static T ParseWithFallback<T>(string input, IFormatProvider provider, NumberStyles styles, TryParseDelegate<T> parser)
     {
         if (parser(input, styles, provider, out var parsedValue))
         {

--- a/src/Moryx/Serialization/EntryConvert/EntryConvertGenerator.cs
+++ b/src/Moryx/Serialization/EntryConvert/EntryConvertGenerator.cs
@@ -130,22 +130,19 @@ public static partial class EntryConvert
         {
             result = ParseWithFallback<float>(
                 value, formatProvider, NumberStyles.Float,
-                float.TryParse,
-                nameof(Single));
+                float.TryParse);
         }
         else if (type == typeof(double))
         {
             result = ParseWithFallback<double>(
                 value, formatProvider, NumberStyles.Float,
-                double.TryParse,
-                nameof(Double));
+                double.TryParse);
         }
         else if (type == typeof(decimal))
         {
             result = ParseWithFallback<decimal>(
                 value, formatProvider, NumberStyles.Number,
-                decimal.TryParse,
-                nameof(Decimal));
+                decimal.TryParse);
         }
         else if (type.IsEnum)
         {
@@ -162,23 +159,22 @@ public static partial class EntryConvert
     private delegate bool TryParseDelegate<T>(string s, NumberStyles style, IFormatProvider provider, out T result);
 
     private static T ParseWithFallback<T>(
-    string s,
+    string input,
     IFormatProvider provider,
     NumberStyles styles,
-    TryParseDelegate<T> parser,
-    string typeName)
+    TryParseDelegate<T> parser)
     {
-        if (parser(s, styles, provider, out var v))
+        if (parser(input, styles, provider, out var parsedValue))
         {
-            return v;
+            return parsedValue;
         }
 
-        if (parser(s, styles, CultureInfo.InvariantCulture, out v))
+        if (parser(input, styles, CultureInfo.InvariantCulture, out parsedValue))
         {
-            return v;
+            return parsedValue;
         }
 
-        throw new FormatException($"Cannot parse '{s}' to {typeName}.");
+        throw new FormatException($"Cannot parse '{input}' to {typeof(T).Name}.");
     }
 
     private static DateTime? ConvertToUtc(DateTime? dateTime)
@@ -252,15 +248,13 @@ public static partial class EntryConvert
             case EntryValueType.Single:
                 result = ParseWithFallback<float>(
                     value, formatProvider, NumberStyles.Float,
-                    float.TryParse,
-                    nameof(Single));
+                    float.TryParse);
                 break;
 
             case EntryValueType.Double:
                 result = ParseWithFallback<double>(
                     value, formatProvider, NumberStyles.Float,
-                    double.TryParse,
-                    nameof(Double));
+                    double.TryParse);
                 break;
         }
         return result;

--- a/src/Moryx/Serialization/EntryConvert/EntryConvertGenerator.cs
+++ b/src/Moryx/Serialization/EntryConvert/EntryConvertGenerator.cs
@@ -19,43 +19,43 @@ public static partial class EntryConvert
     {
         var valueType = EntryValueType.String;
 
-        if (propertyType == typeof(Byte))
+        if (propertyType == typeof(byte))
         {
             valueType = EntryValueType.Byte;
         }
-        else if (propertyType == typeof(Boolean))
+        else if (propertyType == typeof(bool))
         {
             valueType = EntryValueType.Boolean;
         }
-        else if (propertyType == typeof(Int16))
+        else if (propertyType == typeof(short))
         {
             valueType = EntryValueType.Int16;
         }
-        else if (propertyType == typeof(UInt16))
+        else if (propertyType == typeof(ushort))
         {
             valueType = EntryValueType.UInt16;
         }
-        else if (propertyType == typeof(Int32))
+        else if (propertyType == typeof(int))
         {
             valueType = EntryValueType.Int32;
         }
-        else if (propertyType == typeof(UInt32))
+        else if (propertyType == typeof(uint))
         {
             valueType = EntryValueType.UInt32;
         }
-        else if (propertyType == typeof(Int64))
+        else if (propertyType == typeof(long))
         {
             valueType = EntryValueType.Int64;
         }
-        else if (propertyType == typeof(UInt64))
+        else if (propertyType == typeof(ulong))
         {
             valueType = EntryValueType.UInt64;
         }
-        else if (propertyType == typeof(Single))
+        else if (propertyType == typeof(float))
         {
             valueType = EntryValueType.Single;
         }
-        else if (propertyType == typeof(Double))
+        else if (propertyType == typeof(double))
         {
             valueType = EntryValueType.Double;
         }
@@ -93,58 +93,58 @@ public static partial class EntryConvert
         if (type == typeof(string))
         {
             result = value;
-        } 
-        else if (type == typeof(Byte))
-        {
-            result = Byte.Parse(value, formatProvider);
         }
-        else if (type == typeof(Boolean))
+        else if (type == typeof(byte))
         {
-            result = Boolean.Parse(value);
-            }
-        else if (type == typeof(Int16))
-        {
-            result = Int16.Parse(value, formatProvider);
+            result = byte.Parse(value, formatProvider);
         }
-        else if (type == typeof(UInt16))
+        else if (type == typeof(bool))
         {
-            result = UInt16.Parse(value, formatProvider);
+            result = bool.Parse(value);
         }
-        else if (type == typeof(Int32))
+        else if (type == typeof(short))
         {
-            result = Int32.Parse(value, formatProvider);
+            result = short.Parse(value, formatProvider);
         }
-        else if (type == typeof(UInt32))
+        else if (type == typeof(ushort))
         {
-            result = UInt32.Parse(value, formatProvider);
+            result = ushort.Parse(value, formatProvider);
         }
-        else if (type == typeof(Int64))
+        else if (type == typeof(int))
         {
-            result = Int64.Parse(value, formatProvider);
+            result = int.Parse(value, formatProvider);
         }
-        else if (type == typeof(UInt64))
+        else if (type == typeof(uint))
         {
-            result = UInt64.Parse(value, formatProvider);
+            result = uint.Parse(value, formatProvider);
         }
-        else if (type == typeof(Single))
+        else if (type == typeof(long))
+        {
+            result = long.Parse(value, formatProvider);
+        }
+        else if (type == typeof(ulong))
+        {
+            result = ulong.Parse(value, formatProvider);
+        }
+        else if (type == typeof(float))
         {
             result = ParseWithFallback<float>(
                 value, formatProvider, NumberStyles.Float,
-                Single.TryParse,
+                float.TryParse,
                 nameof(Single));
         }
-        else if (type == typeof(Double))
+        else if (type == typeof(double))
         {
             result = ParseWithFallback<double>(
                 value, formatProvider, NumberStyles.Float,
-                Double.TryParse,
+                double.TryParse,
                 nameof(Double));
         }
-        else if (type == typeof(Decimal))
+        else if (type == typeof(decimal))
         {
             result = ParseWithFallback<decimal>(
                 value, formatProvider, NumberStyles.Number,
-                Decimal.TryParse,
+                decimal.TryParse,
                 nameof(Decimal));
         }
         else if (type.IsEnum)
@@ -168,21 +168,35 @@ public static partial class EntryConvert
     TryParseDelegate<T> parser,
     string typeName)
     {
-        if (parser(s, styles, provider, out var v)) return v;
+        if (parser(s, styles, provider, out var v))
+        {
+            return v;
+        }
 
-        if (parser(s, styles, CultureInfo.InvariantCulture, out v)) return v;
+        if (parser(s, styles, CultureInfo.InvariantCulture, out v))
+        {
+            return v;
+        }
 
         throw new FormatException($"Cannot parse '{s}' to {typeName}.");
     }
 
     private static DateTime? ConvertToUtc(DateTime? dateTime)
     {
-        if (dateTime == null) return null;
+        if (dateTime == null)
+        {
+            return null;
+        }
+
         var nonNullDateTime = (DateTime)dateTime;
         if (nonNullDateTime.Kind == DateTimeKind.Utc)
+        {
             return nonNullDateTime;
+        }
         else
+        {
             return TimeZoneInfo.ConvertTimeToUtc(nonNullDateTime, TimeZoneInfo.Local);
+        }
     }
 
     /// <summary>
@@ -204,48 +218,48 @@ public static partial class EntryConvert
                 break;
 
             case EntryValueType.Byte:
-                result = Byte.Parse(value, formatProvider);
+                result = byte.Parse(value, formatProvider);
                 break;
 
             case EntryValueType.Boolean:
-                result = Boolean.Parse(value);
+                result = bool.Parse(value);
                 break;
 
             case EntryValueType.Int16:
-                result = Int16.Parse(value, formatProvider);
+                result = short.Parse(value, formatProvider);
                 break;
 
             case EntryValueType.UInt16:
-                result = UInt16.Parse(value, formatProvider);
+                result = ushort.Parse(value, formatProvider);
                 break;
 
             case EntryValueType.Int32:
-                result = Int32.Parse(value, formatProvider);
+                result = int.Parse(value, formatProvider);
                 break;
 
             case EntryValueType.UInt32:
-                result = UInt32.Parse(value, formatProvider);
+                result = uint.Parse(value, formatProvider);
                 break;
 
             case EntryValueType.Int64:
-                result = Int64.Parse(value, formatProvider);
+                result = long.Parse(value, formatProvider);
                 break;
 
             case EntryValueType.UInt64:
-                result = UInt64.Parse(value, formatProvider);
+                result = ulong.Parse(value, formatProvider);
                 break;
 
             case EntryValueType.Single:
                 result = ParseWithFallback<float>(
                     value, formatProvider, NumberStyles.Float,
-                    Single.TryParse,
+                    float.TryParse,
                     nameof(Single));
                 break;
 
             case EntryValueType.Double:
                 result = ParseWithFallback<double>(
                     value, formatProvider, NumberStyles.Float,
-                    Double.TryParse,
+                    double.TryParse,
                     nameof(Double));
                 break;
         }

--- a/src/Tests/Moryx.Tests/Serialization/EntryConvertSerializationTests.cs
+++ b/src/Tests/Moryx.Tests/Serialization/EntryConvertSerializationTests.cs
@@ -1,9 +1,12 @@
 // Copyright (c) 2026 Phoenix Contact GmbH & Co. KG
 // Licensed under the Apache License, Version 2.0
 
+using System;
+using System.Globalization;
+using System.Linq;
+using System.Threading;
 using Moryx.Serialization;
 using NUnit.Framework;
-using System.Linq;
 
 namespace Moryx.Tests.Serialization;
 
@@ -53,8 +56,77 @@ public class EntryConvertSerializationTests
         var entry = EntryConvert.EncodeObject(myObject);
 
         // Assert
-        Assert.That(entry.SubEntries
-                .FirstOrDefault(x => x.DisplayName == nameof(DummyClass.Number)).Value.Current,
-            Is.EqualTo(myObject.Number.ToString()));
+        Assert.That(entry.SubEntries.FirstOrDefault(x => x.DisplayName == nameof(DummyClass.Number)).Value.Current,
+            Is.EqualTo(myObject.Number.ToString(Thread.CurrentThread.CurrentCulture)));
     }
+
+    [Test]
+    public void ToObject_UsesProvidedFormatProvider_ForFloatDoubleDecimal()
+    {
+        // Arrange
+        var value = "1234,56"; var provider = new CultureInfo("de-DE"); // uses comma as decimal separator
+
+        // Act
+        var floatResult = (float)EntryConvert.ToObject(typeof(float), value, provider);
+        var doubleResult = (double)EntryConvert.ToObject(typeof(double), value, provider);
+        var decimalResult = (decimal)EntryConvert.ToObject(typeof(decimal), value, provider);
+
+        // Assert
+        Assert.That(floatResult, Is.EqualTo(1234.56f).Within(1e-5));
+        Assert.That(doubleResult, Is.EqualTo(1234.56d).Within(1e-10));
+        Assert.That(decimalResult, Is.EqualTo(1234.56m));
+    }
+
+    [Test]
+    public void ToObject_FallsBackToInvariantCulture_WhenProviderFails_ForFloatDoubleDecimal()
+    {
+        // Arrange
+        var value = "1234.56";
+        var provider = new CultureInfo("de-DE"); // dot fails in de-DE, should fallback to invariant
+
+        // Act
+        var floatResult = (float)EntryConvert.ToObject(typeof(float), value, provider);
+        var doubleResult = (double)EntryConvert.ToObject(typeof(double), value, provider);
+        var decimalResult = (decimal)EntryConvert.ToObject(typeof(decimal), value, provider);
+
+        // Assert
+        Assert.That(floatResult, Is.EqualTo(1234.56f).Within(1e-5));
+        Assert.That(doubleResult, Is.EqualTo(1234.56d).Within(1e-10));
+        Assert.That(decimalResult, Is.EqualTo(1234.56m));
+    }
+
+    [Test]
+    public void ToObject_ThrowsFormatException_WhenParsingFails()
+    {
+        // Arrange
+        var value = "not-a-number";
+
+        // Act + Assert
+        Assert.Throws<FormatException>(() =>
+            EntryConvert.ToObject(typeof(float), value, CultureInfo.InvariantCulture));
+
+        Assert.Throws<FormatException>(() =>
+            EntryConvert.ToObject(typeof(decimal), value, CultureInfo.InvariantCulture));
+
+        Assert.Throws<FormatException>(() =>
+            EntryConvert.ToObject(typeof(double), value, CultureInfo.InvariantCulture));
+    }
+
+    [Test]
+    public void ToObject_ByEntryValueType_AlsoUsesParseWithFallback()
+    {
+        // Arrange
+        var provider = new CultureInfo("de-DE");
+        var valueComma = "3,14"; // should parse with provider
+        var valueDot = "3.14";   // should parse via fallback to invariant
+
+        // Act
+        var singleWithProvider = (float)EntryConvert.ToObject(EntryValueType.Single, valueComma, provider);
+        var doubleWithFallback = (double)EntryConvert.ToObject(EntryValueType.Double, valueDot, provider);
+
+        // Assert
+        Assert.That(singleWithProvider, Is.EqualTo(3.14f).Within(1e-5));
+        Assert.That(doubleWithFallback, Is.EqualTo(3.14d).Within(1e-10));
+    }
+
 }


### PR DESCRIPTION
We found the bug, that floating point properties of resources could not be edited, if the culture was changed to de-DE. Together with [PR](https://github.com/PHOENIXCONTACT/ngx-moryx-web/pull/42), this problem should be fixed. May be we should wait for the PR to adujust the version of the ngx-moryx-web package?


- Introduced ParseWithFallback for numeric parsing
  - Attempts parsing using the provided culture first
  - Falls back to InvariantCulture if parsing fails
 
- Replaced direct Parse calls for floating point types
  - Applied to float, double, and decimal

- Improved robustness of type conversion
  - Reduces failures caused by culture-specific number formats (e.g. , vs .)
  - Ensures better compatibility for internationalized inputs