### PR TITLE
Reworked Controllers to use TypedResults.ServerSentEvents

### DIFF
--- a/MORYX-Framework.slnx
+++ b/MORYX-Framework.slnx
@@ -19,7 +19,6 @@
     <Project Path="src/Moryx.Drivers.OpcUa/Moryx.Drivers.OpcUa.csproj" />
     <Project Path="src/Moryx.Drivers.Simulation/Moryx.Drivers.Simulation.csproj" />
   </Folder>
-  <Folder Name="/Mqtt/" />
   <Folder Name="/FactoryMonitor/">
     <Project Path="src/Moryx.Factory/Moryx.Factory.csproj" />
     <Project Path="src/Moryx.FactoryMonitor.Endpoints/Moryx.FactoryMonitor.Endpoints.csproj" />
@@ -182,8 +181,4 @@
   <Project Path="src/Moryx.Launcher/Moryx.Launcher.csproj" />
   <Project Path="src/Moryx/Moryx.csproj" />
   <Project Path="src/StartProject.Asp/StartProject.Asp.csproj" />
-  <Properties Name="ExtensibilityGlobals" Scope="PostLoad">
-    <Property Name="RESX_ShowErrorsInErrorList" Value="True" />
-    <Property Name="RESX_TaskErrorCategory" Value="Message" />
-  </Properties>
 </Solution>

--- a/src/Moryx.ControlSystem.Jobs.Endpoints/JobManagementController.cs
+++ b/src/Moryx.ControlSystem.Jobs.Endpoints/JobManagementController.cs
@@ -3,6 +3,8 @@
 
 using System.Collections.Concurrent;
 using System.Runtime.CompilerServices;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -22,7 +24,12 @@ public class JobManagementController : ControllerBase
 {
     private readonly IJobManagement _jobManagement;
 
-    private static readonly ConcurrentDictionary<Guid, Channel<JobModel>> _jobStreamSubscribers = new();
+    private static readonly ConcurrentDictionary<Guid, Channel<string>> _jobStreamSubscribers = new();
+    private static readonly JsonSerializerOptions _serializerOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        Converters = { new JsonStringEnumConverter() }
+    };
 
     public JobManagementController(IJobManagement jobManagement)
         => _jobManagement = jobManagement;
@@ -103,9 +110,9 @@ public class JobManagementController : ControllerBase
 
         return;
 
-        async IAsyncEnumerable<JobModel> Subscribe([EnumeratorCancellation] CancellationToken token)
+        async IAsyncEnumerable<string> Subscribe([EnumeratorCancellation] CancellationToken token)
         {
-            var channel = Channel.CreateUnbounded<JobModel>();
+            var channel = Channel.CreateUnbounded<string>();
             var id = Guid.NewGuid();
             _jobStreamSubscribers[id] = channel;
 
@@ -127,7 +134,7 @@ public class JobManagementController : ControllerBase
         {
             foreach (var channel in _jobStreamSubscribers.Values)
             {
-                channel.Writer.TryWrite(Converter.ToModel(job));
+                channel.Writer.TryWrite(JsonSerializer.Serialize(Converter.ToModel(job), _serializerOptions));
             }
         }
     }

--- a/src/Moryx.ControlSystem.Jobs.Endpoints/JobManagementController.cs
+++ b/src/Moryx.ControlSystem.Jobs.Endpoints/JobManagementController.cs
@@ -1,14 +1,14 @@
 // Copyright (c) 2026 Phoenix Contact GmbH & Co. KG
 // Licensed under the Apache License, Version 2.0
 
+using System.Collections.Concurrent;
+using System.Runtime.CompilerServices;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Moryx.ControlSystem.Jobs.Endpoints.Properties;
-using Newtonsoft.Json;
 using System.Threading.Channels;
 using Moryx.AspNetCore;
-using Newtonsoft.Json.Serialization;
 
 namespace Moryx.ControlSystem.Jobs.Endpoints;
 
@@ -22,15 +22,7 @@ public class JobManagementController : ControllerBase
 {
     private readonly IJobManagement _jobManagement;
 
-    private static readonly JsonSerializerSettings _serializerSettings = CreateSerializerSettings();
-
-    private static JsonSerializerSettings CreateSerializerSettings()
-    {
-        var serializerSettings = new JsonSerializerSettings();
-        serializerSettings.ContractResolver = new CamelCasePropertyNamesContractResolver();
-        serializerSettings.Converters.Add(new Newtonsoft.Json.Converters.StringEnumConverter());
-        return serializerSettings;
-    }
+    private static readonly ConcurrentDictionary<Guid, Channel<JobModel>> _jobStreamSubscribers = new();
 
     public JobManagementController(IJobManagement jobManagement)
         => _jobManagement = jobManagement;
@@ -82,56 +74,61 @@ public class JobManagementController : ControllerBase
         return Ok();
     }
 
-    private static void WriteToEventQueue(ChannelWriter<string> writer, Job job)
-    {
-        var serialized = JsonConvert.SerializeObject(Converter.ToModel(job), _serializerSettings);
-        writer.TryWrite(serialized);
-    }
-
     [HttpGet("stream")]
     [ProducesResponseType(StatusCodes.Status200OK)]
     public async Task ProgressStream(CancellationToken cancellationToken)
     {
-        var response = Response;
-        response.Headers["Content-Type"] = "text/event-stream";
+        // Define event handlers using the broadcast helper
+        var progressEventHandler = new EventHandler<Job>((_, job) =>
+            Broadcast(job));
 
-        // Define event handling
-        var jobUpdates = Channel.CreateUnbounded<string>();
-        var progressEventHandler = new EventHandler<Job>((_, job) => WriteToEventQueue(jobUpdates.Writer, job));
-        var stateEventHandler = new EventHandler<JobStateChangedEventArgs>((_, eventArgs) => WriteToEventQueue(jobUpdates.Writer, eventArgs.Job));
-
-        // Register handler to facade
-        _jobManagement.ProgressChanged += progressEventHandler;
-        _jobManagement.StateChanged += stateEventHandler;
+        var stateEventHandler = new EventHandler<JobStateChangedEventArgs>((_, e) =>
+            Broadcast(e.Job));
 
         try
         {
-            // Create infinite loop awaiting changes or cancellation
-            while (!cancellationToken.IsCancellationRequested)
-            {
-                // Await entry in queue
-                var streamContent = await jobUpdates.Reader.ReadAsync(cancellationToken);
-                await response.WriteAsync($"data: {streamContent}\r\r", cancellationToken);
-            }
-        }
-        catch (OperationCanceledException)
-        {
-        }
-        catch (ChannelClosedException)
-        {
-        }
-        catch (InvalidOperationException)
-        {
+            var result = TypedResults.ServerSentEvents(Subscribe(cancellationToken));
+
+            // Register event handlers after result creation but before execution to ensure finally cleanup
+            _jobManagement.ProgressChanged += progressEventHandler;
+            _jobManagement.StateChanged += stateEventHandler;
+
+            await result.ExecuteAsync(HttpContext);
         }
         finally
         {
-            // Unregister handler from facade
             _jobManagement.ProgressChanged -= progressEventHandler;
             _jobManagement.StateChanged -= stateEventHandler;
-
-            jobUpdates.Writer.TryComplete();
         }
 
-        await response.CompleteAsync();
+        return;
+
+        async IAsyncEnumerable<JobModel> Subscribe([EnumeratorCancellation] CancellationToken token)
+        {
+            var channel = Channel.CreateUnbounded<JobModel>();
+            var id = Guid.NewGuid();
+            _jobStreamSubscribers[id] = channel;
+
+            try
+            {
+                await foreach (var data in channel.Reader.ReadAllAsync(token))
+                {
+                    yield return data;
+                }
+            }
+            finally
+            {
+                _jobStreamSubscribers.TryRemove(id, out _);
+            }
+        }
+
+        // Local helper to broadcast job updates to all connected clients
+        static void Broadcast(Job job)
+        {
+            foreach (var channel in _jobStreamSubscribers.Values)
+            {
+                channel.Writer.TryWrite(Converter.ToModel(job));
+            }
+        }
     }
 }

--- a/src/Moryx.ControlSystem.Processes.Endpoints/EventHandlers/ProcessHolderEventHandlers.cs
+++ b/src/Moryx.ControlSystem.Processes.Endpoints/EventHandlers/ProcessHolderEventHandlers.cs
@@ -1,18 +1,17 @@
 // Copyright (c) 2026 Phoenix Contact GmbH & Co. KG
 // Licensed under the Apache License, Version 2.0
 
-using System.Threading.Channels;
 using Moryx.AbstractionLayer.Processes;
 using Moryx.AbstractionLayer.Resources;
 using Moryx.ControlSystem.Processes.Endpoints.Extensions;
 
 namespace Moryx.ControlSystem.Processes.Endpoints.EventHandlers;
+
 internal class ProcessHolderEventHandlers
 {
-
     public static EventHandler<IResource> OnResourceRemoved(EventHandler<Process> processChanged, EventHandler groupChanged)
     {
-        return new EventHandler<IResource>((obj, e) =>
+        return (_, e) =>
         {
             if (e is IProcessHolderPosition position)
             {
@@ -22,30 +21,26 @@ internal class ProcessHolderEventHandlers
             {
                 group.Changed -= groupChanged;
             }
-        });
+        };
     }
 
-    public static EventHandler<IResource> OnResourceAdded(
-        Channel<ProcessHolderGroupChangedEventArg> groupChannel,
-        EventHandler groupChanged)
+    public static EventHandler<IResource> OnResourceAdded(EventHandler groupChanged, Action<ProcessHolderGroupModel> broadcast)
     {
-        return new EventHandler<IResource>((obj, e) =>
+        return (_, e) =>
         {
             if (e is ProcessHolderGroup group)
             {
-                groupChannel.Writer.TryWrite(new ProcessHolderGroupChangedEventArg(group.ToDto()));
+                broadcast(group.ToDto());
                 group.Changed += groupChanged;
             }
             else if (e is IProcessHolderPosition position)
             {
-                SendUpdate(groupChannel, position);
+                SendUpdate(broadcast, position);
             }
-        });
+        };
     }
 
-    public static void SendUpdate(
-        Channel<ProcessHolderGroupChangedEventArg> groupChannel,
-        IProcessHolderPosition position)
+    public static void SendUpdate(Action<ProcessHolderGroupModel> broadcast, IProcessHolderPosition position)
     {
         var resource = position as Resource;
         var parentCategory = resource?.ParentCategory();
@@ -56,7 +51,13 @@ internal class ProcessHolderEventHandlers
 
         if (parentCategory == Category.ProcessHolderGroup)
         {
-            groupChannel.Writer.TryWrite(new ProcessHolderGroupChangedEventArg((resource.Parent as IProcessHolderGroup).ToDto()));
+            var parentGroup = (resource.Parent as IProcessHolderGroup)?.ToDto();
+            if (parentGroup == null)
+            {
+                return;
+            }
+
+            broadcast(parentGroup);
         }
         else
         {
@@ -65,51 +66,49 @@ internal class ProcessHolderEventHandlers
                 .OfType<IProcessHolderPosition>()
                 .Select((p, index) => p.ToDto(index, group.Id));
             group.Positions.AddRange(positions);
-            groupChannel.Writer.TryWrite(new ProcessHolderGroupChangedEventArg(group));
+            broadcast(group);
         }
     }
 
-    public static EventHandler OnGroupChanged(Channel<ProcessHolderGroupChangedEventArg> groupChannel)
+    public static EventHandler OnGroupChanged(Action<ProcessHolderGroupModel> broadcast)
     {
-        return new EventHandler((obj, e) =>
+        return (obj, e) =>
         {
             if (obj is not IProcessHolderGroup group)
             {
                 return;
             }
 
-            groupChannel.Writer.TryWrite(new ProcessHolderGroupChangedEventArg(group.ToDto()));
-        });
+            broadcast(group.ToDto());
+        };
     }
 
-    public static EventHandler<Process> OnProcessChanged(
-        Channel<ProcessHolderGroupChangedEventArg> groupChannel)
+    public static EventHandler<Process> OnProcessChanged(Action<ProcessHolderGroupModel> broadcast)
     {
-        return new EventHandler<Process>((obj, process) =>
+        return (obj, _) =>
         {
-            if (obj is IProcessHolderPosition position)
+            switch (obj)
             {
-                SendUpdate(groupChannel, position);
+                case IProcessHolderPosition position:
+                    SendUpdate(broadcast, position);
+                    break;
+                case IProcessHolderGroup group:
+                    broadcast(group.ToDto());
+                    break;
             }
-            else if (obj is IProcessHolderGroup group)
-            {
-                groupChannel.Writer.TryWrite(new ProcessHolderGroupChangedEventArg(group.ToDto()));
-            }
-        });
+        };
     }
 
-    public static EventHandler OnResetExecuted(
-        Channel<ProcessHolderGroupChangedEventArg> groupChannel)
+    public static EventHandler OnResetExecuted(Action<ProcessHolderGroupModel> broadcast)
     {
-        return new EventHandler((obj, e) =>
+        return (obj, e) =>
         {
-            var position = obj as IProcessHolderPosition;
-            if (position is null)
+            if (obj is not IProcessHolderPosition position)
             {
                 return;
             }
 
-            SendUpdate(groupChannel, position);
-        });
+            SendUpdate(broadcast, position);
+        };
     }
 }

--- a/src/Moryx.ControlSystem.Processes.Endpoints/ProcessEngineController.cs
+++ b/src/Moryx.ControlSystem.Processes.Endpoints/ProcessEngineController.cs
@@ -1,6 +1,8 @@
 // Copyright (c) 2026 Phoenix Contact GmbH & Co. KG
 // Licensed under the Apache License, Version 2.0
 
+using System.Collections.Concurrent;
+using System.Runtime.CompilerServices;
 using System.Threading.Channels;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
@@ -13,33 +15,24 @@ using Moryx.ControlSystem.Jobs;
 using Moryx.ControlSystem.Processes.Endpoints.Extensions;
 using Moryx.ControlSystem.Processes.Endpoints.Properties;
 using Moryx.ControlSystem.Processes.Endpoints.StreamServices;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Serialization;
 
 namespace Moryx.ControlSystem.Processes.Endpoints;
 
 /// <summary>
-/// Definition of a REST API on the <see cref="IProcessEnging"/> facade.
+/// Definition of a REST API on the <see cref="IProcessControl"/> facade.
 /// </summary>
 [ApiController]
 [Route("api/moryx/processes/")]
 [Produces("application/json")]
-public class ProcessEngineController : ControllerBase
+public class ProcessEngineController : ControllerBase // TODO: Rename to ProcessControlController
 {
     private readonly IProcessControl _processControl;
     private readonly IProductManagement _productManagement;
     private readonly IResourceManagement _resourceManagement;
     private readonly IJobManagement _jobManagement;
 
-    private static readonly JsonSerializerSettings _serializerSettings = CreateSerializerSettings();
-
-    private static JsonSerializerSettings CreateSerializerSettings()
-    {
-        var serializerSettings = new JsonSerializerSettings();
-        serializerSettings.ContractResolver = new CamelCasePropertyNamesContractResolver();
-        serializerSettings.Converters.Add(new Newtonsoft.Json.Converters.StringEnumConverter());
-        return serializerSettings;
-    }
+    private static readonly ConcurrentDictionary<Guid, Channel<JobProcessModel>> _processStreamSubscribers = new();
+    private static readonly ConcurrentDictionary<Guid, Channel<ProcessActivityModel>> _activityStreamSubscribers = new();
 
     public ProcessEngineController(IProcessControl processControl, IProductManagement productManagement,
         IResourceManagement resourceManagement, IJobManagement jobManagement)
@@ -211,51 +204,56 @@ public class ProcessEngineController : ControllerBase
     [ProducesResponseType(typeof(JobProcessModel), StatusCodes.Status200OK)]
     public async Task ProcessUpdatesStream(CancellationToken cancellationToken)
     {
-        var response = Response;
-        response.Headers["Content-Type"] = "text/event-stream";
-
-        var serializerSettings = new JsonSerializerSettings();
-        serializerSettings.ContractResolver = new CamelCasePropertyNamesContractResolver();
-        serializerSettings.Converters.Add(new Newtonsoft.Json.Converters.StringEnumConverter());
-
-        // Define event handling
-        var processes = Channel.CreateUnbounded<ProcessUpdatedEventArgs>();
-        var eventHandler = new EventHandler<ProcessUpdatedEventArgs>((_, processEventArgs) =>
-        {
-            processes.Writer.TryWrite(processEventArgs);
-        });
-        _processControl.ProcessUpdated += eventHandler;
+        // Define event handler using the broadcast helper
+        var eventHandler = new EventHandler<ProcessUpdatedEventArgs>((_, e) =>
+            Broadcast(e));
 
         try
         {
-            // Create infinite loop awaiting changes or cancellation
-            while (!cancellationToken.IsCancellationRequested)
-            {
-                // Write processes
-                var processArgs = await processes.Reader.ReadAsync(cancellationToken);
-                var processModel = Converter.ConvertProcess(processArgs.Process, _processControl, _resourceManagement);
-                processModel.State = processArgs.Progress;
+            var result = TypedResults.ServerSentEvents(Subscribe(cancellationToken));
 
-                var json = JsonConvert.SerializeObject(processModel, _serializerSettings);
-                await response.WriteAsync($"data: {json}\r\r", cancellationToken);
-            }
-        }
-        catch (OperationCanceledException)
-        {
-        }
-        catch (ChannelClosedException)
-        {
-        }
-        catch (InvalidOperationException)
-        {
+            // Register event handler after result creation but before execution to ensure finally cleanup
+            _processControl.ProcessUpdated += eventHandler;
+
+            await result.ExecuteAsync(HttpContext);
         }
         finally
         {
-            // Unregister handler from facade
             _processControl.ProcessUpdated -= eventHandler;
-            processes.Writer.TryComplete();
         }
-        await response.CompleteAsync();
+
+        return;
+
+        async IAsyncEnumerable<JobProcessModel> Subscribe([EnumeratorCancellation] CancellationToken cancelToken)
+        {
+            var channel = Channel.CreateUnbounded<JobProcessModel>();
+            var id = Guid.NewGuid();
+            _processStreamSubscribers[id] = channel;
+
+            try
+            {
+                await foreach (var data in channel.Reader.ReadAllAsync(cancelToken))
+                {
+                    yield return data;
+                }
+            }
+            finally
+            {
+                _processStreamSubscribers.TryRemove(id, out _);
+            }
+        }
+
+        // Local helper to broadcast process updates to all connected clients
+        void Broadcast(ProcessUpdatedEventArgs e)
+        {
+            var processModel = Converter.ConvertProcess(e.Process, _processControl, _resourceManagement);
+            processModel.State = e.Progress;
+
+            foreach (var channel in _processStreamSubscribers.Values)
+            {
+                channel.Writer.TryWrite(processModel);
+            }
+        }
     }
 
     [HttpGet]
@@ -263,47 +261,57 @@ public class ProcessEngineController : ControllerBase
     [ProducesResponseType(typeof(ProcessActivityModel), StatusCodes.Status200OK)]
     public async Task ActivitiesUpdatesStream(CancellationToken cancellationToken)
     {
-        var response = Response;
-        response.Headers["Content-Type"] = "text/event-stream";
-        var activities = Channel.CreateUnbounded<ActivityUpdatedEventArgs>();
-
-        // Define event handling
-        var eventHandler = new EventHandler<ActivityUpdatedEventArgs>((sender, activityEventArgs) =>
-        {
-            activities.Writer.TryWrite(activityEventArgs);
-        });
-        _processControl.ActivityUpdated += eventHandler;
+        // Define event handler using the broadcast helper
+        var eventHandler = new EventHandler<ActivityUpdatedEventArgs>((_, e) =>
+            Broadcast(e));
 
         try
         {
-            // Create infinite loop awaiting changes or cancellation
-            while (!cancellationToken.IsCancellationRequested)
-            {
-                // Write notifications
-                var activityArgs = await activities.Reader.ReadAsync(cancellationToken);
-                var activityModel = Converter.ConvertActivity(activityArgs.Activity, _processControl, _resourceManagement);
-                activityModel.State = activityArgs.Progress.ToString();
+            var result = TypedResults.ServerSentEvents(Subscribe(cancellationToken));
 
-                var json = JsonConvert.SerializeObject(activityModel, _serializerSettings);
-                await response.WriteAsync($"data: {json}\r\r", cancellationToken);
-            }
-        }
-        catch (OperationCanceledException)
-        {
-        }
-        catch (ChannelClosedException)
-        {
-        }
-        catch (InvalidOperationException)
-        {
+            // Register event handler after result creation but before execution to ensure finally cleanup
+            _processControl.ActivityUpdated += eventHandler;
+
+            await result.ExecuteAsync(HttpContext);
         }
         finally
         {
-            // Unregister handler from facade
             _processControl.ActivityUpdated -= eventHandler;
-            activities.Writer.TryComplete();
         }
-        await response.CompleteAsync();
+
+        return;
+
+        async IAsyncEnumerable<ProcessActivityModel> Subscribe([EnumeratorCancellation] CancellationToken token)
+        {
+            var channel = Channel.CreateUnbounded<ProcessActivityModel>();
+            var id = Guid.NewGuid();
+            _activityStreamSubscribers[id] = channel;
+
+            try
+            {
+                await foreach (var data in channel.Reader.ReadAllAsync(token))
+                {
+                    yield return data;
+                }
+            }
+            finally
+            {
+                _activityStreamSubscribers.TryRemove(id, out _);
+            }
+        }
+
+        // Local helper to broadcast activity updates to all connected clients
+        void Broadcast(ActivityUpdatedEventArgs e)
+        {
+            var activityModel = Converter.ConvertActivity(e.Activity, _processControl, _resourceManagement);
+            activityModel.State = e.Progress.ToString();
+
+            foreach (var channel in _activityStreamSubscribers.Values)
+            {
+                channel.Writer.TryWrite(activityModel);
+            }
+        }
+
     }
 
     #region Process Holder
@@ -326,7 +334,7 @@ public class ProcessEngineController : ControllerBase
     [ProducesResponseType(typeof(ProcessHolderGroupModel), StatusCodes.Status200OK)]
     public async Task GroupStream(CancellationToken cancellationToken)
     {
-        var stream = new ProcessHolderGroupStream(_resourceManagement, _serializerSettings);
+        var stream = new ProcessHolderGroupStream(_resourceManagement);
         await stream.Start(HttpContext, cancellationToken);
     }
 
@@ -360,7 +368,7 @@ public class ProcessEngineController : ControllerBase
     }
     #endregion
 
-    private new ActionResult<TResult> HttpResponse<TResult>(Func<TResult> func, Func<TResult, ActionResult<TResult>> onSuccess = null)
+    private ActionResult<TResult> HttpResponse<TResult>(Func<TResult> func, Func<TResult, ActionResult<TResult>> onSuccess = null)
     {
         try
         {
@@ -380,7 +388,7 @@ public class ProcessEngineController : ControllerBase
         }
     }
 
-    private new ActionResult HttpResponse(Action action)
+    private ActionResult HttpResponse(Action action)
     {
         try
         {
@@ -398,7 +406,7 @@ public class ProcessEngineController : ControllerBase
         ResourceNotFoundException _ => NotFound(ex.Message),
         ArgumentNullException _ => BadRequest(ex.Message),
         ArgumentException _ => BadRequest(ex.Message),
-        KeyNotFoundException _ => StatusCode(500, ex.Message),
-        _ => StatusCode(500, ex.Message),
+        KeyNotFoundException _ => StatusCode(StatusCodes.Status500InternalServerError, ex.Message),
+        _ => StatusCode(StatusCodes.Status500InternalServerError, ex.Message),
     };
 }

--- a/src/Moryx.ControlSystem.Processes.Endpoints/ProcessEngineController.cs
+++ b/src/Moryx.ControlSystem.Processes.Endpoints/ProcessEngineController.cs
@@ -3,6 +3,8 @@
 
 using System.Collections.Concurrent;
 using System.Runtime.CompilerServices;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using System.Threading.Channels;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
@@ -31,9 +33,13 @@ public class ProcessEngineController : ControllerBase // TODO: Rename to Process
     private readonly IResourceManagement _resourceManagement;
     private readonly IJobManagement _jobManagement;
 
-    private static readonly ConcurrentDictionary<Guid, Channel<JobProcessModel>> _processStreamSubscribers = new();
-    private static readonly ConcurrentDictionary<Guid, Channel<ProcessActivityModel>> _activityStreamSubscribers = new();
-
+    private static readonly ConcurrentDictionary<Guid, Channel<string>> _processStreamSubscribers = new();
+    private static readonly ConcurrentDictionary<Guid, Channel<string>> _activityStreamSubscribers = new();
+    private static readonly JsonSerializerOptions _serializerOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        Converters = { new JsonStringEnumConverter() }
+    };
     public ProcessEngineController(IProcessControl processControl, IProductManagement productManagement,
         IResourceManagement resourceManagement, IJobManagement jobManagement)
     {
@@ -224,9 +230,9 @@ public class ProcessEngineController : ControllerBase // TODO: Rename to Process
 
         return;
 
-        async IAsyncEnumerable<JobProcessModel> Subscribe([EnumeratorCancellation] CancellationToken cancelToken)
+        async IAsyncEnumerable<string> Subscribe([EnumeratorCancellation] CancellationToken cancelToken)
         {
-            var channel = Channel.CreateUnbounded<JobProcessModel>();
+            var channel = Channel.CreateUnbounded<string>();
             var id = Guid.NewGuid();
             _processStreamSubscribers[id] = channel;
 
@@ -251,7 +257,7 @@ public class ProcessEngineController : ControllerBase // TODO: Rename to Process
 
             foreach (var channel in _processStreamSubscribers.Values)
             {
-                channel.Writer.TryWrite(processModel);
+                channel.Writer.TryWrite(JsonSerializer.Serialize(processModel, _serializerOptions));
             }
         }
     }
@@ -281,9 +287,9 @@ public class ProcessEngineController : ControllerBase // TODO: Rename to Process
 
         return;
 
-        async IAsyncEnumerable<ProcessActivityModel> Subscribe([EnumeratorCancellation] CancellationToken token)
+        async IAsyncEnumerable<string> Subscribe([EnumeratorCancellation] CancellationToken token)
         {
-            var channel = Channel.CreateUnbounded<ProcessActivityModel>();
+            var channel = Channel.CreateUnbounded<string>();
             var id = Guid.NewGuid();
             _activityStreamSubscribers[id] = channel;
 
@@ -308,7 +314,7 @@ public class ProcessEngineController : ControllerBase // TODO: Rename to Process
 
             foreach (var channel in _activityStreamSubscribers.Values)
             {
-                channel.Writer.TryWrite(activityModel);
+                channel.Writer.TryWrite(JsonSerializer.Serialize(activityModel, _serializerOptions));
             }
         }
 

--- a/src/Moryx.ControlSystem.Processes.Endpoints/StreamServices/ProcessHolderGroupStream.cs
+++ b/src/Moryx.ControlSystem.Processes.Endpoints/StreamServices/ProcessHolderGroupStream.cs
@@ -3,6 +3,8 @@
 
 using System.Collections.Concurrent;
 using System.Runtime.CompilerServices;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using System.Threading.Channels;
 using Microsoft.AspNetCore.Http;
 using Moryx.AbstractionLayer.Resources;
@@ -15,7 +17,12 @@ namespace Moryx.ControlSystem.Processes.Endpoints.StreamServices;
 /// </summary>
 internal class ProcessHolderGroupStream(IResourceManagement resourceManagement)
 {
-    private static readonly ConcurrentDictionary<Guid, Channel<ProcessHolderGroupModel>> _subscribers = new();
+    private static readonly ConcurrentDictionary<Guid, Channel<string>> _subscribers = new();
+    private static readonly JsonSerializerOptions _serializerOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        Converters = { new JsonStringEnumConverter() }
+    };
 
     /// <summary>
     /// Starts the Process Holder Group stream
@@ -39,6 +46,8 @@ internal class ProcessHolderGroupStream(IResourceManagement resourceManagement)
 
         try
         {
+            var result = TypedResults.ServerSentEvents(Subscribe(cancellationToken));
+
             // Register event handlers after result creation but before execution to ensure finally cleanup
             foreach (var position in allPositions)
             {
@@ -54,7 +63,6 @@ internal class ProcessHolderGroupStream(IResourceManagement resourceManagement)
             resourceManagement.ResourceAdded += resourceAdded;
             resourceManagement.ResourceRemoved += resourceRemoved;
 
-            var result = TypedResults.ServerSentEvents(Subscribe(cancellationToken));
             await result.ExecuteAsync(context);
         }
         finally
@@ -74,23 +82,22 @@ internal class ProcessHolderGroupStream(IResourceManagement resourceManagement)
             resourceManagement.ResourceAdded -= resourceAdded;
             resourceManagement.ResourceRemoved -= resourceRemoved;
         }
-
-        return;
-
-        // Local helper to broadcast process holder group changes to all connected clients
     }
 
+    /// <summary>
+    /// Local helper to broadcast process holder group changes to all connected clients
+    /// </summary>
     private static void Broadcast(ProcessHolderGroupModel groupModel)
     {
         foreach (var channel in _subscribers.Values)
         {
-            channel.Writer.TryWrite(groupModel);
+            channel.Writer.TryWrite(JsonSerializer.Serialize(groupModel, _serializerOptions));
         }
     }
 
-    private static async IAsyncEnumerable<ProcessHolderGroupModel> Subscribe([EnumeratorCancellation] CancellationToken token)
+    private static async IAsyncEnumerable<string> Subscribe([EnumeratorCancellation] CancellationToken token)
     {
-        var channel = Channel.CreateUnbounded<ProcessHolderGroupModel>();
+        var channel = Channel.CreateUnbounded<string>();
         var id = Guid.NewGuid();
         _subscribers[id] = channel;
 

--- a/src/Moryx.ControlSystem.Processes.Endpoints/StreamServices/ProcessHolderGroupStream.cs
+++ b/src/Moryx.ControlSystem.Processes.Endpoints/StreamServices/ProcessHolderGroupStream.cs
@@ -1,98 +1,109 @@
 // Copyright (c) 2026 Phoenix Contact GmbH & Co. KG
 // Licensed under the Apache License, Version 2.0
 
+using System.Collections.Concurrent;
+using System.Runtime.CompilerServices;
 using System.Threading.Channels;
 using Microsoft.AspNetCore.Http;
 using Moryx.AbstractionLayer.Resources;
 using Moryx.ControlSystem.Processes.Endpoints.EventHandlers;
-using Newtonsoft.Json;
 
 namespace Moryx.ControlSystem.Processes.Endpoints.StreamServices;
 
 /// <summary>
 /// Provides the streaming functionality for the process holder Group
 /// </summary>
-/// <param name="resourceManagement"></param>
-/// <param name="_serializerSettings"></param>
-internal class ProcessHolderGroupStream(
-    IResourceManagement resourceManagement,
-    JsonSerializerSettings _serializerSettings)
+internal class ProcessHolderGroupStream(IResourceManagement resourceManagement)
 {
+    private static readonly ConcurrentDictionary<Guid, Channel<ProcessHolderGroupModel>> _subscribers = new();
+
     /// <summary>
     /// Starts the Process Holder Group stream
     /// </summary>
-    /// <param name="response">the http response object</param>
+    /// <param name="context">the http context object</param>
     /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
     /// <returns></returns>
     public async Task Start(HttpContext context, CancellationToken cancellationToken)
     {
-        context.Response.Headers.ContentType = "text/event-stream";
-
-        //using this because resourceManagement.GetResources<T> is very restricted in the sense
+        // using unsafe because resourceManagement.GetResources<T> is very restricted in the sense
         // that casting at line 55 doesn't work
         var groups = resourceManagement.GetResourcesUnsafe<IProcessHolderGroup>(_ => true);
-        var allPositions = resourceManagement.GetResourcesUnsafe<IProcessHolderPosition>(_ => true);
+        var allPositions = resourceManagement.GetResourcesUnsafe<IProcessHolderPosition>(_ => true).ToArray();
 
-        // Define event handling
-        var groupChannel = Channel.CreateUnbounded<ProcessHolderGroupChangedEventArg>();
-        var processChanged = ProcessHolderEventHandlers.OnProcessChanged(groupChannel);
-        var groupChanged = ProcessHolderEventHandlers.OnGroupChanged(groupChannel);
-        var resourceAdded = ProcessHolderEventHandlers.OnResourceAdded(groupChannel, groupChanged);
+        // Define event handlers using ProcessHolderEventHandlers with broadcast action
+        var processChanged = ProcessHolderEventHandlers.OnProcessChanged(Broadcast);
+        var groupChanged = ProcessHolderEventHandlers.OnGroupChanged(Broadcast);
+        var resourceAdded = ProcessHolderEventHandlers.OnResourceAdded(groupChanged, Broadcast);
         var resourceRemoved = ProcessHolderEventHandlers.OnResourceRemoved(processChanged, groupChanged);
-        var resetExecuted = ProcessHolderEventHandlers.OnResetExecuted(groupChannel);
+        var resetExecuted = ProcessHolderEventHandlers.OnResetExecuted(Broadcast);
 
-        foreach (var position in allPositions)
-        {
-            position.ProcessChanged += processChanged;
-            position.ResetExecuted += resetExecuted;
-        }
-
-        foreach (var group in groups)
-        {
-            (group as ProcessHolderGroup).Changed += groupChanged;
-        }
-
-        resourceManagement.ResourceAdded += resourceAdded;
-        resourceManagement.ResourceRemoved += resourceRemoved;
         try
         {
-            // Create infinite loop awaiting changes or cancellation
-            while (!cancellationToken.IsCancellationRequested)
+            // Register event handlers after result creation but before execution to ensure finally cleanup
+            foreach (var position in allPositions)
             {
-                // Write groups
-                var groupChangeArgs = await groupChannel.Reader.ReadAsync(cancellationToken);
-                if (groupChangeArgs != null)
-                {
-                    var json = JsonConvert.SerializeObject(groupChangeArgs.Group, _serializerSettings);
-                    await context.Response.WriteAsync($"data: {json}\r\r", cancellationToken);
-                }
+                position.ProcessChanged += processChanged;
+                position.ResetExecuted += resetExecuted;
             }
-        }
-        catch (OperationCanceledException)
-        {
-        }
-        catch (ChannelClosedException)
-        {
-        }
-        catch (InvalidOperationException)
-        {
+
+            foreach (var group in groups)
+            {
+                (group as ProcessHolderGroup).Changed += groupChanged;
+            }
+
+            resourceManagement.ResourceAdded += resourceAdded;
+            resourceManagement.ResourceRemoved += resourceRemoved;
+
+            var result = TypedResults.ServerSentEvents(Subscribe(cancellationToken));
+            await result.ExecuteAsync(context);
         }
         finally
         {
+            // Unregister handlers
             foreach (var position in allPositions)
             {
                 position.ProcessChanged -= processChanged;
                 position.ResetExecuted -= resetExecuted;
             }
+
             foreach (var group in groups)
             {
                 (group as ProcessHolderGroup).Changed -= groupChanged;
             }
+
             resourceManagement.ResourceAdded -= resourceAdded;
             resourceManagement.ResourceRemoved -= resourceRemoved;
-
-            groupChannel.Writer.TryComplete();
         }
-        await context.Response.CompleteAsync();
+
+        return;
+
+        // Local helper to broadcast process holder group changes to all connected clients
+    }
+
+    private static void Broadcast(ProcessHolderGroupModel groupModel)
+    {
+        foreach (var channel in _subscribers.Values)
+        {
+            channel.Writer.TryWrite(groupModel);
+        }
+    }
+
+    private static async IAsyncEnumerable<ProcessHolderGroupModel> Subscribe([EnumeratorCancellation] CancellationToken token)
+    {
+        var channel = Channel.CreateUnbounded<ProcessHolderGroupModel>();
+        var id = Guid.NewGuid();
+        _subscribers[id] = channel;
+
+        try
+        {
+            await foreach (var data in channel.Reader.ReadAllAsync(token))
+            {
+                yield return data;
+            }
+        }
+        finally
+        {
+            _subscribers.TryRemove(id, out _);
+        }
     }
 }

--- a/src/Moryx.FactoryMonitor.Endpoints/Extensions/FactoryMonitorHelper.cs
+++ b/src/Moryx.FactoryMonitor.Endpoints/Extensions/FactoryMonitorHelper.cs
@@ -8,91 +8,69 @@ using Moryx.Factory;
 using Moryx.FactoryMonitor.Endpoints.Models;
 using Moryx.Orders;
 using Newtonsoft.Json;
-using System.Threading.Channels;
 
 namespace Moryx.FactoryMonitor.Endpoints.Extensions;
 
 internal static class FactoryMonitorHelper
 {
-    public static async Task OrderStarted(OperationStartedEventArgs orderEventArg, JsonSerializerSettings serializerSettings, Channel<Tuple<string, string>> _factoryChannel, CancellationToken cancellationToken)
+    public static void OrderStarted(OperationStartedEventArgs orderEventArg, Action<string, object> broadcast)
     {
         var orderModel = Converter.Converter.ToOrderModel(orderEventArg.Operation);
-        await SendOrderUpdate(orderModel, serializerSettings, _factoryChannel, cancellationToken);
+        broadcast("processes", orderModel);
+
     }
 
-    public static async Task OrderUpdated(OperationChangedEventArgs orderEventArg, JsonSerializerSettings serializerSettings, Channel<Tuple<string, string>> _factoryChannel, CancellationToken cancellationToken)
+    public static void OrderUpdated(OperationChangedEventArgs orderEventArg, Action<string, object> broadcast)
     {
-        if (cancellationToken.IsCancellationRequested || orderEventArg.Operation.State is not OperationStateClassification.Running) return;
+        if (orderEventArg.Operation.State is not OperationStateClassification.Running) return;
 
         var orderReferenceModel = Converter.Converter.ToOrderChangedModel(orderEventArg.Operation);
-        await SendOrderUpdate(orderReferenceModel, serializerSettings, _factoryChannel, cancellationToken);
+        broadcast("processes", orderReferenceModel);
     }
 
-    public static async Task SendOrderUpdate(OrderChangedModel orderModel, JsonSerializerSettings serializerSettings, Channel<Tuple<string, string>> _factoryChannel, CancellationToken cancellationToken)
+    public static void PublishCellUpdate(CellStateChangedModel cellModel, Action<string, object> broadcast)
     {
-        var json = JsonConvert.SerializeObject(orderModel, serializerSettings);
-        await _factoryChannel.Writer.WriteAsync(new Tuple<string, string>("processes", json), cancellationToken);
+        broadcast("cellStateChangedModel", cellModel);
     }
 
-    public static async Task PublishCellUpdate(CellStateChangedModel cellModel, JsonSerializerSettings serializerSettings, Channel<Tuple<string, string>> _factoryChannel, CancellationToken cancellationToken)
+    public static void ActivityUpdated(ActivityUpdatedEventArgs activityEventArg, List<ICell> cells, Resource resource,
+        List<OrderModel> orderModels, Action<string, object> broadcast)
     {
-        if (cancellationToken.IsCancellationRequested) return;
-        var json = JsonConvert.SerializeObject(cellModel, serializerSettings);
-        await _factoryChannel.Writer.WriteAsync(new Tuple<string, string>("cellStateChangedModel", json), cancellationToken);
+        if (activityEventArg.Progress == ActivityProgress.Ready)
+        {
+            return;
+        }
+
+        if (cells.All(x => x.Id != activityEventArg.Activity.Tracing.ResourceId))
+        {
+            return;
+        }
+
+        var cell = resource as ICell;
+        if (cell == null)
+        {
+            return;
+        }
+
+        var activityChangedModel = cell.GetActivityChangedModel(activityEventArg.Activity, orderModels);
+        broadcast("activityChangedModel", activityChangedModel);
+
+        var cellStateChangedModel = cell.GetCellStateChangedModel(activityEventArg.Progress, resource);
+        broadcast("cellStateChangedModel", cellStateChangedModel);
     }
 
-    public static async Task ActivityUpdated(
-        ActivityUpdatedEventArgs activityEventArg,
-        JsonSerializerSettings serializerSettings,
-        Channel<Tuple<string, string>> _factoryChannel,
-        List<ICell> cells,
-        Resource resource,
-        Converter.Converter converter,
-        List<OrderModel> orderModels,
-        CancellationToken cancellationToken)
+    public static void ResourceUpdated(IResourceManagement resourceManager,
+        Func<IMachineLocation, bool> cellFilter, Converter.Converter converter, Action<string, object> broadcast)
     {
-        if (cancellationToken.IsCancellationRequested || activityEventArg.Progress == ActivityProgress.Ready) return;
-
-        if (!cells.Any(x => x.Id == activityEventArg.Activity.Tracing.ResourceId)) return;
-
-        var cell = resource;
-        var activityChangedModel = (cell as ICell).GetActivityChangedModel(activityEventArg.Activity, orderModels);
-
-        var cellStateChangedModel = (cell as ICell).GetCellStateChangedModel(activityEventArg.Progress, resource);
-
-        var json = JsonConvert.SerializeObject(activityChangedModel, serializerSettings);
-        await _factoryChannel.Writer.WriteAsync(new Tuple<string, string>("activityChangedModel", json), cancellationToken);
-
-        json = JsonConvert.SerializeObject(cellStateChangedModel, serializerSettings);
-        await _factoryChannel.Writer.WriteAsync(new Tuple<string, string>("cellStateChangedModel", json), cancellationToken);
-    }
-
-    public static async Task ResourceUpdated(
-        JsonSerializerSettings serializerSettings,
-        Channel<Tuple<string, string>> _factoryChannel,
-        IResourceManagement resourceManager,
-        Func<IMachineLocation, bool> cellFilter,
-        Converter.Converter converter,
-        CancellationToken cancellationToken)
-    {
-        if (cancellationToken.IsCancellationRequested) return;
-
         var cells = resourceManager.GetResources(cellFilter)
             .Select(location => location.Machine)
             .Cast<ICell>();
 
         foreach (var cell in cells)
-            await SendResourceUpdate(cell.GetResourceChangedModel(converter, resourceManager, cellFilter), serializerSettings, _factoryChannel, cancellationToken);
-    }
-
-    public static async Task SendResourceUpdate(ResourceChangedModel resourceChangedModel,
-        JsonSerializerSettings serializerSettings,
-        Channel<Tuple<string, string>> _factoryChannel,
-        CancellationToken cancellationToken)
-    {
-        if (cancellationToken.IsCancellationRequested) return;
-        var json = JsonConvert.SerializeObject(resourceChangedModel, serializerSettings);
-        await _factoryChannel.Writer.WriteAsync(new Tuple<string, string>("resourceChangedModel", json), cancellationToken);
+        {
+            var resourceChangedModel = cell.GetResourceChangedModel(converter, resourceManager, cellFilter);
+            broadcast("resourceChangedModel", resourceChangedModel);
+        }
     }
 
     public static List<TransportRouteModel> CreateRoutes(IReadOnlyList<IMachineLocation> locations)
@@ -106,10 +84,9 @@ internal static class FactoryMonitorHelper
                 Destination = Converter.Converter.ToCellLocationModel(x.Destination),
                 Origin = Converter.Converter.ToCellLocationModel(x.Origin),
                 WayPoints = x.WayPoints
-            })?.Select(t => Converter.Converter.ToTransportRouteModel(t)).ToList();
+            }).Select(Converter.Converter.ToTransportRouteModel).ToList();
 
-            if (result is not null)
-                routes.AddRange(result);
+            routes.AddRange(result);
         }
         return routes;
     }

--- a/src/Moryx.FactoryMonitor.Endpoints/FactoryMonitorController.cs
+++ b/src/Moryx.FactoryMonitor.Endpoints/FactoryMonitorController.cs
@@ -4,6 +4,8 @@
 using System.Collections.Concurrent;
 using System.Net.ServerSentEvents;
 using System.Runtime.CompilerServices;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Moryx.AbstractionLayer.Resources;
@@ -40,7 +42,12 @@ public class FactoryMonitorController : ControllerBase
     private readonly IOrderManagement _orderManager;
     private readonly CellSerialization _serialization;
 
-    private static readonly ConcurrentDictionary<Guid, Channel<(string EventType, object Data)>> _factoryStreamSubscribers = new();
+    private static readonly ConcurrentDictionary<Guid, Channel<(string EventType, string Data)>> _factoryStreamSubscribers = new();
+    private static readonly JsonSerializerOptions _serializerOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        Converters = { new JsonStringEnumConverter() }
+    };
 
     private List<ICell> _cells;
     private Timer _resourceChangedTimer;
@@ -277,9 +284,9 @@ public class FactoryMonitorController : ControllerBase
 
         return;
 
-        async IAsyncEnumerable<SseItem<object>> Subscribe([EnumeratorCancellation] CancellationToken token)
+        async IAsyncEnumerable<SseItem<string>> Subscribe([EnumeratorCancellation] CancellationToken token)
         {
-            var channel = Channel.CreateUnbounded<(string EventType, object Data)>();
+            var channel = Channel.CreateUnbounded<(string EventType, string Data)>();
             var id = Guid.NewGuid();
             _factoryStreamSubscribers[id] = channel;
 
@@ -287,7 +294,7 @@ public class FactoryMonitorController : ControllerBase
             {
                 await foreach (var (eventType, data) in channel.Reader.ReadAllAsync(token))
                 {
-                    yield return new SseItem<object>(data, eventType);
+                    yield return new SseItem<string>(data, eventType);
                 }
             }
             finally
@@ -301,7 +308,7 @@ public class FactoryMonitorController : ControllerBase
         {
             foreach (var channel in _factoryStreamSubscribers.Values)
             {
-                channel.Writer.TryWrite((eventType, data));
+                channel.Writer.TryWrite((eventType, JsonSerializer.Serialize(data, _serializerOptions)));
             }
         }
     }

--- a/src/Moryx.FactoryMonitor.Endpoints/FactoryMonitorController.cs
+++ b/src/Moryx.FactoryMonitor.Endpoints/FactoryMonitorController.cs
@@ -1,10 +1,11 @@
 // Copyright (c) 2026 Phoenix Contact GmbH & Co. KG
 // Licensed under the Apache License, Version 2.0
 
+using System.Collections.Concurrent;
+using System.Net.ServerSentEvents;
+using System.Runtime.CompilerServices;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Newtonsoft.Json.Serialization;
-using Newtonsoft.Json;
 using Moryx.AbstractionLayer.Resources;
 using Moryx.ControlSystem.Processes;
 using Moryx.Factory;
@@ -19,7 +20,6 @@ using Moryx.AbstractionLayer.Processes;
 using Moryx.AspNetCore;
 using Moryx.FactoryMonitor.Endpoints.Converter;
 using Moryx.FactoryMonitor.Endpoints.Properties;
-//old models in '.Model' namespace. Only ones still in use: TransoirtRoute- / PathModel & CellSettingsModel
 using Moryx.FactoryMonitor.Endpoints.Extensions;
 using Timer = System.Timers.Timer;
 
@@ -40,8 +40,10 @@ public class FactoryMonitorController : ControllerBase
     private readonly IOrderManagement _orderManager;
     private readonly CellSerialization _serialization;
 
+    private static readonly ConcurrentDictionary<Guid, Channel<(string EventType, object Data)>> _factoryStreamSubscribers = new();
+
     private List<ICell> _cells;
-    private Timer resourceChangedTimer;
+    private Timer _resourceChangedTimer;
     private readonly ILogger<FactoryMonitorController> _logger;
 
     public FactoryMonitorController(IResourceManagement resourceManager, IProcessControl processControl, IOrderManagement orderManagement, ILogger<FactoryMonitorController> logger = null)
@@ -67,7 +69,6 @@ public class FactoryMonitorController : ControllerBase
         var activityChangedModels = new List<ActivityChangedModel>();
         var cellStateChangedModels = new List<CellStateChangedModel>();
         var resourceChangedModels = new List<ResourceChangedModel>();
-        var orderModels = new List<OrderModel>();
 
         var activities = _processControl.GetRunningProcesses()
             .Select(p => p.CurrentActivity())
@@ -93,7 +94,7 @@ public class FactoryMonitorController : ControllerBase
         activityChangedModels = activityChangedModels.OrderBy(x => x.ResourceId).ToList();
         cellStateChangedModels = cellStateChangedModels.OrderBy(x => x.Id).ToList();
         resourceChangedModels = resourceChangedModels.OrderBy(x => x.Id).ToList();
-        orderModels = _orderManager.GetOrderModels(_colorPalette).OrderBy(x => x.Order).ThenBy(x => x.Operation).ToList();
+        var orderModels = _orderManager.GetOrderModels(_colorPalette).OrderBy(x => x.Order).ThenBy(x => x.Operation).ToList();
 
         var factory = _resourceManager.GetRootFactory();
 
@@ -128,23 +129,34 @@ public class FactoryMonitorController : ControllerBase
     {
         // check if there is a factory with the given id
         var factory = _resourceManager.GetResource<IManufacturingFactory>(x => x.Id == factoryId);
-        if (factory is null) return NotFound(Strings.FactoryMonitorController_FactoryNotFound_);
+        if (factory is null)
+        {
+            return NotFound(Strings.FactoryMonitorController_FactoryNotFound_);
+        }
         var converter = new Converter.Converter(_serialization);
 
         var root = _resourceManager.GetRootFactory();
-        SimpleGraph graph = _resourceManager.ReadUnsafe(factory.Id, e => SimpleGraph.Create(e as ManufacturingFactory));
+        var graph = _resourceManager.ReadUnsafe(factory.Id, e => SimpleGraph.Create(e as ManufacturingFactory));
 
         //root level (Factory)
         if (root.Id == factoryId)
-            return graph.Children.Select(e => e.ToVisualItemModel(_resourceManager, _logger, converter, CellFilterBaseOnLocation))
+        {
+            return graph.Children
+                .Select(e => e.ToVisualItemModel(_resourceManager, _logger, converter, CellFilterBaseOnLocation))
                 .Where(x => x is not null).ToList();
+        }
 
         // 1 level tree graph
         graph = graph.GetSubGraphById(factoryId);
-        if (graph is null) return NotFound();
+        if (graph is null)
+        {
+            return NotFound();
+        }
 
-        var output = graph.Children.Select(e => e.ToVisualItemModel(_resourceManager, _logger, converter, CellFilterBaseOnLocation))
+        var output = graph.Children
+            .Select(e => e.ToVisualItemModel(_resourceManager, _logger, converter, CellFilterBaseOnLocation))
             .Where(x => x is not null).ToList();
+
         return output;
     }
 
@@ -166,7 +178,11 @@ public class FactoryMonitorController : ControllerBase
         };
 
         var factory = _resourceManager.ReadUnsafe(factoryId, e => (ManufacturingFactory)e);
-        if (factory is not ManufacturingFactory manufacturingFactory) BadRequest(Strings.FactoryMonitorController_FactoryNotFound_);
+        if (factory is not ManufacturingFactory manufacturingFactory)
+        {
+            BadRequest(Strings.FactoryMonitorController_FactoryNotFound_);
+        }
+
         var parentFactory = factory.GetFactory(); //Get Parent factory
 
         return new FactoryModel
@@ -188,73 +204,65 @@ public class FactoryMonitorController : ControllerBase
     [ProducesResponseType(typeof(OrderChangedModel), StatusCodes.Status200OK)]
     public async Task FactoryStatesStream(CancellationToken cancellationToken)
     {
-        var response = Response;
-        response.Headers.Append("Content-Type", "text/event-stream");
-
-        // Configure Serialization Settings
-        var serializerSettings = new JsonSerializerSettings();
-        serializerSettings.ContractResolver = new CamelCasePropertyNamesContractResolver();
-        serializerSettings.Converters.Add(new Newtonsoft.Json.Converters.StringEnumConverter());
-
-        var _factoryChannel = Channel.CreateUnbounded<Tuple<string, string>>();
-
-        resourceChangedTimer = new();
-        resourceChangedTimer.Interval = 5000;
-        resourceChangedTimer.AutoReset = true;
-        resourceChangedTimer.Enabled = true;
-
+        // Early validation - check if there are cells to monitor
         var locations = _resourceManager.GetResources<IMachineLocation>();
         _cells = locations.Where(CellFilterBaseOnLocation)
             .Select(l => l.Machine)
             .Cast<ICell>().ToList();
+
         if (_cells.Count == 0)
         {
-            await response.WriteAsync("retry: 5000\n", cancellationToken: cancellationToken);
-            await response.CompleteAsync();
+            Response.Headers.Append("Retry-After", "5");
             return;
         }
+
+        // Configure Serialization Settings
         var converter = new Converter.Converter(_serialization);
 
-        var resourceEventHandler = new ElapsedEventHandler(async (sender, eventArgs) =>
-            await FactoryMonitorHelper.ResourceUpdated(serializerSettings, _factoryChannel, _resourceManager, CellFilterBaseOnLocation, converter, cancellationToken)); //resource events are substitute with a timer event since there are no such events
+        // Define event handlers using helper methods
+        var resourceEventHandler = new ElapsedEventHandler((_, _) =>
+            FactoryMonitorHelper.ResourceUpdated(_resourceManager, CellFilterBaseOnLocation, converter, Broadcast));
 
-        var capabilitiesEventHandler = new EventHandler<ICapabilities>(async (sender, eventArgs) =>
-            await FactoryMonitorHelper.PublishCellUpdate((sender as ICell).GetCellStateChangedModel(_resourceManager.ReadUnsafe((sender as ICell).Id, r => r)), serializerSettings, _factoryChannel, cancellationToken));
+        var capabilitiesEventHandler = new EventHandler<ICapabilities>((sender, _) =>
+            FactoryMonitorHelper.PublishCellUpdate((sender as ICell).GetCellStateChangedModel(_resourceManager.ReadUnsafe((sender as ICell).Id, r => r)),
+                Broadcast));
 
-        var orderStartedEventHandler = new EventHandler<OperationStartedEventArgs>(async (sender, eventArgs) =>
-            await FactoryMonitorHelper.OrderStarted(eventArgs, serializerSettings, _factoryChannel, cancellationToken));
+        var orderStartedEventHandler = new EventHandler<OperationStartedEventArgs>((_, eventArgs) =>
+            FactoryMonitorHelper.OrderStarted(eventArgs, Broadcast));
 
-        var orderEventHandler = new EventHandler<OperationChangedEventArgs>(async (sender, eventArgs) =>
-            await FactoryMonitorHelper.OrderUpdated(eventArgs, serializerSettings, _factoryChannel, cancellationToken));
+        var orderEventHandler = new EventHandler<OperationChangedEventArgs>((sender, eventArgs) =>
+            FactoryMonitorHelper.OrderUpdated(eventArgs, Broadcast));
 
-        var activityEventHandler = new EventHandler<ActivityUpdatedEventArgs>(async (sender, eventArgs) => await
-            FactoryMonitorHelper.ActivityUpdated(eventArgs, serializerSettings, _factoryChannel, _cells, _resourceManager.ReadUnsafe(eventArgs.Activity.Tracing.ResourceId, r => r), converter, _orderManager.GetOrderModels(_colorPalette), cancellationToken));
+        var activityEventHandler = new EventHandler<ActivityUpdatedEventArgs>((sender, eventArgs) =>
+            FactoryMonitorHelper.ActivityUpdated(eventArgs, _cells, _resourceManager.ReadUnsafe(eventArgs.Activity.Tracing.ResourceId, r => r),
+                _orderManager.GetOrderModels(_colorPalette), Broadcast));
 
-        foreach (var cell in _cells)
-        {
-            //register to cell notready-to-work event
-            cell.CapabilitiesChanged += capabilitiesEventHandler;
-        }
-
-        _orderManager.OperationStarted += orderStartedEventHandler;
-        _orderManager.OperationUpdated += orderEventHandler;
-        _processControl.ActivityUpdated += activityEventHandler;
-        resourceChangedTimer.Elapsed += resourceEventHandler;
+        // Setup timer
+        _resourceChangedTimer = new();
+        _resourceChangedTimer.Interval = 5000;
+        _resourceChangedTimer.AutoReset = true;
+        _resourceChangedTimer.Enabled = true;
 
         try
         {
-            // Create infinite loop awaiting changes or cancellation
-            while (!cancellationToken.IsCancellationRequested)
-            {
-                var changes = await _factoryChannel.Reader.ReadAsync(cancellationToken);
+            var result = TypedResults.ServerSentEvents(Subscribe(cancellationToken));
 
-                await response.WriteAsync($"type: {changes.Item1}\n", cancellationToken);
-                await response.WriteAsync($"data: {changes.Item2}\r\r", cancellationToken);
+            // Register event handlers after result creation but before execution to ensure finally cleanup
+            foreach (var cell in _cells)
+            {
+                cell.CapabilitiesChanged += capabilitiesEventHandler;
             }
+
+            _orderManager.OperationStarted += orderStartedEventHandler;
+            _orderManager.OperationUpdated += orderEventHandler;
+            _processControl.ActivityUpdated += activityEventHandler;
+            _resourceChangedTimer.Elapsed += resourceEventHandler;
+
+            await result.ExecuteAsync(HttpContext);
         }
         finally
         {
-            // Unregister handler
+            // Unregister handlers
             foreach (var cell in _cells)
             {
                 cell.CapabilitiesChanged -= capabilitiesEventHandler;
@@ -263,11 +271,39 @@ public class FactoryMonitorController : ControllerBase
             _orderManager.OperationStarted -= orderStartedEventHandler;
             _orderManager.OperationUpdated -= orderEventHandler;
             _processControl.ActivityUpdated -= activityEventHandler;
-            resourceChangedTimer.Elapsed -= resourceEventHandler;
-
-            _factoryChannel.Writer.Complete();
+            _resourceChangedTimer.Elapsed -= resourceEventHandler;
+            _resourceChangedTimer?.Dispose();
         }
-        await response.CompleteAsync();
+
+        return;
+
+        async IAsyncEnumerable<SseItem<object>> Subscribe([EnumeratorCancellation] CancellationToken token)
+        {
+            var channel = Channel.CreateUnbounded<(string EventType, object Data)>();
+            var id = Guid.NewGuid();
+            _factoryStreamSubscribers[id] = channel;
+
+            try
+            {
+                await foreach (var (eventType, data) in channel.Reader.ReadAllAsync(token))
+                {
+                    yield return new SseItem<object>(data, eventType);
+                }
+            }
+            finally
+            {
+                _factoryStreamSubscribers.TryRemove(id, out _);
+            }
+        }
+
+        // Local helper to broadcast events to all connected clients
+        static void Broadcast(string eventType, object data)
+        {
+            foreach (var channel in _factoryStreamSubscribers.Values)
+            {
+                channel.Writer.TryWrite((eventType, data));
+            }
+        }
     }
 
     /// <summary>
@@ -420,7 +456,7 @@ public class FactoryMonitorController : ControllerBase
         if (machine is null)
         {
             return false;
-        } 
+        }
 
         return true;
     }

--- a/src/Moryx.Notifications.Endpoints/NotificationPublisherController.cs
+++ b/src/Moryx.Notifications.Endpoints/NotificationPublisherController.cs
@@ -1,14 +1,15 @@
 // Copyright (c) 2026 Phoenix Contact GmbH & Co. KG
 // Licensed under the Apache License, Version 2.0
 
+using System.Collections.Concurrent;
+using System.Runtime.CompilerServices;
+using System.Threading.Channels;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Moryx.AspNetCore;
 using Moryx.Notifications.Endpoints.Models;
 using Moryx.Notifications.Endpoints.Properties;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Serialization;
 
 namespace Moryx.Notifications.Endpoints;
 
@@ -22,15 +23,7 @@ public class NotificationPublisherController : ControllerBase
 {
     private readonly INotificationPublisher _notificationPublisher;
 
-    private static readonly JsonSerializerSettings _serializerSettings = CreateSerializerSettings();
-
-    private static JsonSerializerSettings CreateSerializerSettings()
-    {
-        var serializerSettings = new JsonSerializerSettings();
-        serializerSettings.ContractResolver = new CamelCasePropertyNamesContractResolver();
-        serializerSettings.Converters.Add(new Newtonsoft.Json.Converters.StringEnumConverter());
-        return serializerSettings;
-    }
+    private static readonly ConcurrentDictionary<Guid, Channel<NotificationModel[]>> _notificationStreamSubscribers = new();
 
     public NotificationPublisherController(INotificationPublisher notificationPublisher)
         => _notificationPublisher = notificationPublisher;
@@ -55,57 +48,74 @@ public class NotificationPublisherController : ControllerBase
         return Converter.ToModel(notification);
     }
 
-    private TaskCompletionSource _notificationTcs;
-
     [HttpGet("stream")]
     [ProducesResponseType(typeof(NotificationModel[]), StatusCodes.Status200OK)]
     [Authorize(Policy = NotificationPermissions.CanView)]
     public async Task NotificationStream(CancellationToken cancellationToken)
     {
-        var response = Response;
-        response.Headers.Add("Content-Type", "text/event-stream");
+        // TODO: do not always broadcast all notifications, separate in event-types
+        // https://github.com/PHOENIXCONTACT/MORYX-Framework/issues/1231
 
-        // Define event handling
-        _notificationTcs = new TaskCompletionSource();
-        var eventHandler = new EventHandler<Notification>((sender, notification) => _notificationTcs.TrySetResult());
-        // Register handler to facade
-        _notificationPublisher.Published += eventHandler;
-        _notificationPublisher.Acknowledged += eventHandler;
+        // Define event handlers that broadcast immediately when notifications change
+        var publishedEventHandler = new EventHandler<Notification>((_, _) =>
+            Broadcast());
+
+        var acknowledgedEventHandler = new EventHandler<Notification>((_, _) =>
+            Broadcast());
 
         try
         {
-            // Create infinite loop awaiting changes or cancellation
-            while (!cancellationToken.IsCancellationRequested)
-            {
-                // Write notifications
-                var notifications = _notificationPublisher.GetAll()
-                    .Select(Converter.ToModel).ToList();
-                var json = JsonConvert.SerializeObject(notifications, _serializerSettings);
+            var result = TypedResults.ServerSentEvents(Subscribe(cancellationToken));
 
-                await response.WriteAsync($"data: {json}\r\r", cancellationToken);
+            // Register event handlers after result creation but before execution to ensure finally cleanup
+            _notificationPublisher.Published += publishedEventHandler;
+            _notificationPublisher.Acknowledged += acknowledgedEventHandler;
 
-                // Await task completion
-                await Task.WhenAny(_notificationTcs.Task, Task.Delay(30000, cancellationToken));
-
-                // Create new TCS
-                _notificationTcs = new TaskCompletionSource();
-            }
-        }
-        catch (OperationCanceledException)
-        {
+            await result.ExecuteAsync(HttpContext);
         }
         finally
         {
-            // Unregister handler from facade
-            _notificationPublisher.Published -= eventHandler;
-            _notificationPublisher.Acknowledged -= eventHandler;
-
-            _notificationTcs.TrySetCanceled();
-            _notificationTcs = null;
+            _notificationPublisher.Published -= publishedEventHandler;
+            _notificationPublisher.Acknowledged -= acknowledgedEventHandler;
         }
 
-        await response.WriteAsync("retry: 1000\n");
-        await response.CompleteAsync();
+        return;
+
+        async IAsyncEnumerable<NotificationModel[]> Subscribe([EnumeratorCancellation] CancellationToken token)
+        {
+            var channel = Channel.CreateUnbounded<NotificationModel[]>();
+            var id = Guid.NewGuid();
+            _notificationStreamSubscribers[id] = channel;
+
+            // Send initial instruction set as first item
+            var initialNotifications = _notificationPublisher.GetAll()
+                .Select(Converter.ToModel).ToArray();
+            yield return initialNotifications;
+
+            try
+            {
+                await foreach (var data in channel.Reader.ReadAllAsync(token))
+                {
+                    yield return data;
+                }
+            }
+            finally
+            {
+                _notificationStreamSubscribers.TryRemove(id, out _);
+            }
+        }
+
+        // Local helper to broadcast all notifications to all connected clients
+        void Broadcast()
+        {
+            var notifications = _notificationPublisher.GetAll()
+                .Select(Converter.ToModel).ToArray();
+
+            foreach (var channel in _notificationStreamSubscribers.Values)
+            {
+                channel.Writer.TryWrite(notifications);
+            }
+        }
     }
 
     [HttpPost("{guid}/acknowledge")]

--- a/src/Moryx.Notifications.Endpoints/NotificationPublisherController.cs
+++ b/src/Moryx.Notifications.Endpoints/NotificationPublisherController.cs
@@ -2,7 +2,10 @@
 // Licensed under the Apache License, Version 2.0
 
 using System.Collections.Concurrent;
+using System.Net.ServerSentEvents;
 using System.Runtime.CompilerServices;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using System.Threading.Channels;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
@@ -23,7 +26,12 @@ public class NotificationPublisherController : ControllerBase
 {
     private readonly INotificationPublisher _notificationPublisher;
 
-    private static readonly ConcurrentDictionary<Guid, Channel<NotificationModel[]>> _notificationStreamSubscribers = new();
+    private static readonly ConcurrentDictionary<Guid, Channel<SseItem<string>>> _notificationStreamSubscribers = new();
+    private static readonly JsonSerializerOptions _serializerOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        Converters = { new JsonStringEnumConverter() }
+    };
 
     public NotificationPublisherController(INotificationPublisher notificationPublisher)
         => _notificationPublisher = notificationPublisher;
@@ -81,16 +89,16 @@ public class NotificationPublisherController : ControllerBase
 
         return;
 
-        async IAsyncEnumerable<NotificationModel[]> Subscribe([EnumeratorCancellation] CancellationToken token)
+        async IAsyncEnumerable<SseItem<string>> Subscribe([EnumeratorCancellation] CancellationToken token)
         {
-            var channel = Channel.CreateUnbounded<NotificationModel[]>();
+            var channel = Channel.CreateUnbounded<SseItem<string>>();
             var id = Guid.NewGuid();
             _notificationStreamSubscribers[id] = channel;
 
-            // Send initial instruction set as first item
+            // Send all notifications set as first item
             var initialNotifications = _notificationPublisher.GetAll()
                 .Select(Converter.ToModel).ToArray();
-            yield return initialNotifications;
+            yield return new SseItem<string>(JsonSerializer.Serialize(initialNotifications, _serializerOptions));
 
             try
             {
@@ -113,7 +121,7 @@ public class NotificationPublisherController : ControllerBase
 
             foreach (var channel in _notificationStreamSubscribers.Values)
             {
-                channel.Writer.TryWrite(notifications);
+                channel.Writer.TryWrite(new SseItem<string>(JsonSerializer.Serialize(notifications, _serializerOptions)));
             }
         }
     }

--- a/src/Moryx.Orders.Endpoints/OrderManagementController.cs
+++ b/src/Moryx.Orders.Endpoints/OrderManagementController.cs
@@ -1,15 +1,16 @@
 // Copyright (c) 2026 Phoenix Contact GmbH & Co. KG
 // Licensed under the Apache License, Version 2.0
 
+using System.Collections.Concurrent;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Moryx.AbstractionLayer.Products;
 using Moryx.Orders.Endpoints.Properties;
 using Moryx.Users;
-using Newtonsoft.Json.Serialization;
-using Newtonsoft.Json;
 using System.Net;
+using System.Net.ServerSentEvents;
+using System.Runtime.CompilerServices;
 using System.Threading.Channels;
 using Moryx.AspNetCore;
 using Moryx.Orders.Endpoints.Models;
@@ -27,17 +28,7 @@ public class OrderManagementController : ControllerBase
     private readonly IOrderManagement _orderManagement;
     private readonly IUserManagement _userManagement;
 
-    private static readonly JsonSerializerSettings _serializerSettings = CreateSerializerSettings();
-
-    private static JsonSerializerSettings CreateSerializerSettings()
-    {
-        var serializerSettings = new JsonSerializerSettings
-        {
-            ContractResolver = new CamelCasePropertyNamesContractResolver()
-        };
-        serializerSettings.Converters.Add(new Newtonsoft.Json.Converters.StringEnumConverter());
-        return serializerSettings;
-    }
+    private static readonly ConcurrentDictionary<Guid, Channel<(string, object)>> _operationStreamSubscribers = new();
 
     public OrderManagementController(IOrderManagement orderManagement, IUserManagement userManagement = null)
     {
@@ -63,100 +54,58 @@ public class OrderManagementController : ControllerBase
     [ProducesResponseType(typeof(OperationChangedModel), StatusCodes.Status200OK)]
     public async Task OperationStream(CancellationToken cancellationToken)
     {
-        var response = Response;
-        response.Headers["Content-Type"] = "text/event-stream";
+        // Define event handlers using the broadcast helper
+        var updateEventHandler = new EventHandler<OperationChangedEventArgs>((_, e) =>
+            Broadcast(nameof(OperationTypes.Update), Converter.ToModel(e.Operation)));
 
-        var operationsChannel = Channel.CreateUnbounded<Tuple<string, string>>();
-
-        // Define event handling
-        var updateEventHandler = new EventHandler<OperationChangedEventArgs>((_, eventArgs) =>
-        {
-            var json = JsonConvert.SerializeObject(Converter.ToModel(eventArgs.Operation), _serializerSettings);
-            operationsChannel.Writer.TryWrite(new Tuple<string, string>(nameof(OperationTypes.Update), json));
-        });
-        _orderManagement.OperationUpdated += updateEventHandler;
-
-        var adviceEventHandler = new EventHandler<OperationAdviceEventArgs>((_, eventArgs) =>
-        {
-            var advicedOperation = new OperationAdvicedModel
+        var adviceEventHandler = new EventHandler<OperationAdviceEventArgs>((_, e) =>
+            Broadcast(nameof(OperationTypes.Advice), new OperationAdvicedModel
             {
-                OperationModel = Converter.ToModel(eventArgs.Operation),
-                Advice = Converter.ToModel(eventArgs.Advice)
-            };
-            var json = JsonConvert.SerializeObject(advicedOperation, _serializerSettings);
-            operationsChannel.Writer.TryWrite(new Tuple<string, string>(nameof(OperationTypes.Advice), json));
-        });
-        _orderManagement.OperationAdviced += adviceEventHandler;
+                OperationModel = Converter.ToModel(e.Operation),
+                Advice = Converter.ToModel(e.Advice)
+            }));
 
-        var reportEventHandler = new EventHandler<OperationReportEventArgs>((_, eventArgs) =>
-        {
-            var reportedOperation = new OperationReportedModel
+        var reportEventHandler = new EventHandler<OperationReportEventArgs>((_, e) =>
+            Broadcast(nameof(OperationTypes.Report), new OperationReportedModel
             {
-                OperationModel = Converter.ToModel(eventArgs.Operation),
-                Report = Converter.ToModel(eventArgs.Report)
-            };
-            var json = JsonConvert.SerializeObject(reportedOperation, _serializerSettings);
-            operationsChannel.Writer.TryWrite(new Tuple<string, string>(nameof(OperationTypes.Report), json));
-        });
-        _orderManagement.OperationPartialReport += reportEventHandler;
+                OperationModel = Converter.ToModel(e.Operation),
+                Report = Converter.ToModel(e.Report)
+            }));
 
-        var interruptedEventHandler = new EventHandler<OperationChangedEventArgs>((_, eventArgs) =>
-        {
-            var json = JsonConvert.SerializeObject(Converter.ToModel(eventArgs.Operation), _serializerSettings);
-            operationsChannel.Writer.TryWrite(new Tuple<string, string>(nameof(OperationTypes.Interrupted), json));
-        });
-        _orderManagement.OperationInterrupted += interruptedEventHandler;
+        var interruptedEventHandler = new EventHandler<OperationChangedEventArgs>((_, e) =>
+            Broadcast(nameof(OperationTypes.Interrupted), Converter.ToModel(e.Operation)));
 
-        var completedEventHandler = new EventHandler<OperationReportEventArgs>((_, eventArgs) =>
-        {
-            var completedOperation = new OperationReportedModel
+        var completedEventHandler = new EventHandler<OperationReportEventArgs>((_, e) =>
+            Broadcast(nameof(OperationTypes.Completed), new OperationReportedModel
             {
-                OperationModel = Converter.ToModel(eventArgs.Operation),
-                Report = Converter.ToModel(eventArgs.Report)
-            };
-            var json = JsonConvert.SerializeObject(completedOperation, _serializerSettings);
-            operationsChannel.Writer.TryWrite(new Tuple<string, string>(nameof(OperationTypes.Completed), json));
-        });
-        _orderManagement.OperationCompleted += completedEventHandler;
+                OperationModel = Converter.ToModel(e.Operation),
+                Report = Converter.ToModel(e.Report)
+            }));
 
-        var startedEventHandler = new EventHandler<OperationStartedEventArgs>((_, eventArgs) =>
-        {
-            var startedOperation = new OperationStartedModel
+        var startedEventHandler = new EventHandler<OperationStartedEventArgs>((_, e) =>
+            Broadcast(nameof(OperationTypes.Start), new OperationStartedModel
             {
-                OperationModel = Converter.ToModel(eventArgs.Operation),
-                UserId = eventArgs.User.Identifier
-            };
-            var json = JsonConvert.SerializeObject(startedOperation, _serializerSettings);
-            operationsChannel.Writer.TryWrite(new Tuple<string, string>(nameof(OperationTypes.Start), json));
-        });
-        _orderManagement.OperationStarted += startedEventHandler;
+                OperationModel = Converter.ToModel(e.Operation),
+                UserId = e.User.Identifier
+            }));
 
-        var changedEventHandler = new EventHandler<OperationChangedEventArgs>((_, eventArgs) =>
-        {
-            var json = JsonConvert.SerializeObject(Converter.ToModel(eventArgs.Operation), _serializerSettings);
-            operationsChannel.Writer.TryWrite(new Tuple<string, string>(nameof(OperationTypes.Progress), json));
-        });
-        _orderManagement.OperationProgressChanged += changedEventHandler;
+        var changedEventHandler = new EventHandler<OperationChangedEventArgs>((_, e) =>
+            Broadcast(nameof(OperationTypes.Progress), Converter.ToModel(e.Operation)));
 
         try
         {
-            // Create infinite loop awaiting changes or cancellation
-            while (!cancellationToken.IsCancellationRequested)
-            {
-                var changes = await operationsChannel.Reader.ReadAsync(cancellationToken);
+            var result = TypedResults.ServerSentEvents(Subscribe(cancellationToken));
 
-                await response.WriteAsync($"event: {changes.Item1}\n", cancellationToken);
-                await response.WriteAsync($"data: {changes.Item2}\r\r", cancellationToken);
-            }
-        }
-        catch (OperationCanceledException)
-        {
-        }
-        catch (ChannelClosedException)
-        {
-        }
-        catch (InvalidOperationException)
-        {
+            // Register event handlers after result creation but before execution to ensure finally cleanup
+            _orderManagement.OperationUpdated += updateEventHandler;
+            _orderManagement.OperationAdviced += adviceEventHandler;
+            _orderManagement.OperationPartialReport += reportEventHandler;
+            _orderManagement.OperationInterrupted += interruptedEventHandler;
+            _orderManagement.OperationCompleted += completedEventHandler;
+            _orderManagement.OperationStarted += startedEventHandler;
+            _orderManagement.OperationProgressChanged += changedEventHandler;
+
+            await result.ExecuteAsync(HttpContext);
         }
         finally
         {
@@ -167,11 +116,37 @@ public class OrderManagementController : ControllerBase
             _orderManagement.OperationCompleted -= completedEventHandler;
             _orderManagement.OperationStarted -= startedEventHandler;
             _orderManagement.OperationProgressChanged -= changedEventHandler;
-
-            operationsChannel.Writer.TryComplete();
         }
 
-        await response.CompleteAsync();
+        return;
+
+        async IAsyncEnumerable<SseItem<object>> Subscribe([EnumeratorCancellation] CancellationToken cancelToken)
+        {
+            var channel = Channel.CreateUnbounded<(string, object)>();
+            var id = Guid.NewGuid();
+            _operationStreamSubscribers[id] = channel;
+
+            try
+            {
+                await foreach (var evt in channel.Reader.ReadAllAsync(cancelToken))
+                {
+                    yield return new SseItem<object>(evt.Item2, eventType: evt.Item1);
+                }
+            }
+            finally
+            {
+                _operationStreamSubscribers.TryRemove(id, out _);
+            }
+        }
+
+        // Local helper to broadcast events to all connected clients
+        static void Broadcast(string eventType, object model)
+        {
+            foreach (var channel in _operationStreamSubscribers.Values)
+            {
+                channel.Writer.TryWrite((eventType, model));
+            }
+        }
     }
 
     [HttpGet]

--- a/src/Moryx.Orders.Endpoints/OrderManagementController.cs
+++ b/src/Moryx.Orders.Endpoints/OrderManagementController.cs
@@ -11,6 +11,8 @@ using Moryx.Users;
 using System.Net;
 using System.Net.ServerSentEvents;
 using System.Runtime.CompilerServices;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using System.Threading.Channels;
 using Moryx.AspNetCore;
 using Moryx.Orders.Endpoints.Models;
@@ -28,7 +30,12 @@ public class OrderManagementController : ControllerBase
     private readonly IOrderManagement _orderManagement;
     private readonly IUserManagement _userManagement;
 
-    private static readonly ConcurrentDictionary<Guid, Channel<(string, object)>> _operationStreamSubscribers = new();
+    private static readonly ConcurrentDictionary<Guid, Channel<(string, string)>> _operationStreamSubscribers = new();
+    private static readonly JsonSerializerOptions _serializerOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        Converters = { new JsonStringEnumConverter() }
+    };
 
     public OrderManagementController(IOrderManagement orderManagement, IUserManagement userManagement = null)
     {
@@ -120,9 +127,9 @@ public class OrderManagementController : ControllerBase
 
         return;
 
-        async IAsyncEnumerable<SseItem<object>> Subscribe([EnumeratorCancellation] CancellationToken cancelToken)
+        async IAsyncEnumerable<SseItem<string>> Subscribe([EnumeratorCancellation] CancellationToken cancelToken)
         {
-            var channel = Channel.CreateUnbounded<(string, object)>();
+            var channel = Channel.CreateUnbounded<(string, string)>();
             var id = Guid.NewGuid();
             _operationStreamSubscribers[id] = channel;
 
@@ -130,7 +137,7 @@ public class OrderManagementController : ControllerBase
             {
                 await foreach (var evt in channel.Reader.ReadAllAsync(cancelToken))
                 {
-                    yield return new SseItem<object>(evt.Item2, eventType: evt.Item1);
+                    yield return new SseItem<string>(evt.Item2, eventType: evt.Item1);
                 }
             }
             finally
@@ -140,11 +147,11 @@ public class OrderManagementController : ControllerBase
         }
 
         // Local helper to broadcast events to all connected clients
-        static void Broadcast(string eventType, object model)
+        static void Broadcast(string eventType, object data)
         {
             foreach (var channel in _operationStreamSubscribers.Values)
             {
-                channel.Writer.TryWrite((eventType, model));
+                channel.Writer.TryWrite((eventType, JsonSerializer.Serialize(data, _serializerOptions)));
             }
         }
     }

--- a/src/Moryx.VisualInstructions.Endpoints/VisualInstructionsController.cs
+++ b/src/Moryx.VisualInstructions.Endpoints/VisualInstructionsController.cs
@@ -3,6 +3,8 @@
 
 using System.Collections.Concurrent;
 using System.Runtime.CompilerServices;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using System.Threading.Channels;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
@@ -22,7 +24,12 @@ public class VisualInstructionsController : ControllerBase
     private const string CookieName = "moryx-client-identifier";
     private readonly IVisualInstructions _visualInstructions;
 
-    private static readonly ConcurrentDictionary<Guid, (string Identifier, Channel<InstructionModel[]> Channel)> _instructionStreamSubscribers = new();
+    private static readonly ConcurrentDictionary<Guid, (string Identifier, Channel<string> Channel)> _instructionStreamSubscribers = new();
+    private static readonly JsonSerializerOptions _serializerOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        Converters = { new JsonStringEnumConverter() }
+    };
 
     public VisualInstructionsController(IVisualInstructions visualInstructions)
         => _visualInstructions = visualInstructions;
@@ -63,15 +70,15 @@ public class VisualInstructionsController : ControllerBase
 
         return;
 
-        async IAsyncEnumerable<InstructionModel[]> Subscribe([EnumeratorCancellation] CancellationToken cancelToken)
+        async IAsyncEnumerable<string> Subscribe([EnumeratorCancellation] CancellationToken cancelToken)
         {
-            var channel = Channel.CreateUnbounded<InstructionModel[]>();
+            var channel = Channel.CreateUnbounded<string>();
             var id = Guid.NewGuid();
             _instructionStreamSubscribers[id] = (identifier, channel);
 
-            // Send initial instruction set as first item
+            // Send all instructions as first item
             var initialInstructions = _visualInstructions.GetInstructions(identifier).Select(Converter.ToModel).ToArray();
-            yield return initialInstructions;
+            yield return JsonSerializer.Serialize(initialInstructions, _serializerOptions);
 
             try
             {
@@ -95,7 +102,7 @@ public class VisualInstructionsController : ControllerBase
             {
                 if (clientIdentifier == targetIdentifier)
                 {
-                    channel.Writer.TryWrite(instructions);
+                    channel.Writer.TryWrite(JsonSerializer.Serialize(instructions, _serializerOptions));
                 }
             }
         }

--- a/src/Moryx.VisualInstructions.Endpoints/VisualInstructionsController.cs
+++ b/src/Moryx.VisualInstructions.Endpoints/VisualInstructionsController.cs
@@ -1,13 +1,13 @@
 // Copyright (c) 2026 Phoenix Contact GmbH & Co. KG
 // Licensed under the Apache License, Version 2.0
 
+using System.Collections.Concurrent;
+using System.Runtime.CompilerServices;
 using System.Threading.Channels;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Moryx.Serialization;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Serialization;
 
 namespace Moryx.VisualInstructions.Endpoints;
 
@@ -22,15 +22,7 @@ public class VisualInstructionsController : ControllerBase
     private const string CookieName = "moryx-client-identifier";
     private readonly IVisualInstructions _visualInstructions;
 
-    private static readonly JsonSerializerSettings _serializerSettings = CreateSerializerSettings();
-
-    private static JsonSerializerSettings CreateSerializerSettings()
-    {
-        var serializerSettings = new JsonSerializerSettings();
-        serializerSettings.ContractResolver = new CamelCasePropertyNamesContractResolver();
-        serializerSettings.Converters.Add(new Newtonsoft.Json.Converters.StringEnumConverter());
-        return serializerSettings;
-    }
+    private static readonly ConcurrentDictionary<Guid, (string Identifier, Channel<InstructionModel[]> Channel)> _instructionStreamSubscribers = new();
 
     public VisualInstructionsController(IVisualInstructions visualInstructions)
         => _visualInstructions = visualInstructions;
@@ -41,71 +33,72 @@ public class VisualInstructionsController : ControllerBase
     [Authorize(Policy = VisualInstructionsPermissions.CanView)]
     public async Task InstructionStream(CancellationToken cancellationToken)
     {
-        var response = Response;
-        response.Headers.Add("Content-Type", "text/event-stream");
-
         // Read identifier cookie
         var identifier = Request.Cookies[CookieName];
         if (identifier == null)
         {
-            await response.CompleteAsync();
             BadRequest($"The expected cookie {CookieName} was not send. Make sure the cookie is sent and try again.");
             return;
         }
 
-        var instructionSetChannel = Channel.CreateUnbounded<string>();
-
-        // Define event handling
-        var eventHandler = new EventHandler<InstructionEventArgs>((_, eventArgs) =>
-        {
-            if (eventArgs.Identifier != identifier)
-            {
-                return;
-            }
-
-            WriteIdentifiers(identifier, instructionSetChannel);
-        });
-        _visualInstructions.InstructionAdded += eventHandler;
-        _visualInstructions.InstructionCleared += eventHandler;
+        // Define event handlers using the broadcast helper
+        var eventHandler = new EventHandler<InstructionEventArgs>((_, e) =>
+            Broadcast(e.Identifier));
 
         try
         {
-            // Send initial instruction set via stream
-            WriteIdentifiers(identifier, instructionSetChannel);
+            var result = TypedResults.ServerSentEvents(Subscribe(cancellationToken));
 
-            // Create infinite loop awaiting changes or cancellation
-            while (!cancellationToken.IsCancellationRequested)
-            {
-                var changes = await instructionSetChannel.Reader.ReadAsync(cancellationToken);
-                await response.WriteAsync($"data: {changes}\r\r", cancellationToken);
-            }
-        }
-        catch (OperationCanceledException)
-        {
-        }
-        catch (ChannelClosedException)
-        {
-        }
-        catch (InvalidOperationException)
-        {
+            // Register event handlers after result creation but before execution to ensure finally cleanup
+            _visualInstructions.InstructionAdded += eventHandler;
+            _visualInstructions.InstructionCleared += eventHandler;
+
+            await result.ExecuteAsync(HttpContext);
         }
         finally
         {
-            // Unregister handler from facade
             _visualInstructions.InstructionAdded -= eventHandler;
             _visualInstructions.InstructionCleared -= eventHandler;
-
-            instructionSetChannel.Writer.TryComplete();
         }
 
-        await response.CompleteAsync();
-    }
+        return;
 
-    private void WriteIdentifiers(string identifier, Channel<string> instructionSetChannel)
-    {
-        var instructions = _visualInstructions.GetInstructions(identifier).Select(Converter.ToModel);
-        var json = JsonConvert.SerializeObject(instructions, _serializerSettings);
-        instructionSetChannel.Writer.TryWrite(json);
+        async IAsyncEnumerable<InstructionModel[]> Subscribe([EnumeratorCancellation] CancellationToken cancelToken)
+        {
+            var channel = Channel.CreateUnbounded<InstructionModel[]>();
+            var id = Guid.NewGuid();
+            _instructionStreamSubscribers[id] = (identifier, channel);
+
+            // Send initial instruction set as first item
+            var initialInstructions = _visualInstructions.GetInstructions(identifier).Select(Converter.ToModel).ToArray();
+            yield return initialInstructions;
+
+            try
+            {
+                await foreach (var data in channel.Reader.ReadAllAsync(cancelToken))
+                {
+                    yield return data;
+                }
+            }
+            finally
+            {
+                _instructionStreamSubscribers.TryRemove(id, out _);
+            }
+        }
+
+        // Local helper to broadcast instruction changes to all matching subscribers
+        void Broadcast(string targetIdentifier)
+        {
+            var instructions = _visualInstructions.GetInstructions(targetIdentifier).Select(Converter.ToModel).ToArray();
+
+            foreach (var (clientIdentifier, channel) in _instructionStreamSubscribers.Values)
+            {
+                if (clientIdentifier == targetIdentifier)
+                {
+                    channel.Writer.TryWrite(instructions);
+                }
+            }
+        }
     }
 
     [HttpGet("{identifier}")]

--- a/src/Tests/Moryx.FactoryMonitor.Endpoints.Tests/FactoryMonitorController_StateTest.cs
+++ b/src/Tests/Moryx.FactoryMonitor.Endpoints.Tests/FactoryMonitorController_StateTest.cs
@@ -1,6 +1,7 @@
 // Copyright (c) 2026 Phoenix Contact GmbH & Co. KG
 // Licensed under the Apache License, Version 2.0
 
+using System;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Moq;
@@ -8,23 +9,29 @@ using Moryx.AbstractionLayer.Capabilities;
 using Moryx.ControlSystem.Cells;
 using Moryx.ControlSystem.Processes;
 using Moryx.FactoryMonitor.Endpoints.Models;
-using Newtonsoft.Json;
 using NUnit.Framework;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
 using Moryx.AbstractionLayer.Activities;
 using Moryx.AbstractionLayer.Processes;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Moryx.FactoryMonitor.Endpoints.Tests;
 
 [TestFixture]
-
 public class FactoryMonitorController_StateStreamTest : BaseTest
 {
+    private static readonly JsonSerializerOptions _serializerOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        Converters = { new JsonStringEnumConverter() }
+    };
 
     [SetUp]
     public override void Setup()
@@ -80,7 +87,7 @@ public class FactoryMonitorController_StateStreamTest : BaseTest
     }
 
     [Test]
-    public void FactoryStatesStream()
+    public async Task FactoryStatesStream()
     {
         //Arrange
         var source = new CancellationTokenSource();
@@ -104,21 +111,28 @@ public class FactoryMonitorController_StateStreamTest : BaseTest
 
         _factoryMonitor.ControllerContext = new ControllerContext();
         _factoryMonitor.ControllerContext.HttpContext = new DefaultHttpContext();
+        _factoryMonitor.ControllerContext.HttpContext.RequestServices = new ServiceCollection()
+            .Configure<Microsoft.AspNetCore.Http.Json.JsonOptions>(o =>
+            {
+                o.SerializerOptions.PropertyNamingPolicy = _serializerOptions.PropertyNamingPolicy;
+                foreach (var c in _serializerOptions.Converters)
+                    o.SerializerOptions.Converters.Add(c);
+            })
+            .BuildServiceProvider();
+
         _factoryMonitor.ControllerContext.HttpContext.Response.Body = memoryStream;
 
         _processFacadeMock.Setup(pm => pm.Targets(It.IsAny<Process>()))
             .Returns<Process>(p => _activityTargets.Where(pair => pair.Key.Process == p).SelectMany(pair => pair.Value).ToList());
         _processFacadeMock.Setup(pm => pm.GetRunningProcesses()).Returns([process]);
-        //Act
 
-        Task.Run(async () =>
-        {
-            await _factoryMonitor.FactoryStatesStream(cancellationToken);
-        });
+        // Act — event handlers and the channel subscriber are set up synchronously before
+        // FactoryStatesStream suspends at its first await
+        var streamTask = _factoryMonitor.FactoryStatesStream(cancellationToken);
 
         //assembly activity
-        StartFirstActivity(process, assemblyActivity);
-        Thread.Sleep(500);
+        await StartFirstActivityAsync(process, assemblyActivity);
+        await Task.Delay(500);
         ReadJsonData(memoryStream, streamResponseCells, streamResponseOrders, streamResponseActivities);
 
         // Assert
@@ -127,24 +141,24 @@ public class FactoryMonitorController_StateStreamTest : BaseTest
 
         //Assert part 1
         RaiseActivityUpdated(assemblyActivity, ActivityProgress.Completed);
-        Thread.Sleep(500);
+        await Task.Delay(500);
         ReadJsonData(memoryStream, streamResponseCells, streamResponseOrders, streamResponseActivities);
 
         //verify that the assembly cell is idle
         Assert.That(streamResponseCells.LastOrDefault(x => x.Id == _assemblyCellId)?.State,
             Is.EqualTo(CellState.Idle));
 
-        StartSecondActivity(process, solderingActivity);
-        Thread.Sleep(500);
+        await StartSecondActivityAsync(process, solderingActivity);
+        await Task.Delay(500);
         ReadJsonData(memoryStream, streamResponseCells, streamResponseOrders, streamResponseActivities);
 
         //Assert part 2
         //verify that the soldering cell is running
-        Assert.That(streamResponseCells.LastOrDefault(x => x.Id == _solderingCellId)?.State
-            , Is.EqualTo(CellState.Running));
+        Assert.That(streamResponseCells.LastOrDefault(x => x.Id == _solderingCellId)?.State,
+            Is.EqualTo(CellState.Running));
 
         RaiseActivityUpdated(solderingActivity, ActivityProgress.Completed);
-        Thread.Sleep(500);
+        await Task.Delay(500);
         ReadJsonData(memoryStream, streamResponseCells, streamResponseOrders, streamResponseActivities);
 
         //verify that the soldering cell is not running
@@ -153,74 +167,97 @@ public class FactoryMonitorController_StateStreamTest : BaseTest
 
         // end of the process
         RaiseProcessUpdated(process, ProcessProgress.Completed);
-        Thread.Sleep(500);
+        await Task.Delay(500);
         ReadJsonData(memoryStream, streamResponseCells, streamResponseOrders, streamResponseActivities);
 
         //Assert part 3
         _solderingCell.ChangeCapabilities(NullCapabilities.Instance);
-        Thread.Sleep(500);
+        await Task.Delay(500);
         ReadJsonData(memoryStream, streamResponseCells, streamResponseOrders, streamResponseActivities);
 
         Assert.That(streamResponseCells.LastOrDefault(x => x.Id == _solderingCellId)?.State, Is.EqualTo(CellState.NotReadyToWork));
 
-        //cancel/stop the request task
-        memoryStream.Close();
+        // Cleanup
+        // Cancel first — the channel's ReadAllAsync then throws OperationCanceledException cleanly.
+        // Await the task so the controller's finally block finishes before the test returns.
         source.Cancel();
+        try
+        {
+            await streamTask;
+        }
+        catch (OperationCanceledException)
+        {
+        }
     }
 
-    private void ReadJsonData(MemoryStream memoryStream, List<CellStateChangedModel> cells, List<OrderModel> orders, List<ActivityChangedModel> activities)
+    private static void ReadJsonData(MemoryStream memoryStream, List<CellStateChangedModel> cells, List<OrderModel> orders, List<ActivityChangedModel> activities)
     {
-        var jsonData = Encoding.UTF8.GetString(memoryStream.ToArray());
-        if (string.IsNullOrEmpty(jsonData)) return;
-
-        var array = jsonData.Split("type: ").ToList();
-        foreach (var item in array)
+        var text = Encoding.UTF8.GetString(memoryStream.ToArray());
+        if (string.IsNullOrEmpty(text))
         {
-            if (item.Contains("cellStateChangedModel"))
+            return;
+        }
+
+        // SSE events are delimited by blank lines
+        foreach (var block in text.Split(["\n\n", "\r\n\r\n"], StringSplitOptions.RemoveEmptyEntries))
+        {
+            string eventType = null;
+            string data = null;
+
+            foreach (var line in block.Split(["\r\n", "\n"], StringSplitOptions.RemoveEmptyEntries))
             {
-                //clean up remove "cells" and "data:" text
-                var content = item.Replace("cellStateChangedModel", "").Replace("data: ", "");
-                if (!string.IsNullOrEmpty(content))
-                    cells.Add(JsonConvert.DeserializeObject<CellStateChangedModel>(content));
+                if (line.StartsWith("event: "))
+                {
+                    eventType = line["event: ".Length..];
+                }
+                else if (line.StartsWith("data: "))
+                {
+                    data = line["data: ".Length..];
+                }
             }
-            else if (item.Contains("activityChangedModel"))
+
+            if (data == null)
             {
-                //clean up, remove "processes" and "data:" text
-                var content = item.Replace("activityChangedModel", "").Replace("data: ", "");
-                if (!string.IsNullOrEmpty(content))
-                    activities.Add(JsonConvert.DeserializeObject<ActivityChangedModel>(content));
+                continue;
             }
-            else if (item.Contains("process"))
+
+            switch (eventType)
             {
-                //clean up, remove "processes" and "data:" text
-                var content = item.Replace("process", "").Replace("data: ", "");
-                if (!string.IsNullOrEmpty(content))
-                    orders.AddRange(JsonConvert.DeserializeObject<List<OrderModel>>(content));
+                case "cellStateChangedModel":
+                    cells.Add(JsonSerializer.Deserialize<CellStateChangedModel>(data, _serializerOptions));
+                    break;
+                case "activityChangedModel":
+                    activities.Add(JsonSerializer.Deserialize<ActivityChangedModel>(data, _serializerOptions));
+                    break;
+                case "processes":
+                    var order = JsonSerializer.Deserialize<OrderModel>(data, _serializerOptions);
+                    if (order != null) orders.Add(order);
+                    break;
+                // resourceChangedModel is intentionally ignored in these tests
             }
         }
     }
 
-    private void StartSecondActivity(Process process, SolderingActivity mySecondActivity)
+    private async Task StartSecondActivityAsync(Process process, SolderingActivity mySecondActivity)
     {
-
         // ---------------------second activity
         AssignActivity(process, mySecondActivity, _solderingCell);
         RaiseActivityUpdated(mySecondActivity, ActivityProgress.Ready);
 
-        Thread.Sleep(200);
-        //activity updated
+        await Task.Delay(200);
+
         RaiseActivityUpdated(mySecondActivity, ActivityProgress.Running);
         RaiseProcessUpdated(process, ProcessProgress.Running);
     }
 
-    private void StartFirstActivity(Process process, AssemblyActivity myFirstActivity)
+    private async Task StartFirstActivityAsync(Process process, AssemblyActivity myFirstActivity)
     {
         // ----------- First activity
         AssignActivity(process, myFirstActivity, _assemblyCell);
         RaiseProcessUpdated(process, ProcessProgress.Ready);
         RaiseActivityUpdated(myFirstActivity, ActivityProgress.Ready);
 
-        Thread.Sleep(200);
+        await Task.Delay(200);
 
         RaiseActivityUpdated(myFirstActivity, ActivityProgress.Running);
         RaiseProcessUpdated(process, ProcessProgress.Running);


### PR DESCRIPTION
- [x] all event streams are using TypedResults.ServerSentEvents
- [x] all manual serialization with newtonsoft are replaced by System.Text.Json (also manual). Rollback in MORYX12: https://github.com/PHOENIXCONTACT/MORYX-Framework/issues/1233
- [x] manual tests of all services in UI