### PR TITLE
Added OperationCanceledException for ServerSentEvents

### DIFF
--- a/src/Moryx.ControlSystem.Jobs.Endpoints/JobManagementController.cs
+++ b/src/Moryx.ControlSystem.Jobs.Endpoints/JobManagementController.cs
@@ -102,6 +102,10 @@ public class JobManagementController : ControllerBase
 
             await result.ExecuteAsync(HttpContext);
         }
+        catch (OperationCanceledException)
+        {
+            // client disconnected — this is expected, not an error
+        }
         finally
         {
             _jobManagement.ProgressChanged -= progressEventHandler;

--- a/src/Moryx.ControlSystem.Processes.Endpoints/ProcessEngineController.cs
+++ b/src/Moryx.ControlSystem.Processes.Endpoints/ProcessEngineController.cs
@@ -280,6 +280,10 @@ public class ProcessEngineController : ControllerBase // TODO: Rename to Process
 
             await result.ExecuteAsync(HttpContext);
         }
+        catch (OperationCanceledException)
+        {
+            // client disconnected — this is expected, not an error
+        }
         finally
         {
             _processControl.ActivityUpdated -= eventHandler;

--- a/src/Moryx.ControlSystem.Processes.Endpoints/StreamServices/ProcessHolderGroupStream.cs
+++ b/src/Moryx.ControlSystem.Processes.Endpoints/StreamServices/ProcessHolderGroupStream.cs
@@ -65,6 +65,10 @@ internal class ProcessHolderGroupStream(IResourceManagement resourceManagement)
 
             await result.ExecuteAsync(context);
         }
+        catch (OperationCanceledException)
+        {
+            // client disconnected — this is expected, not an error
+        }
         finally
         {
             // Unregister handlers

--- a/src/Moryx.FactoryMonitor.Endpoints/FactoryMonitorController.cs
+++ b/src/Moryx.FactoryMonitor.Endpoints/FactoryMonitorController.cs
@@ -270,6 +270,10 @@ public class FactoryMonitorController : ControllerBase
 
             await result.ExecuteAsync(HttpContext);
         }
+        catch (OperationCanceledException)
+        {
+            // client disconnected — this is expected, not an error
+        }
         finally
         {
             // Unregister handlers
@@ -316,7 +320,7 @@ public class FactoryMonitorController : ControllerBase
         }
     }
 
-    // ToDo: Rename to move location in MORYX 12 and 
+    // ToDo: Rename to move location in MORYX 12 and
     /// <summary>
     /// Return the location of the cell in the factory
     /// </summary>

--- a/src/Moryx.Notifications.Endpoints/NotificationPublisherController.cs
+++ b/src/Moryx.Notifications.Endpoints/NotificationPublisherController.cs
@@ -81,6 +81,10 @@ public class NotificationPublisherController : ControllerBase
 
             await result.ExecuteAsync(HttpContext);
         }
+        catch (OperationCanceledException)
+        {
+            // client disconnected — this is expected, not an error
+        }
         finally
         {
             _notificationPublisher.Published -= publishedEventHandler;

--- a/src/Moryx.Orders.Endpoints/OrderManagementController.cs
+++ b/src/Moryx.Orders.Endpoints/OrderManagementController.cs
@@ -114,6 +114,10 @@ public class OrderManagementController : ControllerBase
 
             await result.ExecuteAsync(HttpContext);
         }
+        catch (OperationCanceledException)
+        {
+            // client disconnected — this is expected, not an error
+        }
         finally
         {
             _orderManagement.OperationUpdated -= updateEventHandler;

--- a/src/Moryx.VisualInstructions.Endpoints/VisualInstructionsController.cs
+++ b/src/Moryx.VisualInstructions.Endpoints/VisualInstructionsController.cs
@@ -62,6 +62,10 @@ public class VisualInstructionsController : ControllerBase
 
             await result.ExecuteAsync(HttpContext);
         }
+        catch (OperationCanceledException)
+        {
+            // client disconnected — this is expected, not an error
+        }
         finally
         {
             _visualInstructions.InstructionAdded -= eventHandler;


### PR DESCRIPTION
Added `OperationCanceledException back to SeverSentEvents. The EventSources are not closed correctly on client. This will hide the exception but the EventSources should be closed correctly: https://github.com/PHOENIXCONTACT/MORYX-Framework/issues/1255


FYI @1nf0rmagician 