### PR TITLE
Fix collection properties becoming null after instantiation

### DIFF
--- a/src/Moryx.Resources.Management/Facades/ResourceManagementFacade.cs
+++ b/src/Moryx.Resources.Management/Facades/ResourceManagementFacade.cs
@@ -121,10 +121,38 @@ internal class ResourceManagementFacade : FacadeBase, IResourceManagement
         ValidateHealthState();
 
         var resource = ResourceGraph.Instantiate(resourceType.ResourceType());
-        await initializer(resource);
+        CollectionsInitialized(resource);
+        await initializer(resource); 
         await ResourceGraph.SaveAsync(resource, cancellationToken);
         return resource.Id;
     }
+
+
+
+    /// <summary>
+    /// Ensures that all collection-type properties of the resource are initialized
+    /// after instantiation, to handle cases where deserialization overrides default initializers.
+    /// </summary>
+
+    private void CollectionsInitialized(object resource)
+    {
+        foreach (var prop in resource.GetType().GetProperties())
+        {
+            if (!prop.CanWrite || prop.PropertyType == typeof(string))
+                continue;
+
+            if (typeof(System.Collections.IEnumerable).IsAssignableFrom(prop.PropertyType)
+                && prop.GetValue(resource) == null)
+            {
+                try
+                {
+                    prop.SetValue(resource, Activator.CreateInstance(prop.PropertyType));
+                }
+                catch { }
+            }
+        }
+    }
+
 
 
     public TResult ReadUnsafe<TResult>(long id, Func<Resource, TResult> accessor)

--- a/src/Moryx.Resources.Management/Resources/ResourceEntityAccessor.cs
+++ b/src/Moryx.Resources.Management/Resources/ResourceEntityAccessor.cs
@@ -67,11 +67,12 @@ internal class ResourceEntityAccessor
         // Copy default properties
         Instance.Id = Id;
         Instance.Name = Name;
-        Instance.Description = Description;
 
         // Copy extended data from json, or simply use JSON to provide defaults
-        JsonConvert.PopulateObject(ExtensionData ?? "{}", Instance, JsonSettings.Minimal);
-
+        if (!string.IsNullOrEmpty(ExtensionData))
+        {
+            JsonConvert.PopulateObject(ExtensionData ?? "{}", Instance, JsonSettings.Minimal);
+        }
         return Instance;
     }
 


### PR DESCRIPTION
Fixed an issue where collection properties were becoming null during ResourceGraph instantiation.
Added a post-instantiation initialization step to ensure all collections are properly initialized before usage.
