### PR TITLE
Fix several issues in the factory monitor module

### DIFF
--- a/src/Moryx.FactoryMonitor.Endpoints/Extensions/CellExtensions.cs
+++ b/src/Moryx.FactoryMonitor.Endpoints/Extensions/CellExtensions.cs
@@ -29,8 +29,10 @@ internal static class CellExtensions
                 .GetResources(cellFilter)
                 .FirstOrDefault(x => x.Machine?.Id == cell.Id);
             resourceChangedCellModel.Location = Converter.Converter.ToCellLocationModel(machineLocation);
+            resourceChangedCellModel.CellLocation = resourceChangedCellModel.Location;
             resourceChangedCellModel.CellImageURL = machineLocation.Image;
             resourceChangedCellModel.IconName = machineLocation.SpecificIcon;
+            resourceChangedCellModel.CellIconName = resourceChangedCellModel.IconName;
             resourceChangedCellModel.FactoryId = GetFactoryId(cell, resourceManager);
 
             return resourceChangedCellModel;

--- a/src/Moryx.FactoryMonitor.Endpoints/Extensions/FactoryMonitorHelper.cs
+++ b/src/Moryx.FactoryMonitor.Endpoints/Extensions/FactoryMonitorHelper.cs
@@ -18,11 +18,10 @@ internal static class FactoryMonitorHelper
     private const string Activity_Event_Type_Key = "activityChangedModel";
     private const string Recource_Event_Type_Key = "resourceChangedModel";
 
-    public static void OrderStarted(OperationStartedEventArgs orderEventArg, Action<string, object> broadcast)
+    public static void OrderStarted(OperationStartedEventArgs orderEventArg, List<OrderModel> models, Action<string, object> broadcast)
     {
-        var orderModel = Converter.Converter.ToOrderModel(orderEventArg.Operation);
+        var orderModel = models.Single(o => o.Order == orderEventArg.Operation.Order.Number && o.Operation == orderEventArg.Operation.Number);
         broadcast(Order_Event_Type_Key, orderModel);
-
     }
 
     public static void OrderUpdated(OperationChangedEventArgs orderEventArg, Action<string, object> broadcast)

--- a/src/Moryx.FactoryMonitor.Endpoints/Extensions/FactoryMonitorHelper.cs
+++ b/src/Moryx.FactoryMonitor.Endpoints/Extensions/FactoryMonitorHelper.cs
@@ -7,30 +7,38 @@ using Moryx.ControlSystem.Processes;
 using Moryx.Factory;
 using Moryx.FactoryMonitor.Endpoints.Models;
 using Moryx.Orders;
-using Newtonsoft.Json;
 
 namespace Moryx.FactoryMonitor.Endpoints.Extensions;
 
 internal static class FactoryMonitorHelper
 {
+    private const string Order_Event_Type_Key = "order";
+    private const string Order_Changed_Event_Type_Key = "orderChanged";
+    private const string Cell_State_Event_Type_Key = "cellStateChangedModel";
+    private const string Activity_Event_Type_Key = "activityChangedModel";
+    private const string Recource_Event_Type_Key = "resourceChangedModel";
+
     public static void OrderStarted(OperationStartedEventArgs orderEventArg, Action<string, object> broadcast)
     {
         var orderModel = Converter.Converter.ToOrderModel(orderEventArg.Operation);
-        broadcast("processes", orderModel);
+        broadcast(Order_Event_Type_Key, orderModel);
 
     }
 
     public static void OrderUpdated(OperationChangedEventArgs orderEventArg, Action<string, object> broadcast)
     {
-        if (orderEventArg.Operation.State is not OperationStateClassification.Running) return;
+        if (orderEventArg.Operation.State is not OperationStateClassification.Running)
+        {
+            return;
+        }
 
         var orderReferenceModel = Converter.Converter.ToOrderChangedModel(orderEventArg.Operation);
-        broadcast("processes", orderReferenceModel);
+        broadcast(Order_Changed_Event_Type_Key, orderReferenceModel);
     }
 
     public static void PublishCellUpdate(CellStateChangedModel cellModel, Action<string, object> broadcast)
     {
-        broadcast("cellStateChangedModel", cellModel);
+        broadcast(Cell_State_Event_Type_Key, cellModel);
     }
 
     public static void ActivityUpdated(ActivityUpdatedEventArgs activityEventArg, List<ICell> cells, Resource resource,
@@ -46,17 +54,16 @@ internal static class FactoryMonitorHelper
             return;
         }
 
-        var cell = resource as ICell;
-        if (cell == null)
+        if (resource is not ICell cell)
         {
             return;
         }
 
         var activityChangedModel = cell.GetActivityChangedModel(activityEventArg.Activity, orderModels);
-        broadcast("activityChangedModel", activityChangedModel);
+        broadcast(Activity_Event_Type_Key, activityChangedModel);
 
         var cellStateChangedModel = cell.GetCellStateChangedModel(activityEventArg.Progress, resource);
-        broadcast("cellStateChangedModel", cellStateChangedModel);
+        broadcast(Cell_State_Event_Type_Key, cellStateChangedModel);
     }
 
     public static void ResourceUpdated(IResourceManagement resourceManager,
@@ -69,7 +76,7 @@ internal static class FactoryMonitorHelper
         foreach (var cell in cells)
         {
             var resourceChangedModel = cell.GetResourceChangedModel(converter, resourceManager, cellFilter);
-            broadcast("resourceChangedModel", resourceChangedModel);
+            broadcast(Recource_Event_Type_Key, resourceChangedModel);
         }
     }
 

--- a/src/Moryx.FactoryMonitor.Endpoints/FactoryMonitorController.cs
+++ b/src/Moryx.FactoryMonitor.Endpoints/FactoryMonitorController.cs
@@ -143,6 +143,7 @@ public class FactoryMonitorController : ControllerBase
         var converter = new Converter.Converter(_serialization);
 
         var root = _resourceManager.GetRootFactory();
+        // ToDo: Cannot assume ManufacturingFactory base class
         var graph = _resourceManager.ReadUnsafe(factory.Id, e => SimpleGraph.Create(e as ManufacturingFactory));
 
         //root level (Factory)

--- a/src/Moryx.FactoryMonitor.Endpoints/FactoryMonitorController.cs
+++ b/src/Moryx.FactoryMonitor.Endpoints/FactoryMonitorController.cs
@@ -69,14 +69,15 @@ public class FactoryMonitorController : ControllerBase
     [HttpGet("state")]
     public ActionResult<FactoryStateModel> InitialFactoryState()
     {
-        var locations = _resourceManager.GetResources<IMachineLocation>();
-        var cells = locations.Where(CellFilterBaseOnLocation)
-            .Select(l => l.Machine)
-            .Cast<ICell>().ToList();
         var activityChangedModels = new List<ActivityChangedModel>();
         var cellStateChangedModels = new List<CellStateChangedModel>();
         var resourceChangedModels = new List<ResourceChangedModel>();
 
+        var locations = _resourceManager.GetResources<IMachineLocation>();
+        var cells = locations.Where(CellFilterBaseOnLocation)
+            .Select(l => l.Machine)
+            .Cast<ICell>().ToList();
+        var orders = _orderManager.GetOrderModels(_colorPalette).OrderBy(x => x.Order).ThenBy(x => x.Operation).ToList();
         var activities = _processControl.GetRunningProcesses()
             .Select(p => p.CurrentActivity())
             .Where(a => a is not null && a.Tracing is not null);
@@ -88,7 +89,7 @@ public class FactoryMonitorController : ControllerBase
             {
                 var activity = activities.FirstOrDefault(a => a.Tracing.ResourceId == cell.Id);
                 //to-do: handle multiple activities in one cell
-                activityChangedModels.Add(cell.GetActivityChangedModel(activity, _orderManager.GetOrderModels(_colorPalette)));
+                activityChangedModels.Add(cell.GetActivityChangedModel(activity, orders));
                 cellStateChangedModels.Add(cell.GetCellStateChangedModel(ActivityProgress.Running, _resourceManager.ReadUnsafe(cell.Id, r => r)));
             }
             else
@@ -98,10 +99,9 @@ public class FactoryMonitorController : ControllerBase
             resourceChangedModels.Add(cell.GetResourceChangedModel(converter, _resourceManager, CellFilterBaseOnLocation));
         }
 
-        activityChangedModels = activityChangedModels.OrderBy(x => x.ResourceId).ToList();
-        cellStateChangedModels = cellStateChangedModels.OrderBy(x => x.Id).ToList();
-        resourceChangedModels = resourceChangedModels.OrderBy(x => x.Id).ToList();
-        var orderModels = _orderManager.GetOrderModels(_colorPalette).OrderBy(x => x.Order).ThenBy(x => x.Operation).ToList();
+        activityChangedModels = [.. activityChangedModels.OrderBy(x => x.ResourceId)];
+        cellStateChangedModels = [.. cellStateChangedModels.OrderBy(x => x.Id)];
+        resourceChangedModels = [.. resourceChangedModels.OrderBy(x => x.Id)];
 
         var factory = _resourceManager.GetRootFactory();
 
@@ -109,7 +109,7 @@ public class FactoryMonitorController : ControllerBase
         model.ActivityChangedModels = activityChangedModels;
         model.CellStateChangedModels = cellStateChangedModels;
         model.ResourceChangedModels = resourceChangedModels;
-        model.OrderModels = orderModels;
+        model.OrderModels = orders;
 
         return model;
     }
@@ -238,7 +238,7 @@ public class FactoryMonitorController : ControllerBase
                 Broadcast));
 
         var orderStartedEventHandler = new EventHandler<OperationStartedEventArgs>((_, eventArgs) =>
-            FactoryMonitorHelper.OrderStarted(eventArgs, Broadcast));
+            FactoryMonitorHelper.OrderStarted(eventArgs, _orderManager.GetOrderModels(_colorPalette), Broadcast));
 
         var orderEventHandler = new EventHandler<OperationChangedEventArgs>((sender, eventArgs) =>
             FactoryMonitorHelper.OrderUpdated(eventArgs, Broadcast));

--- a/src/Moryx.FactoryMonitor.Endpoints/FactoryMonitorController.cs
+++ b/src/Moryx.FactoryMonitor.Endpoints/FactoryMonitorController.cs
@@ -114,6 +114,7 @@ public class FactoryMonitorController : ControllerBase
         return model;
     }
 
+    // Currently returns a list of all visualizable items and is not used, so remove or at least rename in MORYX 12
     /// <summary>
     /// List of all the cells
     /// </summary>
@@ -128,6 +129,7 @@ public class FactoryMonitorController : ControllerBase
         return cells.Select(x => new SimpleGraph { Id = x.Id }.ToVisualItemModel(_resourceManager, _logger, converter, CellFilterBaseOnLocation)).ToList();
     }
 
+    // ToDo: Endpoints usually return arrays and pagination would be good.
     /// <summary>
     /// Get the list of displayable item for this current factory view
     /// </summary>
@@ -144,7 +146,7 @@ public class FactoryMonitorController : ControllerBase
 
         var root = _resourceManager.GetRootFactory();
         // ToDo: Cannot assume ManufacturingFactory base class
-        var graph = _resourceManager.ReadUnsafe(factory.Id, e => SimpleGraph.Create(e as ManufacturingFactory));
+        var graph = _resourceManager.ReadUnsafe(factory.Id, SimpleGraph.Create);
 
         //root level (Factory)
         if (root.Id == factoryId)
@@ -314,6 +316,7 @@ public class FactoryMonitorController : ControllerBase
         }
     }
 
+    // ToDo: Rename to move location in MORYX 12 and 
     /// <summary>
     /// Return the location of the cell in the factory
     /// </summary>

--- a/src/Moryx.FactoryMonitor.Endpoints/Models/InternalOperationClassification.cs
+++ b/src/Moryx.FactoryMonitor.Endpoints/Models/InternalOperationClassification.cs
@@ -5,37 +5,53 @@ namespace Moryx.FactoryMonitor.Endpoints.Models;
 
 public enum InternalOperationClassification
 {
-    //
-    // Summary:
-    //     Classification during the creation
-    Initial,
-    //
-    // Summary:
-    //     Created operation and ready to start the production
-    Ready,
-    //
-    // Summary:
-    //     There is currently a working progress like the production or a reporting
-    Running,
-    //
-    // Summary:
-    //     The operation was interrupted but the production is currently running for the
-    //     last parts
-    Interrupting,
-    //
-    // Summary:
-    //     The operation reached the current amount or the user has interrupted the operation
-    Interrupted,
-    //
-    // Summary:
-    //     The operation was declared as finished and can not be started again
-    Completed,
-    //
-    // Summary:
-    //     This operation was declared as aborted and was never started.
-    Aborted,
-    //
-    // Summary:
-    //     This operation is not finished, but has reached the targeted amount (not equal total amount of the order)
-    AmountReached
+    /// <summary>
+    /// Classification during the creation
+    /// </summary>
+    Initial = 0,
+
+    /// <summary>
+    /// This operation is loading or reloading operation related information.
+    /// </summary>  
+    Assigning = 1,
+
+    /// <summary>
+    /// The operation failed in the creation process.
+    /// </summary>
+    Failed = 1 << 1,
+
+    /// <summary>
+    /// This operation was declared as aborted and was never started.
+    /// </summary>
+    Aborted = 1 << 2,
+
+    /// <summary>
+    /// Created operation and ready to start the production
+    /// </summary>
+    Ready = 1 << 3,
+
+    /// <summary>
+    /// There is currently a working progress like the production or a reporting
+    /// </summary>
+    Running = 1 << 4,
+
+    /// <summary>
+    /// The operation was interrupted but the production is currently running for the last parts
+    /// </summary>
+    Interrupting = 1 << 5,
+
+    /// <summary>
+    /// The operation reached the current amount or the user has interrupted the operation
+    /// </summary>
+    Interrupted = 1 << 6,
+
+    /// <summary>
+    /// The operation was declared as finished and can not be started again
+    /// </summary>
+    Completed = 1 << 7,
+
+    /// <summary>
+    /// This operation is not finished, but has reached the targeted amount (not equal total amount of the order)
+    /// </summary>
+    AmountReached = 1 << 8,
 }

--- a/src/Moryx.FactoryMonitor.Endpoints/Models/ResourceChangedModel.cs
+++ b/src/Moryx.FactoryMonitor.Endpoints/Models/ResourceChangedModel.cs
@@ -14,6 +14,7 @@ public class ResourceChangedModel : VisualizableItemModel
     [DataMember]
     public virtual string CellName { get; set; }
 
+    // ToDo: Verify why this is duplicated and not using the location of the visual item
     [DataMember]
     public virtual string CellIconName { get; set; }
 
@@ -23,6 +24,7 @@ public class ResourceChangedModel : VisualizableItemModel
     [DataMember]
     public long Id { get; set; }
 
+    // ToDo: Verify why this is duplicated and not using the location of the visual item
     [DataMember]
     public CellLocationModel CellLocation { get; set; }
 

--- a/src/Moryx.FactoryMonitor.Endpoints/Models/SimpleGraph.cs
+++ b/src/Moryx.FactoryMonitor.Endpoints/Models/SimpleGraph.cs
@@ -37,14 +37,17 @@ internal class SimpleGraph
     /// </summary>
     public static SimpleGraph Create(Resource resource)
     {
-        if (resource is not ManufacturingFactory factory) return null;
+        if (resource is not IManufacturingFactory factory)
+        {
+            return null;
+        }
 
         var graph = new SimpleGraph
         {
             Id = factory.Id,
-            Type = nameof(ManufacturingFactory)
+            Type = nameof(IManufacturingFactory)
         };
-        factory.Children.ForEach(graph.Append);
+        resource.Children.ForEach(graph.Append);
         return graph;
     }
 
@@ -61,7 +64,7 @@ internal class SimpleGraph
             }
 
             var resourcesAtThisLocation = resource.Children.Where(x => x is ICell || x is IManufacturingFactory).ToArray();
-            if(resource is ICell)
+            if(resource is ICell || resource is IManufacturingFactory)
             {
                 resourcesAtThisLocation = [resource];
             }
@@ -83,16 +86,16 @@ internal class SimpleGraph
 
             switch (resourceAtThisLocation)
             {
-                case IManufacturingFactory factory:
-                    model = Converter.Converter.ToFactoryStateModel(factory);
-                    break;
                 case ICell cell:
                     model = cell.GetResourceChangedModel(converter, resourceManager, filter);
                     model.IsACell = true;
                     break;
+                case IManufacturingFactory factory:
+                    model = Converter.Converter.ToFactoryStateModel(factory);
+                    break;
             }
             model.IconName = machineLocation.SpecificIcon;
-            model.Id = resourceAtThisLocation?.Id ?? 0;
+            model.Id = resourceAtThisLocation.Id;
             model.Location = Converter.Converter.ToCellLocationModel(machineLocation);
             return model;
         });
@@ -102,13 +105,18 @@ internal class SimpleGraph
 
     public SimpleGraph GetSubGraphById(long id)
     {
-        if (Type == nameof(ManufacturingFactory) && Id == id) return this;
+        if (Type == nameof(IManufacturingFactory) && Id == id)
+        {
+            return this;
+        }
 
         foreach (var child in Children)
         {
             var result = child.GetSubGraphById(id);
             if (result is not null)
+            {
                 return result;
+            }
         }
         return null;
     }
@@ -117,14 +125,14 @@ internal class SimpleGraph
     {
         switch (addition)
         {
-            case MachineLocation:
-            case ManufacturingFactory:
-            case Cell:
+            case IMachineLocation:
+            case IManufacturingFactory:
+            case ICell:
                 AddSubGraph(addition);
                 return;
 
-            case MachineGroup group:
-                group.Children?.ForEach(Append);
+            case IMachineGroup group:
+                addition.Children?.ForEach(Append);
                 return;
         }
     }
@@ -137,8 +145,10 @@ internal class SimpleGraph
             Type = addition.GetType().Name
         };
 
-        if (addition is not Cell)
+        if (addition is not ICell)
+        {
             addition.Children.ForEach(subGraph.Append);
+        }
 
         Children.Add(subGraph);
     }

--- a/src/Moryx.FactoryMonitor.Web/app/src/app/app.config.ts
+++ b/src/Moryx.FactoryMonitor.Web/app/src/app/app.config.ts
@@ -3,31 +3,33 @@
  * Licensed under the Apache License, Version 2.0
 */
 
+import { DragDropModule } from '@angular/cdk/drag-drop';
 import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
-import { ApplicationConfig, importProvidersFrom } from '@angular/core';
+import { ApplicationConfig, importProvidersFrom, inject, provideAppInitializer } from '@angular/core';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { MatButtonModule } from '@angular/material/button';
 import { MatDialogModule } from '@angular/material/dialog';
-import { MatInputModule } from '@angular/material/input';
 import { MatIconModule } from '@angular/material/icon';
+import { MatInputModule } from '@angular/material/input';
 import { MatListModule } from '@angular/material/list';
-import { MatTooltipModule } from '@angular/material/tooltip';
 import { MatSnackBarModule } from '@angular/material/snack-bar';
+import { MatTooltipModule } from '@angular/material/tooltip';
 import { BrowserModule } from '@angular/platform-browser';
 import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
+import { provideRouter } from '@angular/router';
+import { provideTranslateService } from '@ngx-translate/core';
+import { provideTranslateHttpLoader } from '@ngx-translate/http-loader';
+import { firstValueFrom } from 'rxjs';
 import { environment } from 'src/environments/environment';
 import { ApiModule } from './api/api.module';
+import { FactoryMonitorService } from './api/services';
+import { routes } from './app.routes';
 import { CellSettingsService } from './services/cell-settings.service';
 import { CellStoreService } from './services/cell-store.service';
 import { ChangeBackgroundService } from './services/change-background.service';
 import { EditMenuService } from './services/edit-menu.service';
+import { FactorySelectionService } from './services/factory-selection.service';
 import { OrderStoreService } from './services/order-store.service';
-import { provideRouter } from '@angular/router';
-import { routes } from './app.routes';
-import { DragDropModule } from '@angular/cdk/drag-drop';
-
-import { provideTranslateService } from '@ngx-translate/core';
-import { provideTranslateHttpLoader } from '@ngx-translate/http-loader';
 
 export const appConfig: ApplicationConfig = {
   providers: [
@@ -60,5 +62,20 @@ export const appConfig: ApplicationConfig = {
       fallbackLang: 'en'
     }),
     provideAnimationsAsync(),
+    provideAppInitializer(async () => {
+      const api = inject(FactoryMonitorService);
+      const orderStore = inject(OrderStoreService);
+      const cellStore = inject(CellStoreService);
+      const factorySelectionService = inject(FactorySelectionService);
+      
+      // ToDo: Error Handling
+      const initialState = await firstValueFrom(api.initialFactoryState());
+
+      orderStore.initialize(initialState);
+
+      cellStore.initialize(initialState);
+      
+      factorySelectionService.initialize(initialState);
+    }),
   ]
 };

--- a/src/Moryx.FactoryMonitor.Web/app/src/app/app.html
+++ b/src/Moryx.FactoryMonitor.Web/app/src/app/app.html
@@ -1,7 +1,7 @@
 <div
   class="main"
   [style]="{
-    'background-image': 'url(' + backgroundImage() + ')'
+    'background-image': backgroundImage()
   }">
   <div
     class="draggable-area"

--- a/src/Moryx.FactoryMonitor.Web/app/src/app/app.html
+++ b/src/Moryx.FactoryMonitor.Web/app/src/app/app.html
@@ -6,7 +6,7 @@
   <div
     class="draggable-area"
     [style]="{
-      'background-color': isEditMode ? ' rgb(253, 253, 253,0.4)' : 'transparent'
+      'background-color': isEditMode() ? ' rgb(253, 253, 253,0.4)' : 'transparent'
     }">
     <div class="left-items">
       <app-edit-menu></app-edit-menu>

--- a/src/Moryx.FactoryMonitor.Web/app/src/app/app.ts
+++ b/src/Moryx.FactoryMonitor.Web/app/src/app/app.ts
@@ -35,7 +35,11 @@ export class App {
   private cellStoreService = inject(CellStoreService);
 
   private editMenuState = toSignal(inject(EditMenuService).activeState$, { initialValue: EditMenuState.Closed });
-  backgroundImage = toSignal(inject(ChangeBackgroundService).backgroundChanged$, { initialValue: '' });
+  private background = toSignal(inject(ChangeBackgroundService).backgroundChanged$);
+  backgroundImage = computed(() => {
+    const bg = this.background();
+    return bg ? `url(${bg})` : 'none';
+  });
   isEditMode = computed(() => this.editMenuState() === EditMenuState.EditingCells);
 
   constructor() {

--- a/src/Moryx.FactoryMonitor.Web/app/src/app/app.ts
+++ b/src/Moryx.FactoryMonitor.Web/app/src/app/app.ts
@@ -3,7 +3,7 @@
  * Licensed under the Apache License, Version 2.0
 */
 
-import { Component, inject, OnInit, signal } from '@angular/core';
+import { Component, computed, inject, OnDestroy, OnInit, signal } from '@angular/core';
 import { EditMenuService } from './services/edit-menu.service';
 import { EditMenuState } from './services/EditMenutState';
 import { ChangeBackgroundService } from './services/change-background.service';
@@ -16,6 +16,7 @@ import { EditMenu } from './components/edit-menu/edit-menu';
 import { OrdersContainer } from './components/orders-container/orders-container';
 import { CellDetails } from './components/cell-details/cell-details';
 import { RouterOutlet } from '@angular/router';
+import { toSignal } from '@angular/core/rxjs-interop';
 
 @Component({
   selector: 'app-root',
@@ -28,21 +29,16 @@ import { RouterOutlet } from '@angular/router';
     RouterOutlet
   ]
 })
-export class App implements OnInit {
-  private editMenuService = inject(EditMenuService);
-  private backgroundService = inject(ChangeBackgroundService);
+export class App {
   private languageService = inject(LanguageService);
   private translateService = inject(TranslateService);
   private cellStoreService = inject(CellStoreService);
 
-  backgroundImage = signal<string>('');
-  private editMenuState !: EditMenuState;
+  private editMenuState = toSignal(inject(EditMenuService).activeState$, { initialValue: EditMenuState.Closed });
+  backgroundImage = toSignal(inject(ChangeBackgroundService).backgroundChanged$, { initialValue: '' });
+  isEditMode = computed(() => this.editMenuState() === EditMenuState.EditingCells);
 
   constructor() {
-    this.editMenuService.activeState$.subscribe({
-      next: state => this.editMenuState = state
-    });
-
     this.translateService.addLangs([
       TranslationConstants.LANGUAGES.EN,
       TranslationConstants.LANGUAGES.DE,
@@ -52,19 +48,8 @@ export class App implements OnInit {
     this.translateService.use(this.languageService.getDefaultLanguage());
   }
 
-  ngOnInit(): void {
-    this.backgroundService.backgroundChanged$.subscribe({
-      next: url => this.backgroundImage.update(_ => url)
-    });
-  }
-
   getCell(cellId: number): CellModel {
     const output = this.cellStoreService.getCell(cellId) ?? <CellModel>{};
     return output;
   }
-
-  get isEditMode() {
-    return this.editMenuState === EditMenuState.EditingCells;
-  }
 }
-

--- a/src/Moryx.FactoryMonitor.Web/app/src/app/components/cell/cell.html
+++ b/src/Moryx.FactoryMonitor.Web/app/src/app/components/cell/cell.html
@@ -1,11 +1,13 @@
+@let data = currentCell();
+
 <div
   #cell
   class="cell-container"
   [ngStyle]="{
     'border-color': borderColor(),
     background: backgroundColor(),
-    top: (currentCell()?.location?.positionY ?? 0) * 100 + '%',
-    left: (currentCell()?.location?.positionX ?? 0) * 100 + '%'
+    top: (data.location?.positionY ?? 0) * 100 + '%',
+    left: (data.location?.positionX ?? 0) * 100 + '%'
   }"
   cdkDrag
   cdkDragBoundary=".draggable-area"
@@ -13,6 +15,6 @@
   [cdkDragDisabled]="!isEditMode()"
   (click)="onCellClicked()">
   <mat-icon [ngStyle]="{ color: iconColor() }">{{
-    currentCell()?.iconName
+    data.iconName
   }}</mat-icon>
 </div>

--- a/src/Moryx.FactoryMonitor.Web/app/src/app/components/cell/cell.ts
+++ b/src/Moryx.FactoryMonitor.Web/app/src/app/components/cell/cell.ts
@@ -3,7 +3,7 @@
  * Licensed under the Apache License, Version 2.0
 */
 
-import { Component, OnInit, ElementRef, viewChild, input, computed, signal, effect, untracked, inject } from '@angular/core';
+import { Component, OnInit, OnDestroy, ElementRef, viewChild, input, computed, inject, linkedSignal } from '@angular/core';
 import { EditMenuState } from 'src/app/services/EditMenutState';
 import { CellStoreService } from 'src/app/services/cell-store.service';
 import { CellState } from '../../api/models/cell-state';
@@ -13,6 +13,9 @@ import { CdkDragEnd, DragDropModule } from '@angular/cdk/drag-drop';
 import CellModel from 'src/app/models/cellModel';
 import { CommonModule } from '@angular/common';
 import { MatIcon } from '@angular/material/icon';
+import { VisualizableItemModel } from 'src/app/api/models';
+import { toSignal } from '@angular/core/rxjs-interop';
+import { Subscription } from 'rxjs';
 
 @Component({
   selector: 'app-cell',
@@ -24,92 +27,84 @@ import { MatIcon } from '@angular/material/icon';
     DragDropModule
   ]
 })
-export class Cell implements OnInit {
+export class Cell implements OnInit, OnDestroy {
   private cellStoreService = inject(CellStoreService);
   private orderStoreService = inject(OrderStoreService);
   private editMenuService = inject(EditMenuService);
 
-  cellElement = viewChild<ElementRef<HTMLElement>>('cell');
-  container = input<ElementRef<HTMLElement>>();
-  parameters = input.required<CellModel>();
+  private subscriptions = new Subscription();
+
+  cellElement = viewChild.required<ElementRef<HTMLElement>>('cell');
+  container = input.required<ElementRef<HTMLElement>>();
+  parameters = input.required<VisualizableItemModel>();
   isEditMode = computed(() => this.editMenuState() === EditMenuState.EditingCells);
-  private editMenuState = signal<EditMenuState | undefined>(undefined);
-  currentCell = signal<CellModel | undefined>(undefined);
-  isHighlighted = signal<boolean>(true);
+  private editMenuState = toSignal(this.editMenuService.activeState$);
+  currentCell = linkedSignal<CellModel>(() => this.cellStoreService.getCell(this.parameters().id!));
+  private currentOrder = computed(() => {
+    const cell = this.currentCell();
+    if (!cell?.orderNumber || !cell.operationNumber) return null;
+    return this.orderStoreService.getOrder(cell.orderNumber, cell.operationNumber);
+  });
+  private currentOrderIsToggled = linkedSignal(() => !!this.currentOrder()?.isToggled);
+  isHighlighted = computed(() => {
+    const cell = this.currentCell();
+    return !!cell && cell.state == CellState.Running && !!cell.orderNumber && !!cell.operationNumber &&
+        this.currentOrderIsToggled();
+  });
   backgroundColor = computed(() =>
     this.currentCell()?.state === CellState.NotReadyToWork ? '#e46d6d' : 'white'
   );
   borderColor = computed(() => {
     const cell = this.currentCell();
-    if (this.isHighlighted() && this.currentCell()!.orderColor)
-      return this.currentCell()?.orderColor!;
-    if (this.currentCell()?.state === CellState.NotReadyToWork)
+    if (this.isHighlighted() && cell.orderColor)
+      return cell.orderColor!;
+    if (cell.state === CellState.NotReadyToWork)
       return '#e46d6d';
     return 'white';
   });
   iconColor = computed(() => {
-    if (this.isHighlighted() && this.currentCell()?.orderColor)
-      return this.currentCell()?.orderColor!;
-    if (this.currentCell()?.state === CellState.NotReadyToWork)
+    const cell = this.currentCell();
+    if (this.isHighlighted() && cell.orderColor)
+      return cell.orderColor!;
+    if (cell.state === CellState.NotReadyToWork)
       return 'white';
     return '#585858';
   });
 
-  constructor() {
-    effect(() => {
-      const parameters = this.parameters();
-      untracked(() => {
-        this.updateCell(parameters);
-      });
-    });
-  }
-
   ngOnInit(): void {
     // React to toggling of an order
-    this.orderStoreService.toggledOrder$.subscribe(o => {
-      if (this.currentCell()?.orderNumber !== o.orderNumber || this.currentCell()?.operationNumber !== o.operationNumber)
+    this.subscriptions.add(this.orderStoreService.toggledOrder$.subscribe(o => {
+      if (this.currentOrder()?.orderNumber !== o.orderNumber || this.currentOrder()?.operationNumber !== o.operationNumber)
         return;
-      this.isHighlighted.set(o.isToggled);
-    });
-
-    // Keep the menu state
-    this.editMenuService.activeState$.subscribe({
-      next: state => (this.editMenuState.set(state))
-    });
+      this.currentOrderIsToggled.set(o.isToggled);
+    }));
 
     // React to updates to the cell data
-    this.cellStoreService.cellUpdated$.subscribe(c => {
+    this.subscriptions.add(this.cellStoreService.cellUpdated$.subscribe(c => {
       if (c.id !== this.currentCell()?.id) {
         return;
       }
 
-      this.updateCell(c);
-    });
+      this.currentCell.set({... c});
+    }));
   }
 
-  private updateCell(newParams: CellModel) {
-    if (!newParams) {
-      return;
-    }
-    
-    this.currentCell.set(newParams);
-    const shouldBeHighlighted = newParams.state == CellState.Running && !!newParams.orderNumber && !!newParams.operationNumber &&
-        !!this.orderStoreService.getOrder(newParams.orderNumber, newParams.operationNumber)?.isToggled;
-    this.isHighlighted.set(shouldBeHighlighted);  
+  ngOnDestroy(): void {
+    this.subscriptions.unsubscribe();
   }
 
   onCellClicked() {
     //Do not show details menu if the edit button is not closed
     if (this.editMenuState() != EditMenuState.Closed) return;
-    this.cellStoreService.selectCell(this.currentCell()?.id!);
+    this.cellStoreService.selectCell(this.currentCell().id!);
   }
 
   onCellMove(event: CdkDragEnd<any>) {
     // Calculate new position as percetage value relative to the cell-container
-    const cellY = this.cellElement()?.nativeElement?.offsetTop! + event.distance.y;
-    const cellX = this.cellElement()?.nativeElement?.offsetLeft! + event.distance.x;
-    const containerHeight = this.container()?.nativeElement?.offsetHeight!;
-    const containerWidth = this.container()?.nativeElement?.offsetWidth!;
+    const cellY = this.cellElement().nativeElement?.offsetTop! + event.distance.y;
+    const cellX = this.cellElement().nativeElement?.offsetLeft! + event.distance.x;
+    const containerHeight = this.container().nativeElement?.offsetHeight!;
+    const containerWidth = this.container().nativeElement?.offsetWidth!;
     this.currentCell.update(cell => {
       cell!.location!.positionX = this.clamp(cellX / containerWidth);
       cell!.location!.positionY = this.clamp(cellY / containerHeight);
@@ -117,7 +112,7 @@ export class Cell implements OnInit {
     });
 
     // Save position and reset translation
-    this.cellStoreService.moveCell(this.currentCell()?.location!);
+    this.cellStoreService.moveCell(this.currentCell().location!);
     event.source._dragRef.reset();
   }
 
@@ -125,4 +120,3 @@ export class Cell implements OnInit {
     return Math.max(0, Math.min(x, 1));
   }
 }
-

--- a/src/Moryx.FactoryMonitor.Web/app/src/app/components/cell/cell.ts
+++ b/src/Moryx.FactoryMonitor.Web/app/src/app/components/cell/cell.ts
@@ -16,6 +16,7 @@ import { MatIcon } from '@angular/material/icon';
 import { VisualizableItemModel } from 'src/app/api/models';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { Subscription } from 'rxjs';
+import { createUpdatedLocation } from 'src/app/extensions/locations';
 
 @Component({
   selector: 'app-cell',
@@ -99,24 +100,15 @@ export class Cell implements OnInit, OnDestroy {
     this.cellStoreService.selectCell(this.currentCell().id!);
   }
 
-  onCellMove(event: CdkDragEnd<any>) {
+  async onCellMove(event: CdkDragEnd<any>) {
+    const params = this.parameters();
+
     // Calculate new position as percetage value relative to the cell-container
-    const cellY = this.cellElement().nativeElement?.offsetTop! + event.distance.y;
-    const cellX = this.cellElement().nativeElement?.offsetLeft! + event.distance.x;
-    const containerHeight = this.container().nativeElement?.offsetHeight!;
-    const containerWidth = this.container().nativeElement?.offsetWidth!;
-    this.currentCell.update(cell => {
-      cell!.location!.positionX = this.clamp(cellX / containerWidth);
-      cell!.location!.positionY = this.clamp(cellY / containerHeight);
-      return cell;
-    });
+    const updatedLocation = createUpdatedLocation(event, this.cellElement(), 
+      this.container(), params.location?.id);
 
-    // Save position and reset translation
-    this.cellStoreService.moveCell(this.currentCell().location!);
+    // Save position and reset translation as the new position is immediately applied
+    await this.cellStoreService.moveItem(params, updatedLocation);
     event.source._dragRef.reset();
-  }
-
-  private clamp(x: number) {
-    return Math.max(0, Math.min(x, 1));
-  }
+  }  
 }

--- a/src/Moryx.FactoryMonitor.Web/app/src/app/components/cell/cell.ts
+++ b/src/Moryx.FactoryMonitor.Web/app/src/app/components/cell/cell.ts
@@ -3,20 +3,20 @@
  * Licensed under the Apache License, Version 2.0
 */
 
-import { Component, OnInit, OnDestroy, ElementRef, viewChild, input, computed, inject, linkedSignal } from '@angular/core';
+import { CdkDragEnd, DragDropModule } from '@angular/cdk/drag-drop';
+import { CommonModule } from '@angular/common';
+import { Component, computed, ElementRef, inject, input, linkedSignal, OnDestroy, OnInit, viewChild } from '@angular/core';
+import { toSignal } from '@angular/core/rxjs-interop';
+import { MatIcon } from '@angular/material/icon';
+import { Subscription } from 'rxjs';
+import { VisualizableItemModel } from 'src/app/api/models';
+import { createUpdatedLocation } from 'src/app/extensions/locations';
+import CellModel from 'src/app/models/cellModel';
 import { EditMenuState } from 'src/app/services/EditMenutState';
 import { CellStoreService } from 'src/app/services/cell-store.service';
-import { CellState } from '../../api/models/cell-state';
 import { EditMenuService } from 'src/app/services/edit-menu.service';
 import { OrderStoreService } from 'src/app/services/order-store.service';
-import { CdkDragEnd, DragDropModule } from '@angular/cdk/drag-drop';
-import CellModel from 'src/app/models/cellModel';
-import { CommonModule } from '@angular/common';
-import { MatIcon } from '@angular/material/icon';
-import { VisualizableItemModel } from 'src/app/api/models';
-import { toSignal } from '@angular/core/rxjs-interop';
-import { Subscription } from 'rxjs';
-import { createUpdatedLocation } from 'src/app/extensions/locations';
+import { CellState } from '../../api/models/cell-state';
 
 @Component({
   selector: 'app-cell',
@@ -41,11 +41,7 @@ export class Cell implements OnInit, OnDestroy {
   isEditMode = computed(() => this.editMenuState() === EditMenuState.EditingCells);
   private editMenuState = toSignal(this.editMenuService.activeState$);
   currentCell = linkedSignal<CellModel>(() => this.cellStoreService.getCell(this.parameters().id!));
-  private currentOrder = computed(() => {
-    const cell = this.currentCell();
-    if (!cell?.orderNumber || !cell.operationNumber) return null;
-    return this.orderStoreService.getOrder(cell.orderNumber, cell.operationNumber);
-  });
+  private currentOrder = computed(() => this.orderStoreService.getOrder(this.currentCell()));
   private currentOrderIsToggled = linkedSignal(() => !!this.currentOrder()?.isToggled);
   isHighlighted = computed(() => {
     const cell = this.currentCell();

--- a/src/Moryx.FactoryMonitor.Web/app/src/app/components/cell/cell.ts
+++ b/src/Moryx.FactoryMonitor.Web/app/src/app/components/cell/cell.ts
@@ -40,6 +40,7 @@ export class Cell implements OnInit {
     this.currentCell()?.state === CellState.NotReadyToWork ? '#e46d6d' : 'white'
   );
   borderColor = computed(() => {
+    const cell = this.currentCell();
     if (this.isHighlighted() && this.currentCell()!.orderColor)
       return this.currentCell()?.orderColor!;
     if (this.currentCell()?.state === CellState.NotReadyToWork)
@@ -78,20 +79,23 @@ export class Cell implements OnInit {
 
     // React to updates to the cell data
     this.cellStoreService.cellUpdated$.subscribe(c => {
-      if (c?.id != this.currentCell()?.id) return;
-      this.updateCell(c!);
+      if (c.id !== this.currentCell()?.id) {
+        return;
+      }
+
+      this.updateCell(c);
     });
   }
 
   private updateCell(newParams: CellModel) {
+    if (!newParams) {
+      return;
+    }
+    
     this.currentCell.set(newParams);
-    if (this.currentCell()?.orderNumber && this.currentCell()?.operationNumber)
-      if (newParams.state == CellState.Running &&
-        this.orderStoreService.getOrder(this.currentCell()?.orderNumber!, this.currentCell()?.operationNumber!)?.isToggled) {
-        this.isHighlighted.set(true);
-      } else {
-        this.isHighlighted.set(false);
-      }
+    const shouldBeHighlighted = newParams.state == CellState.Running && !!newParams.orderNumber && !!newParams.operationNumber &&
+        !!this.orderStoreService.getOrder(newParams.orderNumber, newParams.operationNumber)?.isToggled;
+    this.isHighlighted.set(shouldBeHighlighted);  
   }
 
   onCellClicked() {

--- a/src/Moryx.FactoryMonitor.Web/app/src/app/components/edit-menu/edit-menu.ts
+++ b/src/Moryx.FactoryMonitor.Web/app/src/app/components/edit-menu/edit-menu.ts
@@ -84,7 +84,7 @@ export class EditMenu implements OnInit {
 
         this.factoryMonitorService.getNavigation({ factoryId: factory }).subscribe(navigation => {
           this.navigationItem = navigation;
-          this.backgroundService.changeLocalBackground(navigation.backgroundURL ?? '');
+          this.backgroundService.updateBackground(navigation.backgroundURL);
 
           if (!navigation.parentId) {
             this.canGoBack.set(false);

--- a/src/Moryx.FactoryMonitor.Web/app/src/app/components/factory-board/factory-board.html
+++ b/src/Moryx.FactoryMonitor.Web/app/src/app/components/factory-board/factory-board.html
@@ -1,6 +1,6 @@
 @for (item of factoryContent(); track item) {
   @if (item.isACell) {
-    <app-cell  [container]="elemRef" [parameters]="getCell(item.id ?? 0)"></app-cell>
+    <app-cell  [container]="elemRef" [parameters]="item"></app-cell>
   }
   @if (!item.isACell) {
     <app-factory [container]="elemRef" [parameters]="item"></app-factory>

--- a/src/Moryx.FactoryMonitor.Web/app/src/app/components/factory-board/factory-board.html
+++ b/src/Moryx.FactoryMonitor.Web/app/src/app/components/factory-board/factory-board.html
@@ -1,4 +1,4 @@
-@for (item of factoryContent(); track item) {
+@for (item of factoryContent(); track item.id) {
   @if (item.isACell) {
     <app-cell  [container]="elemRef" [parameters]="item"></app-cell>
   }

--- a/src/Moryx.FactoryMonitor.Web/app/src/app/components/factory-board/factory-board.ts
+++ b/src/Moryx.FactoryMonitor.Web/app/src/app/components/factory-board/factory-board.ts
@@ -5,8 +5,6 @@
 
 import { Component, ElementRef, inject, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
-import CellModel from 'src/app/models/cellModel';
-import { CellStoreService } from 'src/app/services/cell-store.service';
 import { FactorySelectionService } from 'src/app/services/factory-selection.service';
 import { Cell } from '../cell/cell';
 import { Factory } from '../factory/factory';
@@ -26,7 +24,6 @@ import { toSignal } from '@angular/core/rxjs-interop';
 export class FactoryBoard implements OnInit {
   elemRef = inject(ElementRef);
   private factorySelectionService = inject(FactorySelectionService);
-  private cellStoreService = inject(CellStoreService);
   private activatedRoute = inject(ActivatedRoute);
   factoryContent = toSignal(this.factorySelectionService.factoryContent$);
   factoryId !: number | undefined;
@@ -40,6 +37,7 @@ export class FactoryBoard implements OnInit {
     // This can be drastically simplified by setting the default factory-content automatically. Also route
     // changes coulde be processed in the serive making this a pure display component.
     //use the default factory when no factory id provided in the url
+    // Solution: Use Route Resolver to prepare data before component actually is loaded
     this.factorySelectionService.defaultFactory$.subscribe(item => {
       if (this.factoryId != undefined && this.factoryId > 0) return;
       if (!item) return;
@@ -51,10 +49,5 @@ export class FactoryBoard implements OnInit {
     if (this.factoryId != undefined && this.factoryId > 0)
       //select a new factory based on the id in the url
       this.factorySelectionService.selectFactory(this.factoryId);
-  }
-
-  getCell(cellId: number): CellModel {
-    const output = this.cellStoreService.getCell(cellId) ?? <CellModel>{};
-    return output;
   }
 }

--- a/src/Moryx.FactoryMonitor.Web/app/src/app/components/factory/factory.html
+++ b/src/Moryx.FactoryMonitor.Web/app/src/app/components/factory/factory.html
@@ -1,11 +1,13 @@
+@let factory = parameters();
+
 <div
   #FactoryElement
   class="cell-container"
   [ngStyle]="{
     'border-color': borderColor(),
     background: backgroundColor,
-    top: (factory().location?.positionY ?? 0) * 100 + '%',
-    left: (factory().location?.positionX ?? 0) * 100 + '%'
+    top: (factory.location?.positionY ?? 0) * 100 + '%',
+    left: (factory.location?.positionX ?? 0) * 100 + '%'
   }"
   cdkDrag
   cdkDragBoundary=".draggable-area"
@@ -13,6 +15,6 @@
   [cdkDragDisabled]="!isEditMode()"
   (click)="onCellClicked()">
   <mat-icon [ngStyle]="{ color: iconColor() }">{{
-    factory().iconName
+    factory.iconName
   }}</mat-icon>
 </div>

--- a/src/Moryx.FactoryMonitor.Web/app/src/app/components/factory/factory.ts
+++ b/src/Moryx.FactoryMonitor.Web/app/src/app/components/factory/factory.ts
@@ -3,19 +3,18 @@
  * Licensed under the Apache License, Version 2.0
 */
 
-import { Component, ElementRef, inject, signal, computed, input, viewChild, OnInit } from '@angular/core';
+import { Component, ElementRef, inject, computed, input, viewChild, OnInit, linkedSignal } from '@angular/core';
 import { CellStoreService } from 'src/app/services/cell-store.service';
 import { CdkDragEnd, DragDropModule } from '@angular/cdk/drag-drop';
 import { EditMenuState } from 'src/app/services/EditMenutState';
 import { EditMenuService } from 'src/app/services/edit-menu.service';
-import { FactoryStateModel } from 'src/app/api/models/factory-state-model';
 import { FactorySelectionService } from 'src/app/services/factory-selection.service';
 import { CellState } from 'src/app/api/models/cell-state';
-import CellModel from 'src/app/models/cellModel';
-import { VisualizableItemModel } from 'src/app/api/models/visualizable-item-model';
 import { Router } from '@angular/router';
 import { CommonModule } from '@angular/common';
 import { MatIconModule } from '@angular/material/icon';
+import { toSignal } from '@angular/core/rxjs-interop';
+import { VisualizableItemModel } from 'src/app/api/models';
 
 @Component({
   selector: 'app-factory',
@@ -29,16 +28,14 @@ import { MatIconModule } from '@angular/material/icon';
 })
 export class Factory implements OnInit {
   private cellStoreService = inject(CellStoreService);
-  private editMenuService = inject(EditMenuService);
   private factorySelectionService = inject(FactorySelectionService);
   private router = inject(Router);
 
-  cellElement = viewChild<ElementRef<HTMLElement>>('FactoryElement');
+  private factoryElement = viewChild.required<ElementRef<HTMLElement>>('FactoryElement');
   container = input.required<ElementRef<HTMLElement>>();
   parameters = input.required<VisualizableItemModel>();
-  factory = computed(() => this.parameters() as FactoryStateModel);
-  cells = signal<CellModel[]>([]);
-  private editMenuState = signal<EditMenuState>(EditMenuState.Closed);
+  cells = linkedSignal(() => this.cellStoreService.getCells(this.parameters()));
+  private editMenuState = toSignal(inject(EditMenuService).activeState$);
 
   backgroundColor = 'white';
 
@@ -51,7 +48,7 @@ export class Factory implements OnInit {
   borderColor = computed(() => {
     const workingCell = this.firstWorkingCell();
     if (this.isHighlighted() && workingCell?.orderColor) return workingCell.orderColor;
-    return 'white';
+    return this.backgroundColor;
   });
 
   iconColor = computed(() => {
@@ -61,68 +58,46 @@ export class Factory implements OnInit {
   });
 
   ngOnInit(): void {
-    // Keep the menu state
-    this.editMenuService.activeState$.subscribe({
-      next: state => this.editMenuState.set(state)
-    });
-
-    this.cellStoreService.cells$.subscribe(c =>
-      this.cells.set(c.filter(cell => cell.factoryId === this.factory().id))
-    );
-
     // React to updates to the cell data
-    this.cellStoreService.cellUpdated$.subscribe(cell => {
-      if (!cell) {
+    this.cellStoreService.cellUpdated$.subscribe(cell => {     
+      if (cell.factoryId != this.parameters().id) {
         return;
       }
 
-      if (cell.id != this.factory().id && !this.cells().some(c => c.id === cell.id)) {
-        return;
-      }
-
-      this.updateFactoryCell(cell);
-    });
-  }
-
-  updateFactoryCell(cell: CellModel) {
-    this.cells.update(cells => {
-      const cellToUpdate = cells.find(c => c.id === cell.id);
-      if (!cellToUpdate) return cells;
-
-      cellToUpdate.iconName = cell.iconName;
-      cellToUpdate.image = cell.image;
-      cellToUpdate.name = cell.name;
-      cellToUpdate.propertySettings = cell.propertySettings;
-      cellToUpdate.state = cell.state;
-      cellToUpdate.classification = cell.classification;
-      cellToUpdate.orderNumber = cell.orderNumber;
-      cellToUpdate.operationNumber = cell.operationNumber;
-      cellToUpdate.orderColor = cell.orderColor;
-      return [...cells];
+      this.cells.update(cells => {
+        const index = cells.findIndex(c => c.id === cell.id);
+        cells[index] = cell;
+        return [... cells];
+      });
     });
   }
 
   onCellClicked() {
     if (this.editMenuState() !== EditMenuState.Closed) return;
 
-    this.router.navigate(['/factory', this.factory().id]).then(() => {
+    // ToDo: Move to a RouteResolver to cleanly load and unload data
+    this.router.navigate(['/factory', this.parameters().id]).then(() => {
       //close the delails on the right if it is openned
       this.cellStoreService.selectCell(undefined);
-      this.factorySelectionService.selectFactory(this.factory().id ?? 0);
+      this.factorySelectionService.selectFactory(this.parameters().id ?? 0);
     });
   }
 
   onCellMove(event: CdkDragEnd<any>) {
-    if (!this.factory().location) return;
+    const params = this.parameters();
+    const factoryElement = this.factoryElement();
+    const containerElement = this.container();
+
+    if (!params.location) return;
 
     // Calculate new position as percetage value relative to the cell-container
-    const cellY = this.cellElement()!.nativeElement.offsetTop + event.distance.y;
-    const cellX = this.cellElement()!.nativeElement.offsetLeft + event.distance.x;
-    const containerHeight = this.container().nativeElement.offsetHeight;
-    const containerWidth = this.container().nativeElement.offsetWidth;
+    const cellY = factoryElement.nativeElement.offsetTop + event.distance.y;
+    const cellX = factoryElement.nativeElement.offsetLeft + event.distance.x;
+    const containerHeight = containerElement.nativeElement.offsetHeight;
+    const containerWidth = containerElement.nativeElement.offsetWidth;
 
     const updatedLocation = {
-      ...this.factory().location,
+      ...this.parameters().location,
       positionX: this.clamp(cellX / containerWidth),
       positionY: this.clamp(cellY / containerHeight)
     };
@@ -136,4 +111,3 @@ export class Factory implements OnInit {
     return Math.max(0, Math.min(x, 1));
   }
 }
-

--- a/src/Moryx.FactoryMonitor.Web/app/src/app/components/factory/factory.ts
+++ b/src/Moryx.FactoryMonitor.Web/app/src/app/components/factory/factory.ts
@@ -15,6 +15,11 @@ import { CommonModule } from '@angular/common';
 import { MatIconModule } from '@angular/material/icon';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { VisualizableItemModel } from 'src/app/api/models';
+import { createUpdatedLocation } from 'src/app/extensions/locations';
+import { lastValueFrom } from 'rxjs';
+import { HttpErrorResponse } from '@angular/common/http';
+import { FactoryMonitorService } from 'src/app/api/services';
+import { SnackbarService } from '@moryx/ngx-web-framework/services';
 
 @Component({
   selector: 'app-factory',
@@ -29,6 +34,8 @@ import { VisualizableItemModel } from 'src/app/api/models';
 export class Factory implements OnInit {
   private cellStoreService = inject(CellStoreService);
   private factorySelectionService = inject(FactorySelectionService);
+  private factoryMonitorService = inject(FactoryMonitorService);  
+  private snackbarService = inject(SnackbarService);
   private router = inject(Router);
 
   private factoryElement = viewChild.required<ElementRef<HTMLElement>>('FactoryElement');
@@ -83,31 +90,19 @@ export class Factory implements OnInit {
     });
   }
 
-  onCellMove(event: CdkDragEnd<any>) {
+  async onCellMove(event: CdkDragEnd<any>) {
     const params = this.parameters();
-    const factoryElement = this.factoryElement();
-    const containerElement = this.container();
-
-    if (!params.location) return;
 
     // Calculate new position as percetage value relative to the cell-container
-    const cellY = factoryElement.nativeElement.offsetTop + event.distance.y;
-    const cellX = factoryElement.nativeElement.offsetLeft + event.distance.x;
-    const containerHeight = containerElement.nativeElement.offsetHeight;
-    const containerWidth = containerElement.nativeElement.offsetWidth;
-
-    const updatedLocation = {
-      ...this.parameters().location,
-      positionX: this.clamp(cellX / containerWidth),
-      positionY: this.clamp(cellY / containerHeight)
-    };
-
+    const updatedLocation = createUpdatedLocation(event, this.factoryElement(), 
+      this.container(), params.location?.id);
+    
     // Save position and reset translation
-    this.cellStoreService.moveCell(updatedLocation);
-    event.source._dragRef.reset();
-  }
-
-  private clamp(x: number) {
-    return Math.max(0, Math.min(x, 1));
+    try {
+      await lastValueFrom(this.factoryMonitorService.moveCell({ body: updatedLocation }));
+    } catch (error) {
+      this.snackbarService.handleError(error as HttpErrorResponse);
+      return;
+    }
   }
 }

--- a/src/Moryx.FactoryMonitor.Web/app/src/app/components/orders-container/orders-container.html
+++ b/src/Moryx.FactoryMonitor.Web/app/src/app/components/orders-container/orders-container.html
@@ -1,10 +1,6 @@
 @for (order of runningOrders(); track order) {
-  <div>
-    <div class="order-container" [class.isToggled]="order.isToggled" (click)="toggleOrder(order)">
-      <div class="order-color-indicator" [style.background]="order.orderColor"></div>
-      <div>
-        <h4>{{order.orderNumber}}-{{order.operationNumber}}</h4>
-      </div>
-    </div>
+  <div class="order-container" [class.isToggled]="order.isToggled" (click)="toggleOrder(order)">
+    <div class="order-color-indicator" [style.background]="order.orderColor"></div>
+    <h4>{{order.orderNumber}}-{{order.operationNumber}}</h4>
   </div>
 }

--- a/src/Moryx.FactoryMonitor.Web/app/src/app/components/orders-container/orders-container.scss
+++ b/src/Moryx.FactoryMonitor.Web/app/src/app/components/orders-container/orders-container.scss
@@ -5,28 +5,27 @@
 }
 
 .order-container {
-    max-width: auto;
     height: 40px;
     background: rgba(255, 255, 255, 0.5);
     box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25), 0px 8px 24px rgba(0, 0, 0, 0.25);
-    border-radius: 2px;
+    border-radius: 4px;
     display:  flex;
     justify-content: space-evenly;
     align-items: center;
     cursor: pointer;
     margin-bottom: 5px;
-    padding: 4px;
+    padding: 4px 8px;
 }
 
 .order-color-indicator {
     width: 34px;
     height: 34px;
     border-radius: 50%;
-    margin-right: 5px;
+    margin-right: 8px;
 }
 
 .isToggled {
-    background-color: rgb(0, 124, 132,0.9);
-    color: rgb(233, 233, 233);
+    background-color: var(--mat-sys-secondary-container);
+    color: var(--mat-sys-on-secondary-container);
     border-color: transparent;
 }

--- a/src/Moryx.FactoryMonitor.Web/app/src/app/dialogs/change-background-dialog/change-background-dialog.html
+++ b/src/Moryx.FactoryMonitor.Web/app/src/app/dialogs/change-background-dialog/change-background-dialog.html
@@ -1,9 +1,11 @@
+@let canSave = backgroundChangeService.canSaveBackground();
+
 <div mat-dialog-title>
   <span>{{ TranslationConstants.CHANGE_BACKGROUND_DIALOG.BACKGROUND_IMAGE | translate }}</span>
 </div>
 <div mat-dialog-content>
   <div>
-    @if (backgroundChangeService.canSaveBackground$ | async) {
+    @if (canSave) {
       <mat-form-field class="background-input"
         appearance="outline">
         <mat-label>{{ TranslationConstants.CHANGE_BACKGROUND_DIALOG.BACKGROUND_URL | translate }}</mat-label>
@@ -17,7 +19,7 @@
         }
       </mat-form-field>
     }
-    @if (!(backgroundChangeService.canSaveBackground$ | async)) {
+    @else {
       <p>
         {{ TranslationConstants.CHANGE_BACKGROUND_DIALOG.NO_MANUFACTURING_RESOURCE| translate }}
       </p>
@@ -30,7 +32,7 @@
     mat-flat-button
     color="primary"
     (click)="onSave()"
-    [disabled]="backgroundUrlFormControl.invalid || !(backgroundChangeService.canSaveBackground$ | async)">
+    [disabled]="backgroundUrlFormControl.invalid || !canSave">
     {{ TranslationConstants.SHARED.SAVE | translate }}
   </button>
 </div>

--- a/src/Moryx.FactoryMonitor.Web/app/src/app/extensions/converter.ts
+++ b/src/Moryx.FactoryMonitor.Web/app/src/app/extensions/converter.ts
@@ -37,11 +37,30 @@ export class Converter {
   }
 
   public static resourceChangedModelToCell(resourceModel: ResourceChangedModel): CellModel {
-    if (!resourceModel.id) throw new TypeError("cannot create resource without id");
+    if (!resourceModel.id) throw new TypeError("Cannot create resource without id");
     const cell = <CellModel>{};
     cell.id = resourceModel.id;
 
-    return this.addResourceDataToCell(cell, resourceModel)
+    if (resourceModel.cellName) {
+      cell.name = resourceModel.cellName
+    }
+    if (resourceModel.factoryId) {
+      cell.factoryId= resourceModel.factoryId
+    }
+    if (resourceModel.cellIconName) {
+      cell.iconName = resourceModel.cellIconName
+    }
+    if (resourceModel.cellImageURL) {
+      cell.image = resourceModel.cellImageURL
+    }
+    if (resourceModel.cellLocation) {
+      cell.location = resourceModel.cellLocation
+    }
+    if (resourceModel.cellPropertySettings) {
+      cell.propertySettings = resourceModel.cellPropertySettings
+    }
+
+    return cell;
   }
 
   public static orderModelToOrder(orderModel: OrderModel): Order {
@@ -67,43 +86,11 @@ export class Converter {
     return order
   }
 
-  public static addResourceDataToCell(cell: CellModel, model: ResourceChangedModel): CellModel {
-    if (model.cellName) {
-      cell.name = model.cellName ?? ''
-    }
-    if (model.factoryId) {
-      cell.factoryId= model.factoryId ?? ''
-    }
-    if (model.cellIconName) {
-      cell.iconName = model.cellIconName ?? ''
-    }
-    if (model.cellImageURL) {
-      cell.image = model.cellImageURL ?? ''
-    }
-    if (model.cellLocation) {
-      cell.location = model.cellLocation
-    }
-    if (model.cellPropertySettings) {
-      cell.propertySettings = model.cellPropertySettings
-    }
-
-    return cell
-  }
-
   public static addStateDataToCell(cell: CellModel, model: CellStateChangedModel): CellModel {
-    if (!cell.state) {
+    if (model.state) {
       cell.state = model.state
     }
 
     return cell
-  }
-
-  public static modelToOrder(order: OrderModel): Order {
-    return <Order>{
-      isToggled: true,
-      operationNumber: order.operation,
-      orderColor: order.color,
-      orderNumber: order.order,
-    };
   }
 }

--- a/src/Moryx.FactoryMonitor.Web/app/src/app/extensions/locations.ts
+++ b/src/Moryx.FactoryMonitor.Web/app/src/app/extensions/locations.ts
@@ -1,0 +1,22 @@
+import { ElementRef } from "@angular/core";
+import { CellLocationModel } from "../api/models";
+import { CdkDragEnd } from '@angular/cdk/drag-drop';
+
+export function createUpdatedLocation(event: CdkDragEnd<any>, itemElement: ElementRef<HTMLElement>, 
+  containerElement: ElementRef<HTMLElement>, id: number | undefined) {
+
+  const cellY = itemElement.nativeElement.offsetTop! + event.distance.y;
+  const cellX = itemElement.nativeElement.offsetLeft! + event.distance.x;
+  const containerHeight = containerElement.nativeElement.offsetHeight;
+  const containerWidth = containerElement.nativeElement.offsetWidth;
+
+  return <CellLocationModel>{
+    id: id,
+    positionX: clamp(cellX / containerWidth),
+    positionY: clamp(cellY / containerHeight)
+  };
+}
+
+function clamp(x: number) {
+  return Math.max(0, Math.min(x, 1));
+}

--- a/src/Moryx.FactoryMonitor.Web/app/src/app/services/cell-store.service.ts
+++ b/src/Moryx.FactoryMonitor.Web/app/src/app/services/cell-store.service.ts
@@ -16,7 +16,11 @@ import { Converter } from '../extensions/converter';
 import { FactoryStateModel } from '../api/models/factory-state-model';
 import { FactorySelectionService } from './factory-selection.service';
 import { HttpErrorResponse } from '@angular/common/http';
+import { VisualizableItemModel } from '../api/models';
 
+
+// ToDo: While this is called cell-store service it actually holds all items 
+// (also factories). 
 @Injectable({
   providedIn: 'root'
 })
@@ -29,11 +33,10 @@ export class CellStoreService {
 
   private _cellSelected = new BehaviorSubject<CellModel | undefined>(undefined);
   private _cellUpdated = new ReplaySubject<CellModel>();
-  private _cells = new BehaviorSubject<CellModel[]>([]);
+  private _cells : CellModel[] = [];
 
   public cellSelected$ = this._cellSelected.asObservable();
   public cellUpdated$ = this._cellUpdated.asObservable();
-  public cells$ = this._cells.asObservable();
 
   updatedCell: BehaviorSubject<CellModel | undefined> = new BehaviorSubject<CellModel | undefined>(undefined);
 
@@ -41,7 +44,6 @@ export class CellStoreService {
   constructor() {
     this.init();
   }
-
 
   private async init() {
     let factoryState: FactoryStateModel | undefined;
@@ -82,7 +84,7 @@ export class CellStoreService {
       this._orderService.applyOrderColor(cell);
     }
 
-    this._cells.next(Object.values(cells));
+    this._cells = Object.values(cells);
     this.subscribe();
   }
 
@@ -108,33 +110,36 @@ export class CellStoreService {
       return;
     }
 
-    const selectedCell = this._cells.getValue().find(c => c.id === id);
+    const selectedCell = this._cells.find(c => c.id === id);
     this._cellSelected.next(selectedCell);
   }
 
-  public moveCell(e: CellLocationModel) {
-    this.factoryMonitorService.moveCell({ body: e }).subscribe({
-      error: err => this.snackbarService.handleError(err)
-    });
+  public async moveItem(item: VisualizableItemModel, update: CellLocationModel) {
+    try {
+      const location = await lastValueFrom(this.factoryMonitorService.moveCell({ body: update }));
+      this.updateCell(<CellModel>{ id: item.id, location: location });
+    } catch (error) {
+      this.snackbarService.handleError(error as HttpErrorResponse);
+      return;
+    }
   }
 
   public getCell(cellId: number) : CellModel {
-    const cell = this._cells.getValue().find(c => c.id === cellId)
+    const cell = this._cells.find(c => c.id === cellId)
     if (!cell) 
       throw Error(`Tried to process unknown cell with id ${cellId}`);
     return cell;
   }
 
   public getCells(factory: FactoryStateModel): CellModel[] {
-    return this._cells.getValue().filter(c => c.factoryId === factory.id);
+    return this._cells.filter(c => c.factoryId === factory.id);
   }
 
   // Cell updates are retrieved as partial updates to the existing cell models, 
   // so we need to merge the incoming data with the existing cell data
   public updateCell(cell: CellModel) {
-    const cells = this._cells.getValue();
-    const indexToUpdate = cells.findIndex(x => x.id === cell.id);
-    let cellToUpdate = cells[indexToUpdate];
+    const indexToUpdate = this._cells.findIndex(x => x.id === cell.id);
+    let cellToUpdate = {... this._cells[indexToUpdate]};
 
     if (cell.iconName != '' && cell.iconName) {
       cellToUpdate.iconName = cell.iconName;
@@ -163,17 +168,15 @@ export class CellStoreService {
     if (cell.operationNumber) {
       cellToUpdate.operationNumber = cell.operationNumber;
     }
-    if (
-      cellToUpdate.orderNumber &&
-      cell.orderNumber != '' &&
-      cellToUpdate.operationNumber &&
-      cell.operationNumber != ''
-    ) {
+    if (cellToUpdate.orderNumber && cell.orderNumber && cellToUpdate.operationNumber &&
+      cell.operationNumber) {
       this._orderService.applyOrderColor(cellToUpdate);
     }
+    if (cell.location) {
+      cellToUpdate.location = cell.location;
+    }
 
-    cells[indexToUpdate] = cellToUpdate;
-    this._cells.next(cells);
+    this._cells[indexToUpdate] = cellToUpdate;
     this._cellUpdated.next(cellToUpdate);
   }
 }

--- a/src/Moryx.FactoryMonitor.Web/app/src/app/services/cell-store.service.ts
+++ b/src/Moryx.FactoryMonitor.Web/app/src/app/services/cell-store.service.ts
@@ -4,7 +4,7 @@
 */
 
 import { inject, Injectable } from '@angular/core';
-import { BehaviorSubject } from 'rxjs';
+import { BehaviorSubject, lastValueFrom, ReplaySubject } from 'rxjs';
 import { FactoryStateStreamService } from './factory-state-stream.service';
 import { OrderStoreService } from './order-store.service';
 import { FactoryMonitorService } from '../api/services';
@@ -14,23 +14,21 @@ import CellModel from '../models/cellModel';
 import Order from '../models/order';
 import { Converter } from '../extensions/converter';
 import { FactoryStateModel } from '../api/models/factory-state-model';
-import { ResourceChangedModel } from '../api/models/resource-changed-model';
-import { ActivityChangedModel } from '../api/models/activity-changed-model';
-import { CellStateChangedModel } from '../api/models/cell-state-changed-model';
 import { FactorySelectionService } from './factory-selection.service';
+import { HttpErrorResponse } from '@angular/common/http';
 
 @Injectable({
   providedIn: 'root'
 })
 export class CellStoreService {
-  private orderService = inject(OrderStoreService);
+  private _orderService = inject(OrderStoreService);
   private factoryStateStreamService = inject(FactoryStateStreamService);
   private factoryMonitorService = inject(FactoryMonitorService);
   private factorySelectionService = inject(FactorySelectionService);
   private snackbarService = inject(SnackbarService);
 
   private _cellSelected = new BehaviorSubject<CellModel | undefined>(undefined);
-  private _cellUpdated = new BehaviorSubject<CellModel | undefined>(undefined);
+  private _cellUpdated = new ReplaySubject<CellModel>();
   private _cells = new BehaviorSubject<CellModel[]>([]);
 
   public cellSelected$ = this._cellSelected.asObservable();
@@ -39,57 +37,53 @@ export class CellStoreService {
 
   updatedCell: BehaviorSubject<CellModel | undefined> = new BehaviorSubject<CellModel | undefined>(undefined);
 
+  // ToDo: Move async work to an provideAppInitializer
   constructor() {
-    this.factoryMonitorService.initialFactoryState().subscribe({
-      next: factoryState => {
-        //only set default
-        this.factorySelectionService.setDefaultFactory(factoryState);
-        this.initializeOrders(factoryState);
+    this.init();
+  }
 
-        // get all the cells in the database that need to be displayed (only once), we will rely on the eventStream to update the list
-        this.factoryMonitorService.allCells().subscribe(rawCells => {
-          const rawRecourceChanges: Array<ResourceChangedModel> = [];
 
-          rawCells.forEach(r =>
-            rawRecourceChanges.push(<ResourceChangedModel>{
-              id: r.id,
-              cellIconName: r.iconName,
-              cellLocation: r.location,
-              factoryId: 0
-            })
-          );
+  private async init() {
+    let factoryState: FactoryStateModel | undefined;
+    try {
+      factoryState = await lastValueFrom(this.factoryMonitorService.initialFactoryState());
+    } catch (error) {
+      this.snackbarService.handleError(error as HttpErrorResponse);
+    }
 
-          const rawActivityChanges: Array<ActivityChangedModel> = [];
-          factoryState.activityChangedModels?.forEach(a => rawActivityChanges.push(a));
-          let activityLength = rawActivityChanges.length;
+    if (!factoryState) {
+      return;
+    }
 
-          const rawCellStateChanges: Array<CellStateChangedModel> = [];
-          factoryState.cellStateChangedModels?.forEach(c => rawCellStateChanges.push(c));
+    this.factorySelectionService.setDefaultFactory(factoryState);
+    // ToDo: Make method call on order service
+    const orders = this.initializeOrders(factoryState);
 
-          let cells: { [id: string]: CellModel } = {};
+    let cells: { [id: string]: CellModel; } = {};
+    const initialRecourceChanges = factoryState.resourceChangedModels ?? [];
+    for (let raw of initialRecourceChanges) {
+      const cell = Converter.resourceChangedModelToCell(raw);
+      if (cell.id)
+        cells[cell.id] = cell;
+    }
 
-          for (let raw of rawRecourceChanges) {
-            let cell = Converter.resourceChangedModelToCell(raw);
-            cell = Converter.addStateDataToCell(cell, raw);
-            if (cell.id) cells[cell.id] = cell;
-          }
+    const initialStateChanges = factoryState.cellStateChangedModels ?? [];
+    for (let raw of initialStateChanges) {
+      if (!raw.id) continue;
+      const cell = cells[raw.id];
+      Converter.addStateDataToCell(cell, raw);
+    }
 
-          for (let i = 0; i < activityLength; i++) {
-            let activity = rawActivityChanges[i];
-            if (!activity.resourceId) continue;
-            Converter.addActivityChangedModelToCell(cells[activity.resourceId], activity);
-          }
+    const initialActivityChanges = factoryState.activityChangedModels ?? [];
+    for (let raw of initialActivityChanges) {
+      if (!raw.resourceId) continue;
+      const cell = cells[raw.resourceId];
+      Converter.addActivityChangedModelToCell(cell, raw);
+      this._orderService.applyOrderColor(cell);
+    }
 
-          this._cells.next(Object.values(cells));
-          this.subscribe();
-
-          for (const key in cells) {
-            this.updateCell(cells[key]);
-          }
-        });
-      },
-      error: err => this.snackbarService.handleError(err)
-    });
+    this._cells.next(Object.values(cells));
+    this.subscribe();
   }
 
   private initializeOrders(factoryState: FactoryStateModel) {
@@ -98,27 +92,18 @@ export class CellStoreService {
 
     orders = orderModels.map(order => Converter.orderModelToOrder(order));
 
-    this.orderService._orders.next(orders);
-    this.orderService.updateRunningOrders();
+    this._orderService._orders.next(orders);
+    this._orderService.updateRunningOrders();
+    return orders;
   }
 
   private subscribe() {
-    this.factoryStateStreamService.updatedCell.subscribe({
-      next: cell => {
-        if (!cell?.id) {
-          return;
-        }
-        if (!this._cells.getValue().length) {
-          return;
-        }
-
-        this.updateCell(cell);
-      }
-    });
+    this.factoryStateStreamService.updatedCell.subscribe(cell => this.updateCell(cell));
   }
 
   public selectCell(id: number | undefined) {
-    if (this._cellSelected.getValue() && this._cellSelected.getValue()?.id === id || !id) {
+    const current = this._cellSelected.getValue();
+    if (current && current.id === id || !id) {
       this._cellSelected.next(undefined);
       return;
     }
@@ -128,16 +113,24 @@ export class CellStoreService {
   }
 
   public moveCell(e: CellLocationModel) {
-    //send cell update to server
     this.factoryMonitorService.moveCell({ body: e }).subscribe({
       error: err => this.snackbarService.handleError(err)
     });
   }
 
-  public getCell(cellId: number) {
-    return this._cells.getValue().find(c => c.id === cellId);
+  public getCell(cellId: number) : CellModel {
+    const cell = this._cells.getValue().find(c => c.id === cellId)
+    if (!cell) 
+      throw Error(`Tried to process unknown cell with id ${cellId}`);
+    return cell;
   }
 
+  public getCells(factory: FactoryStateModel): CellModel[] {
+    return this._cells.getValue().filter(c => c.factoryId === factory.id);
+  }
+
+  // Cell updates are retrieved as partial updates to the existing cell models, 
+  // so we need to merge the incoming data with the existing cell data
   public updateCell(cell: CellModel) {
     const cells = this._cells.getValue();
     const indexToUpdate = cells.findIndex(x => x.id === cell.id);
@@ -176,11 +169,7 @@ export class CellStoreService {
       cellToUpdate.operationNumber &&
       cell.operationNumber != ''
     ) {
-      cellToUpdate.orderColor =
-        this.orderService._orders
-          .getValue()
-          .find(o => o.operationNumber === cellToUpdate.operationNumber && o.orderNumber === cellToUpdate.orderNumber)
-          ?.orderColor ?? '';
+      this._orderService.applyOrderColor(cellToUpdate);
     }
 
     cells[indexToUpdate] = cellToUpdate;

--- a/src/Moryx.FactoryMonitor.Web/app/src/app/services/cell-store.service.ts
+++ b/src/Moryx.FactoryMonitor.Web/app/src/app/services/cell-store.service.ts
@@ -3,64 +3,36 @@
  * Licensed under the Apache License, Version 2.0
 */
 
+import { HttpErrorResponse } from '@angular/common/http';
 import { inject, Injectable } from '@angular/core';
+import { SnackbarService } from '@moryx/ngx-web-framework/services';
 import { BehaviorSubject, lastValueFrom, ReplaySubject } from 'rxjs';
+import { VisualizableItemModel } from '../api/models';
+import { CellLocationModel } from '../api/models/cell-location-model';
+import { FactoryStateModel } from '../api/models/factory-state-model';
+import { FactoryMonitorService } from '../api/services';
+import { Converter } from '../extensions/converter';
+import CellModel from '../models/cellModel';
 import { FactoryStateStreamService } from './factory-state-stream.service';
 import { OrderStoreService } from './order-store.service';
-import { FactoryMonitorService } from '../api/services';
-import { CellLocationModel } from '../api/models/cell-location-model';
-import { SnackbarService } from '@moryx/ngx-web-framework/services';
-import CellModel from '../models/cellModel';
-import Order from '../models/order';
-import { Converter } from '../extensions/converter';
-import { FactoryStateModel } from '../api/models/factory-state-model';
-import { FactorySelectionService } from './factory-selection.service';
-import { HttpErrorResponse } from '@angular/common/http';
-import { VisualizableItemModel } from '../api/models';
 
-
-// ToDo: While this is called cell-store service it actually holds all items 
-// (also factories). 
 @Injectable({
   providedIn: 'root'
 })
 export class CellStoreService {
-  private _orderService = inject(OrderStoreService);
-  private factoryStateStreamService = inject(FactoryStateStreamService);
-  private factoryMonitorService = inject(FactoryMonitorService);
-  private factorySelectionService = inject(FactorySelectionService);
-  private snackbarService = inject(SnackbarService);
+  private readonly orderService = inject(OrderStoreService);
+  private readonly factoryStateStreamService = inject(FactoryStateStreamService);
+  private readonly factoryMonitorService = inject(FactoryMonitorService);
+  private readonly snackbarService = inject(SnackbarService);
 
-  private _cellSelected = new BehaviorSubject<CellModel | undefined>(undefined);
-  private _cellUpdated = new ReplaySubject<CellModel>();
+  private readonly _cellSelected = new BehaviorSubject<CellModel | undefined>(undefined);
+  private readonly _cellUpdated = new ReplaySubject<CellModel>();
   private _cells : CellModel[] = [];
 
-  public cellSelected$ = this._cellSelected.asObservable();
-  public cellUpdated$ = this._cellUpdated.asObservable();
+  public readonly cellSelected$ = this._cellSelected.asObservable();
+  public readonly cellUpdated$ = this._cellUpdated.asObservable();
 
-  updatedCell: BehaviorSubject<CellModel | undefined> = new BehaviorSubject<CellModel | undefined>(undefined);
-
-  // ToDo: Move async work to an provideAppInitializer
-  constructor() {
-    this.init();
-  }
-
-  private async init() {
-    let factoryState: FactoryStateModel | undefined;
-    try {
-      factoryState = await lastValueFrom(this.factoryMonitorService.initialFactoryState());
-    } catch (error) {
-      this.snackbarService.handleError(error as HttpErrorResponse);
-    }
-
-    if (!factoryState) {
-      return;
-    }
-
-    this.factorySelectionService.setDefaultFactory(factoryState);
-    // ToDo: Make method call on order service
-    const orders = this.initializeOrders(factoryState);
-
+  public initialize(factoryState: FactoryStateModel) {
     let cells: { [id: string]: CellModel; } = {};
     const initialRecourceChanges = factoryState.resourceChangedModels ?? [];
     for (let raw of initialRecourceChanges) {
@@ -81,25 +53,13 @@ export class CellStoreService {
       if (!raw.resourceId) continue;
       const cell = cells[raw.resourceId];
       Converter.addActivityChangedModelToCell(cell, raw);
-      this._orderService.applyOrderColor(cell);
+      this.orderService.applyOrderColor(cell);
     }
 
+    // Set initial cells
     this._cells = Object.values(cells);
-    this.subscribe();
-  }
-
-  private initializeOrders(factoryState: FactoryStateModel) {
-    let orders: Order[] = [];
-    let orderModels = factoryState.orderModels ?? [];
-
-    orders = orderModels.map(order => Converter.orderModelToOrder(order));
-
-    this._orderService._orders.next(orders);
-    this._orderService.updateRunningOrders();
-    return orders;
-  }
-
-  private subscribe() {
+    
+    // Subscribe to changes after initialization
     this.factoryStateStreamService.updatedCell.subscribe(cell => this.updateCell(cell));
   }
 
@@ -170,7 +130,7 @@ export class CellStoreService {
     }
     if (cellToUpdate.orderNumber && cell.orderNumber && cellToUpdate.operationNumber &&
       cell.operationNumber) {
-      this._orderService.applyOrderColor(cellToUpdate);
+      this.orderService.applyOrderColor(cellToUpdate);
     }
     if (cell.location) {
       cellToUpdate.location = cell.location;

--- a/src/Moryx.FactoryMonitor.Web/app/src/app/services/change-background.service.ts
+++ b/src/Moryx.FactoryMonitor.Web/app/src/app/services/change-background.service.ts
@@ -35,7 +35,7 @@ export class ChangeBackgroundService {
     });
     this.factoryMonitorService.initialFactoryState().subscribe({
       next: (fsm: FactoryStateModel) => {
-        this._backgroundChanged.next(fsm.backgroundURL ?? this.defaultUrl);
+        this.changeLocalBackground(fsm.backgroundURL ?? this.defaultUrl);
       }
     });
   }
@@ -50,14 +50,25 @@ export class ChangeBackgroundService {
       })
       .subscribe({
         next: () => {
-          this._backgroundChanged.next(url);
+          this.changeLocalBackground(url);
         },
         error: () => this.snackbarService.showError('An error occured while saving the background URL')
       });
   }
 
   public changeLocalBackground(url: string) {
+    if (!this.isAbsoluteUrl(url)) {
+      url = environment.rootUrl + url;
+    }
+    
     this._backgroundChanged.next(url);
   }
+  
+  private isAbsoluteUrl(url: string): boolean {
+    try {
+      return Boolean(new URL(url).origin);
+    } catch {
+      return false;
+    }
+  }
 }
-

--- a/src/Moryx.FactoryMonitor.Web/app/src/app/services/change-background.service.ts
+++ b/src/Moryx.FactoryMonitor.Web/app/src/app/services/change-background.service.ts
@@ -3,13 +3,13 @@
  * Licensed under the Apache License, Version 2.0
 */
 
-import { inject, Injectable } from '@angular/core';
+import { computed, inject, Injectable } from '@angular/core';
 import { BehaviorSubject } from 'rxjs';
 import { FactoryMonitorService } from '../api/services';
 import { SnackbarService } from '@moryx/ngx-web-framework/services';
 import { FactorySelectionService } from './factory-selection.service';
 import { environment } from 'src/environments/environment';
-import { FactoryStateModel } from '../api/models/factory-state-model';
+import { toSignal } from '@angular/core/rxjs-interop';
 
 @Injectable({
   providedIn: 'root'
@@ -17,46 +17,34 @@ import { FactoryStateModel } from '../api/models/factory-state-model';
 export class ChangeBackgroundService {
   private factoryMonitorService = inject(FactoryMonitorService);
   private snackbarService = inject(SnackbarService);
-  private factorySelectionService = inject(FactorySelectionService);
 
-  defaultUrl = environment.rootUrl + '/background.PNG';
-  private _factory?: number;
-  private _backgroundChanged = new BehaviorSubject<string>(this.defaultUrl);
+  private _factory = toSignal(inject(FactorySelectionService).factorySelected$);
+  private _backgroundChanged = new BehaviorSubject<string|undefined>(undefined);
   public backgroundChanged$ = this._backgroundChanged.asObservable();
-  private _canSaveBackground = new BehaviorSubject<boolean>(false);
-  public canSaveBackground$ = this._canSaveBackground.asObservable();
-
-  constructor() {
-    this.factorySelectionService.factorySelected$.subscribe({
-      next: factorySelected => {
-        this._factory = factorySelected;
-        this._canSaveBackground.next(true);
-      }
-    });
-    this.factoryMonitorService.initialFactoryState().subscribe({
-      next: (fsm: FactoryStateModel) => {
-        this.changeLocalBackground(fsm.backgroundURL ?? this.defaultUrl);
-      }
-    });
-  }
+  public canSaveBackground = computed(() => !!this._factory());
 
   public changeBackground(url: string) {
     if (!url || !this._factory) return;
 
     this.factoryMonitorService
       .changeBackground({
-        resourceId: this._factory,
+        resourceId: this._factory(),
         url: url
       })
       .subscribe({
         next: () => {
-          this.changeLocalBackground(url);
+          this.updateBackground(url);
         },
         error: () => this.snackbarService.showError('An error occured while saving the background URL')
       });
   }
 
-  public changeLocalBackground(url: string) {
+  public updateBackground(url: string | null | undefined) {
+    if (!url) {
+      this._backgroundChanged.next(undefined);
+      return;
+    }
+
     if (!this.isAbsoluteUrl(url)) {
       url = environment.rootUrl + url;
     }

--- a/src/Moryx.FactoryMonitor.Web/app/src/app/services/factory-selection.service.ts
+++ b/src/Moryx.FactoryMonitor.Web/app/src/app/services/factory-selection.service.ts
@@ -9,6 +9,7 @@ import { FactoryStateModel } from '../api/models/factory-state-model';
 import { FactoryMonitorService } from '../api/services';
 import { VisualizableItemModel } from '../api/models/visualizable-item-model';
 
+// ToDo: Make this a route resolver, it loads data and does not need to be a service for that.
 @Injectable({
   providedIn: 'root'
 })

--- a/src/Moryx.FactoryMonitor.Web/app/src/app/services/factory-selection.service.ts
+++ b/src/Moryx.FactoryMonitor.Web/app/src/app/services/factory-selection.service.ts
@@ -6,8 +6,8 @@
 import { inject, Injectable } from '@angular/core';
 import { BehaviorSubject } from 'rxjs';
 import { FactoryStateModel } from '../api/models/factory-state-model';
-import { FactoryMonitorService } from '../api/services';
 import { VisualizableItemModel } from '../api/models/visualizable-item-model';
+import { FactoryMonitorService } from '../api/services';
 
 // ToDo: Make this a route resolver, it loads data and does not need to be a service for that.
 @Injectable({
@@ -36,7 +36,7 @@ export class FactorySelectionService {
       });
   }
 
-  public setDefaultFactory(factory: FactoryStateModel | undefined){
+  public initialize(factory: FactoryStateModel){
     this._defaultFactory.next(factory);
   }
 }

--- a/src/Moryx.FactoryMonitor.Web/app/src/app/services/factory-state-stream.service.ts
+++ b/src/Moryx.FactoryMonitor.Web/app/src/app/services/factory-state-stream.service.ts
@@ -4,7 +4,7 @@
 */
 
 import { inject, Injectable } from '@angular/core';
-import { BehaviorSubject } from 'rxjs';
+import { ReplaySubject } from 'rxjs';
 import { ActivityChangedModel } from '../api/models/activity-changed-model';
 import { CellStateChangedModel } from '../api/models/cell-state-changed-model';
 import { ResourceChangedModel } from '../api/models/resource-changed-model';
@@ -19,42 +19,68 @@ import { OrderChangedModel } from '../api/models/order-changed-model';
   providedIn: 'root'
 })
 export class FactoryStateStreamService {
-  private factoryMonitorService = inject(FactoryMonitorService);
-  updatedCell: BehaviorSubject<CellModel | undefined> = new BehaviorSubject<CellModel | undefined>(undefined);
-  updatedOrder: BehaviorSubject<Order | undefined> = new BehaviorSubject<Order | undefined>(undefined);
+  private readonly factoryMonitorService = inject(FactoryMonitorService);
+  private readonly Order_Event_Type_Key = "order";
+  private readonly Order_Changed_Event_Type_Key = "orderChanged";
+  private readonly Cell_State_Event_Type_Key = "cellStateChangedModel";
+  private readonly Activity_Event_Type_Key = "activityChangedModel";
+  private readonly Recource_Event_Type_Key = "resourceChangedModel";
 
-  constructor() {
+  // ToDo: Only make observable public
+  updatedCell: ReplaySubject<CellModel> = new ReplaySubject<CellModel>();
+  updatedOrder: ReplaySubject<Order> = new ReplaySubject<Order>();
+
+    constructor() {
     const eventSource = new EventSource(this.factoryMonitorService.rootUrl + FactoryMonitorService.FactoryStatesStreamPath);
-    eventSource.onmessage = event => {
-      const activityChangedModel = <ActivityChangedModel>JSON.parse(event.data);
-      const resourceChangedModel = <ResourceChangedModel>JSON.parse(event.data);
-      const cellStateChangedModel = <CellStateChangedModel>JSON.parse(event.data);
-      const orderModel = <OrderModel>JSON.parse(event.data);
-      const orderChangedModel = <OrderChangedModel>JSON.parse(event.data);
 
-      if(activityChangedModel?.resourceId){
-        const cell = Converter.activityChangedModelToCell(activityChangedModel);
-        this.updatedCell.next(cell);
-      }
-      else if(resourceChangedModel?.cellName){
-        const cell = Converter.resourceChangedModelToCell(resourceChangedModel);
-        this.updatedCell.next(cell);
-      }
-      else if(cellStateChangedModel?.id &&cellStateChangedModel?.state){
-        const cell = Converter.cellStateChangedModelToCell(cellStateChangedModel);
-        this.updatedCell.next(cell);
-      }
-      else if(orderModel?.color){
-        const order = Converter.orderModelToOrder(orderModel);
-        this.updatedOrder.next(order);
-      }
-      else if(orderChangedModel?.state){
-        const order = Converter.orderChangedModelToOrder(orderChangedModel);
-        this.updatedOrder.next(order);
-      }
-    };
+    eventSource.addEventListener(this.Order_Event_Type_Key, (event: MessageEvent<any>) => {
+      this.transformOrderEvent(event);
+    });
+
+    eventSource.addEventListener(this.Order_Changed_Event_Type_Key, (event: MessageEvent<any>) => {
+      this.transformOrderChangedEvent(event);
+    });
+
+    eventSource.addEventListener(this.Cell_State_Event_Type_Key, (event: MessageEvent<any>) => {
+      this.transformCellStateChangedEvent(event);
+    });
+
+    eventSource.addEventListener(this.Activity_Event_Type_Key, (event: MessageEvent<any>) => {
+      this.transformActivityChangedEvent(event);
+    });
+
+    eventSource.addEventListener(this.Recource_Event_Type_Key, (event: MessageEvent<any>) => {
+      this.transformResourceEvent(event);
+    });
   }
 
+  private transformResourceEvent(event: MessageEvent<any>) {
+    const resourceChangedModel = <ResourceChangedModel>JSON.parse(event.data);
+    const cell = Converter.resourceChangedModelToCell(resourceChangedModel);
+    this.updatedCell.next(cell);
+  }
 
+  private transformActivityChangedEvent(event: MessageEvent<any>) {
+    const activityChangedModel = <ActivityChangedModel>JSON.parse(event.data);
+    const cell = Converter.activityChangedModelToCell(activityChangedModel);
+    this.updatedCell.next(cell);
+  }
+
+  private transformCellStateChangedEvent(event: MessageEvent<any>) {
+    const cellStateChangedModel = <CellStateChangedModel>JSON.parse(event.data);
+    const cell = Converter.cellStateChangedModelToCell(cellStateChangedModel);
+    this.updatedCell.next(cell);
+  }
+
+  private transformOrderChangedEvent(event: MessageEvent<any>) {
+    const orderChangedModel = <OrderChangedModel>JSON.parse(event.data);
+    const order = Converter.orderChangedModelToOrder(orderChangedModel);
+    this.updatedOrder.next(order);
+  }
+
+  private transformOrderEvent(event: MessageEvent<any>) {
+    const orderModel = <OrderModel>JSON.parse(event.data);
+    const order = Converter.orderModelToOrder(orderModel);
+    this.updatedOrder.next(order);
+  }
 }
-

--- a/src/Moryx.FactoryMonitor.Web/app/src/app/services/order-store.service.ts
+++ b/src/Moryx.FactoryMonitor.Web/app/src/app/services/order-store.service.ts
@@ -4,7 +4,7 @@
 */
 
 import { inject, Injectable } from '@angular/core';
-import { BehaviorSubject, Observable, Subject } from 'rxjs';
+import { BehaviorSubject, Subject } from 'rxjs';
 import { OrderModel } from '../api/models/order-model';
 import { FactoryStateStreamService } from './factory-state-stream.service';
 import Order from '../models/order';
@@ -20,9 +20,9 @@ export class OrderStoreService {
   private _runningOrders = new BehaviorSubject<Order[]>([]);
   private _toggledOrder = new Subject<Order>();
 
-  public orders$: Observable<Order[]>;
-  public runningOrders$: Observable<Order[]>;
-  public toggledOrder$: Observable<Order>;
+  public orders$ = this._orders.asObservable();
+  public runningOrders$ = this._runningOrders.asObservable();
+  public toggledOrder$ = this._toggledOrder.asObservable();
 
   constructor() {
     this.factoryStateStreamService.updatedOrder.subscribe({
@@ -35,10 +35,7 @@ export class OrderStoreService {
       },
     });
 
-    this.orders$ = this._orders.asObservable();
     this._runningOrders.next(this._orders.getValue().filter(o => o.classification == InternalOperationClassification.Running))
-    this.runningOrders$ = this._runningOrders.asObservable();
-    this.toggledOrder$ = this._toggledOrder.asObservable();
   }
 
   private getUpdateOrders(orders: Order[]): Order[] {
@@ -110,6 +107,7 @@ export class OrderStoreService {
     this._orders.next(orders)
   }
 
+  // ToDo: Remove/make automatic
   public updateRunningOrders(){
     const orders = this._orders.getValue();
     this._runningOrders.next(orders.filter(o => o.classification == InternalOperationClassification.Running))

--- a/src/Moryx.FactoryMonitor.Web/app/src/app/services/order-store.service.ts
+++ b/src/Moryx.FactoryMonitor.Web/app/src/app/services/order-store.service.ts
@@ -25,12 +25,13 @@ export class OrderStoreService {
   public readonly runningOrders$ = this._orders.pipe(
     map(orders => orders.filter(o => o.classification === InternalOperationClassification.Running)),
     // Prevent other order state changes from triggering updates in the UI 
-    distinctUntilChanged((previousOrders, newOrders) => this.areSameSet(previousOrders, newOrders)),
+    // ToDo: Reanble when OrderManagement facade fires order-started event before order-changed-to-running event
+    // distinctUntilChanged((previousOrders, newOrders) => this.areSameSet(previousOrders, newOrders)),
     shareReplay(1)
   );
-  private areSameSet(previousOrders: Order[], newOrders: Order[]): boolean {
-    return previousOrders.length === newOrders.length && previousOrders.every((x, i) => x.orderNumber === newOrders[i].orderNumber && x.operationNumber === newOrders[i].operationNumber);
-  }
+  // private areSameSet(previousOrders: Order[], newOrders: Order[]): boolean {
+  //   return previousOrders.length === newOrders.length && previousOrders.every((x, i) => x.orderNumber === newOrders[i].orderNumber && x.operationNumber === newOrders[i].operationNumber);
+  // }
 
   constructor() {
     this.factoryStateStreamService.updatedOrder.subscribe(order => this.updateOrder(order));
@@ -51,17 +52,22 @@ export class OrderStoreService {
     }
 
     const orders = this._orders.getValue();
-    const indexToUpdate = orders.findIndex(o => o.operationNumber === order.operationNumber && o.orderNumber === order.orderNumber);
-    let orderToUpdate = orders[indexToUpdate];
+    let indexToUpdate = orders.findIndex(o => o.operationNumber === order.operationNumber && o.orderNumber === order.orderNumber);
+    if(indexToUpdate === -1) {
+      orders.push(order);
+    } else {
+      
+      let orderToUpdate = orders[indexToUpdate];
 
-    if (order.classification) {
-      orderToUpdate.classification = order.classification;
-    }
-    if (order.orderColor && order.orderColor != '') {
-      orderToUpdate.orderColor = order.orderColor;
-    }
+      if (order.classification) {
+        orderToUpdate.classification = order.classification;
+      }
+      if (order.orderColor && order.orderColor != '') {
+        orderToUpdate.orderColor = order.orderColor;
+      }
 
-    orders[indexToUpdate] = orderToUpdate;
+      orders[indexToUpdate] = orderToUpdate;
+    }
 
     this._orders.next(orders)
   }

--- a/src/Moryx.FactoryMonitor.Web/app/src/app/services/order-store.service.ts
+++ b/src/Moryx.FactoryMonitor.Web/app/src/app/services/order-store.service.ts
@@ -4,12 +4,13 @@
 */
 
 import { inject, Injectable } from '@angular/core';
-import { BehaviorSubject, Subject } from 'rxjs';
-import { OrderModel } from '../api/models/order-model';
-import { FactoryStateStreamService } from './factory-state-stream.service';
-import Order from '../models/order';
+import { BehaviorSubject, distinctUntilChanged, map, shareReplay, Subject } from 'rxjs';
+import { FactoryStateModel } from '../api/models';
 import { InternalOperationClassification } from '../api/models/internal-operation-classification';
+import { Converter } from '../extensions/converter';
 import CellModel from '../models/cellModel';
+import Order from '../models/order';
+import { FactoryStateStreamService } from './factory-state-stream.service';
 
 @Injectable({
   providedIn: 'root',
@@ -17,102 +18,66 @@ import CellModel from '../models/cellModel';
 export class OrderStoreService {
   private factoryStateStreamService = inject(FactoryStateStreamService);
 
-  public _orders = new BehaviorSubject<Order[]>([]);
-  private _runningOrders = new BehaviorSubject<Order[]>([]);
-  private _toggledOrder = new Subject<Order>();
+  private readonly _orders = new BehaviorSubject<Order[]>([]);
+  private readonly _toggledOrder = new Subject<Order>();
 
-  public orders$ = this._orders.asObservable();
-  public runningOrders$ = this._runningOrders.asObservable();
-  public toggledOrder$ = this._toggledOrder.asObservable();
+  public readonly toggledOrder$ = this._toggledOrder.asObservable();
+  public readonly runningOrders$ = this._orders.pipe(
+    map(orders => orders.filter(o => o.classification === InternalOperationClassification.Running)),
+    // Prevent other order state changes from triggering updates in the UI 
+    distinctUntilChanged((previousOrders, newOrders) => this.areSameSet(previousOrders, newOrders)),
+    shareReplay(1)
+  );
+  private areSameSet(previousOrders: Order[], newOrders: Order[]): boolean {
+    return previousOrders.length === newOrders.length && previousOrders.every((x, i) => x.orderNumber === newOrders[i].orderNumber && x.operationNumber === newOrders[i].operationNumber);
+  }
 
   constructor() {
-    this.factoryStateStreamService.updatedOrder.subscribe({
-      next: order => {
-        if (!order?.orderNumber) return;
-
-        if (!this._orders.getValue().length) return;
-
-        this.updateOrder(order);
-      },
-    });
-
-    this._runningOrders.next(this._orders.getValue().filter(o => o.classification == InternalOperationClassification.Running))
+    this.factoryStateStreamService.updatedOrder.subscribe(order => this.updateOrder(order));
   }
 
-  // ToDo: Check why it is unused
-  private getUpdateOrders(orders: Order[]): Order[] {
-    // Unselect orders that existed but were unselected
-    const currentlyUnselectedOrders = this._orders.getValue().filter(order => !order.isToggled);
-    orders.forEach(
-      no =>
-        (no.isToggled = !!!currentlyUnselectedOrders.find(
-          co =>
-            no.orderNumber === co.orderNumber &&
-            no.operationNumber === co.operationNumber
-        ))
-    );
+  public initialize(factoryState: FactoryStateModel) {
+    const orderModels = factoryState.orderModels ?? [];
 
-    return orders;
+    const orders = orderModels.map(order => Converter.orderModelToOrder(order));
+
+    this._orders.next(orders);
   }
 
-  public getOrder(orderNumber: string, operationNumber: string): Order | undefined {
-    return this._orders
-      .getValue()
-      .find(o => o.operationNumber === operationNumber && o.orderNumber === orderNumber);
-  }
-
-  public toggleOrder(order: Order) {
-    order.isToggled = !order.isToggled;
-    this._toggledOrder.next(order);
-  }
-
-  //Groupes the orders to creates a Map<string,OrderModel[]>
-  groupBy(list: OrderModel[], keyGetter: (orderType: OrderModel) => string) {
-    const map = new Map();
-    list.forEach(item => {
-      const key = keyGetter(item);
-      const collection = map.get(key);
-      if (!collection) {
-        map.set(key, [item]);
-      } else {
-        collection.push(item);
-      }
-    });
-    return map;
-  }
-
-  // flatten the grouped order that has the format Map<string, OrderModel[]> to a simple OrderModel[]
-  flattenOrders(groupedOrders: Map<string, OrderModel[]>) {
-    let orders: OrderModel[] = [];
-    groupedOrders.forEach((value: OrderModel[], key: string) =>
-      orders.push(...orders, <OrderModel>{ order: key, operation: value[0]?.operation, color: value[0]?.color })
-    );
-
-    return orders;
-  }
-
+  // We update orders partially to retain the toggled state through order updates from the backend
   public updateOrder(order: Order) {
+    if (!order?.orderNumber || !order.operationNumber) {
+      return;
+    }
+
     const orders = this._orders.getValue();
     const indexToUpdate = orders.findIndex(o => o.operationNumber === order.operationNumber && o.orderNumber === order.orderNumber);
     let orderToUpdate = orders[indexToUpdate];
 
-    if(order.classification){
+    if (order.classification) {
       orderToUpdate.classification = order.classification;
     }
-    if(order.orderColor && order.orderColor != ''){
+    if (order.orderColor && order.orderColor != '') {
       orderToUpdate.orderColor = order.orderColor;
     }
 
     orders[indexToUpdate] = orderToUpdate;
 
-    this._runningOrders.next(orders.filter(o => o.classification == InternalOperationClassification.Running))
     this._orders.next(orders)
   }
 
-  // ToDo: Remove/make automatic
-  public updateRunningOrders(){
-    const orders = this._orders.getValue();
-    this._runningOrders.next(orders.filter(o => o.classification == InternalOperationClassification.Running))
+  public getOrder(cell: CellModel): Order | undefined {
+    if (!cell?.orderNumber || !cell.operationNumber) {
+      return undefined;
+    }
+
+    return this._orders.getValue()
+      .find(o => o.operationNumber === cell.operationNumber && o.orderNumber === cell.orderNumber);
+  }
+
+  public toggleOrder(order: Order) {
+    order.isToggled = !order.isToggled;
+    this._toggledOrder.next(order);
   }
 
   public applyOrderColor(cell: CellModel): CellModel {
@@ -121,4 +86,3 @@ export class OrderStoreService {
     return cell;
   }
 }
-

--- a/src/Moryx.FactoryMonitor.Web/app/src/app/services/order-store.service.ts
+++ b/src/Moryx.FactoryMonitor.Web/app/src/app/services/order-store.service.ts
@@ -9,6 +9,7 @@ import { OrderModel } from '../api/models/order-model';
 import { FactoryStateStreamService } from './factory-state-stream.service';
 import Order from '../models/order';
 import { InternalOperationClassification } from '../api/models/internal-operation-classification';
+import CellModel from '../models/cellModel';
 
 @Injectable({
   providedIn: 'root',
@@ -38,6 +39,7 @@ export class OrderStoreService {
     this._runningOrders.next(this._orders.getValue().filter(o => o.classification == InternalOperationClassification.Running))
   }
 
+  // ToDo: Check why it is unused
   private getUpdateOrders(orders: Order[]): Order[] {
     // Unselect orders that existed but were unselected
     const currentlyUnselectedOrders = this._orders.getValue().filter(order => !order.isToggled);
@@ -111,6 +113,12 @@ export class OrderStoreService {
   public updateRunningOrders(){
     const orders = this._orders.getValue();
     this._runningOrders.next(orders.filter(o => o.classification == InternalOperationClassification.Running))
+  }
+
+  public applyOrderColor(cell: CellModel): CellModel {
+    const color = this._orders.getValue().find(o => o.operationNumber === cell.operationNumber && o.orderNumber === cell.orderNumber)?.orderColor;
+    cell.orderColor = color ?? '';
+    return cell;
   }
 }
 

--- a/src/Moryx.FactoryMonitor.Web/app/src/main.ts
+++ b/src/Moryx.FactoryMonitor.Web/app/src/main.ts
@@ -8,5 +8,39 @@ import { App } from './app/app';
 import { appConfig } from './app/app.config';
 
 bootstrapApplication(App, appConfig)
-  .catch(err => console.error(err));
+  .catch(err => {
+    console.error(err)
+    // Render a simple error instead of a blank page when loading the factory fails
+    document.body.innerHTML = `
+      <div style="
+        height: 100vh;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        margin: 0;
+        padding: 24px;
+        box-sizing: border-box;
+        font-family: Roboto, Arial, sans-serif;
+        color: #333;
+        text-align: center;
+      ">
+        <div style="
+          display: flex;
+          flex-direction: column;
+          align-items: center;
+          gap: 12px;
+        ">
+          <span class="material-icons" style="font-size: 48px; color: #666;">
+            refresh
+          </span>
 
+          <div style="font-size: 18px; line-height: 1.5;">
+            Could not load application data.<br>
+            Please
+            <a href="" onclick="window.location.reload(); return false;">reload</a>
+            the page or contact your administrator.
+          </div>
+        </div>
+      </div>
+    `;
+});


### PR DESCRIPTION
### Summary

This PR combines several changes that are split into separate coherent commits. I recommend reviewing them one by one.

[Fix state stream event types](https://github.com/PHOENIXCONTACT/MORYX-Framework/commit/369224224961670b59d941ca33cc56e6f3e038e8)  
Multiple events where combined under the same event type which did not match the actual objects anyway.
Also adds proper event listeners on UI side, events were not processed before as onMessage is not fired for typed messages.

[Fix image paths in dev environment](https://github.com/PHOENIXCONTACT/MORYX-Framework/commit/1d0586209a972dc5392af40676202e2842dd929f)  
Environment root url wasn't used for relative urls before.

[Simplify observables/signals usage in FactoryMonitor](https://github.com/PHOENIXCONTACT/MORYX-Framework/commit/9e971369f4d6eb72b8e73479161304b34ec43f39)

[Fix mapped order state enum](https://github.com/PHOENIXCONTACT/MORYX-Framework/commit/6805744f45df2c11c07e36bac12920d8d29de744)  
After the update to MORYX 10 we forgot about the mapping happening in the endpoint. As a result the endpoint send meaningless integers instead of the string-enum values

[Simplify backgorund handling in factory monitor](https://github.com/PHOENIXCONTACT/MORYX-Framework/commit/56390b810946a298ccae5ee8ee050457b417c72e)  
Before there was an unnecessary call to the initial state api, which never populates the background url, so it was always reset to a blank background. Depending on the timing this caused a bug in the UI.
We removed the API call and simplified the backround url handling.

[Fix missing assignements on duplicated properties](https://github.com/PHOENIXCONTACT/MORYX-Framework/commit/4c02acd4449bd55305e5414faad3437b683af033)  
While the duplicated properties in themselves cannot be explained the can also not be removed in this major.
Hence, we added the missing assignements and todos to verify the properties.

[Some clean-up in Factory Monitor UI components](https://github.com/PHOENIXCONTACT/MORYX-Framework/commit/1e193dca68d38233d0af8a75671b3ea2b104fa40)

[Resolve UI update issues in Factory Monitor](https://github.com/PHOENIXCONTACT/MORYX-Framework/commit/877092a34e8aa2278aaf2f6cefd7186f6f734311)  
The issues leading to stream updates not being processed were manifold.
- Remove unnecessary API call to get all cells
- Properly processed initial change models from factory state
- Finished incomplete application of signals in factory and cell components
- Added missing object recreations on updates

Also started to clean-up code, remove duplicates, unused imports, splitting of responsibilities, removal of unnecessary service references, etc.

[Fix unsynchronized machine locations](https://github.com/PHOENIXCONTACT/MORYX-Framework/pull/1238/commits/4e6fe8aaf492da1ff5f6a3ee6eaab83a97437b3f)  
The behavior before had mixed up several aspects. For cells the location is taken from the cached cell in the cell store service, which was never correctly updated and also not set on the observable with a new reference, so the update was not applied and not triggered by the signal infrastructure. For factory items the behaviour is different, as the location is retrieved on each navigation to a new factory board and not cached locally. Hence no update in the cache is necessary. Because of this, we however need to keep the drag event translation (instead of resetting it as done for the cell).

[Fix inconsistent usage of interfaces and base types](https://github.com/PHOENIXCONTACT/MORYX-Framework/pull/1238/commits/fc8b9df57d90139b9e03d360df7dd0d7fe8f66a5) 
In the factory monitor controller we should make use of the defining interfaces underneath the web module, however some functions only worked with the utility base classes which are not necessary to be used.

[Reorganize factory monitor initialization](https://github.com/PHOENIXCONTACT/MORYX-Framework/pull/1238/commits/cfe33b6801af74e6c7c2737f6fc253ee86331653)  
Before the initialization of the factory monitor ui app happened hidden in the cell-store service and from there spread into other services. We replaced this with central app initialization via an app initializer. This reduced coupling beteween the apps and fixed issues were reloading in sub factory boards lead to timing issues.

Also adds an error page when the initialization failed instead of the current blank page and removed a lot of unused code especially from the order store service

[Register new operations in factory monitor](https://github.com/PHOENIXCONTACT/MORYX-Framework/pull/1238/commits/a6c97ad9da42cadc99d11f534add31316b3e90cf)  
The order store service caches the known orders in the system, however it did not add new orders thus far.
Also the endpoint did send incomplete order models on the order started event missing the order color.

### Relevant logs and/or screenshots

**Recovered functionality:**
https://github.com/user-attachments/assets/9f26985a-62ab-429e-894c-4390157cfa8c

**Failed loading Screen:**
<img width="1920" height="1080" alt="Snag_c14b37" src="https://github.com/user-attachments/assets/ef5a5290-a55a-4aaf-82aa-bc716c24efbe" />

### Breaking Changes

While technically the changes to the event types on the factory monitor stream break existing applications, we consider them to be bugs. They mixed different types on the same typed stream and used a misleading/wrong type name for the stream.

### Checklist for Submitter

- [x] I have tested these changes locally
- [ ] I have updated documentation as needed
- [ ] I have added or updated tests as appropriate
- [x] I have used clear and descriptive commit messages

### Review

**Typical tasks**

- [ ] Merge request is well described
- [ ] Critical sections are *documented in code*
- [ ] *Tests* are extended
- [ ] *Documentation* is created / updated
- [ ] Running in test environment
- [ ] Ports to other maintained versions are created

**Clean code**

- [x] *All* unused references are removed
- [x] Clean code rules are respected with passion (naming, ...)
- [x] Avoid *copy and pasted* code snippets
