### PR TITLE
Appreciate that a process holders parent may be null

### DIFF
--- a/src/Moryx.ControlSystem.Processes.Endpoints/EventHandlers/ProcessHolderEventHandlers.cs
+++ b/src/Moryx.ControlSystem.Processes.Endpoints/EventHandlers/ProcessHolderEventHandlers.cs
@@ -62,9 +62,10 @@ internal class ProcessHolderEventHandlers
         else
         {
             var group = ProcessHolderMappers.ModelFromParent(resource);
-            var positions = resource.Parent.Children
+            var positions = resource.Parent?.Children
                 .OfType<IProcessHolderPosition>()
-                .Select((p, index) => p.ToDto(index, group.Id));
+                .Select((p, index) => p.ToDto(index, group.Id))
+                ?? [];
             group.Positions.AddRange(positions);
             broadcast(group);
         }


### PR DESCRIPTION
A missing parent should resolve to an empty list instead of null reference exception leading to items not being updated.