### PR TITLE
Fix styling for the Launcher right region

### DIFF
--- a/src/Moryx.Launcher/Pages/Shared/_Layout.cshtml
+++ b/src/Moryx.Launcher/Pages/Shared/_Layout.cshtml
@@ -166,20 +166,25 @@
                 </aside>
             }
         }
-        <div class="tw-flex-1 tw-flex tw-h-full tw-w-full tw-box-border tw-overflow-auto tw-flex-col" main>
-            @Html.Partial("AboutModal")
+        <div class="tw-flex tw-h-full tw-w-full tw-box-border tw-overflow-hidden tw-flex-row" main>
+            <div class="tw-flex-1 tw-flex tw-h-full tw-box-border tw-overflow-hidden tw-flex-col">
+                @Html.Partial("AboutModal")
 
-            @if (shouldShowNotificationBar)
-            {
-                <moryx-notifications-bar api="@(Url.Content("~/api/moryx/notifications/stream"))">@Strings.Layout_Details</moryx-notifications-bar>
-            }
+                @if (shouldShowNotificationBar)
+                {
+                    <moryx-notifications-bar api="@(Url.Content("~/api/moryx/notifications/stream"))">
+                        @Strings.Layout_Details
+                    </moryx-notifications-bar>
+                }
 
-            <div class="tw-overflow-hidden tw-h-screen tw-w-full tw-box-border">
-                @RenderBody()
+                <div class="tw-overflow-hidden tw-h-screen tw-w-full tw-box-border">
+                    @RenderBody()
+                </div>
             </div>
+            
             @if (_navigator is ILauncher launcher && launcher.GetRegion(LauncherRegion.Right) is RegionItem rightRegion)
             {
-                <aside class="tw-flex-initial tw-overflow-hidden">@await Html.PartialAsync(rightRegion.PartialView)</aside>
+                <aside class="tw-h-full tw-box-border tw-overflow-hidden">@await Html.PartialAsync(rightRegion.PartialView)</aside>
             }
         </div>
         <div class="tw-w-full tw-py-[8px] tw-h-[48px] tw-box-content tw-flex tw-items-center tw-justify-around tw-shadow-md tw-bg-white tw-drop-shadow" id="launcher-bottom-nav-bar" bottombar>

--- a/src/Moryx.Launcher/app/.npmrc
+++ b/src/Moryx.Launcher/app/.npmrc
@@ -1,2 +1,0 @@
-registry=https://registry.npmjs.org/
-strict-ssl=false


### PR DESCRIPTION
While removing a div in #1212 we accidently broke the launchers layout. This is reverted and fixed.

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/f99fa3aa-292d-499d-bbfd-ad811533d8eb" />
