### PR TITLE
Fix empty field validation in EntrySerialize Methods in Resource UI.

### DIFF
--- a/src/Moryx/Serialization/EntryConvert/EntryConvert.cs
+++ b/src/Moryx/Serialization/EntryConvert/EntryConvert.cs
@@ -465,7 +465,7 @@ public static partial class EntryConvert
     private static Entry ConvertParameter(ParameterInfo parameter, ICustomSerialization serialization)
     {
         var parameterType = parameter.ParameterType;
-        var defaultValue = parameter.HasDefaultValue ? parameter.DefaultValue.ToString() : null;
+        var defaultValue = parameter.HasDefaultValue ? parameter.DefaultValue?.ToString() : null;
 
         var parameterModel = new Entry
         {
@@ -484,7 +484,7 @@ public static partial class EntryConvert
         };
 
         // mark the parameter as required when there is no default value
-        parameterModel.Validation.IsRequired = defaultValue is null ? true : false;
+        parameterModel.Validation.IsRequired = parameter.HasDefaultValue ? false : true;
 
         switch (parameterModel.Value.Type)
         {

--- a/src/Tests/Moryx.Tests/Serialization/EntryConvertSerializationTests.cs
+++ b/src/Tests/Moryx.Tests/Serialization/EntryConvertSerializationTests.cs
@@ -139,16 +139,19 @@ public class EntryConvertSerializationTests
         // Act
         var entry = EntryConvert.EncodeMethod(method);
       
-        var demoValidation = entry.Parameters.SubEntries.First(x => x.DisplayName == "demo").Validation;
-        var exampleValidation = entry.Parameters.SubEntries.First(x => x.DisplayName == "exmaplestring").Validation;
+        var plainParameterValidation = entry.Parameters.SubEntries.First(x => x.DisplayName == "plainParameter").Validation;
+        var requiredParameterValidation = entry.Parameters.SubEntries.First(x => x.DisplayName == "requiredParameter").Validation;
         var nullableValidation = entry.Parameters.SubEntries.First(x => x.DisplayName == "nullableString").Validation;
-        var defaultValueValidation = entry.Parameters.SubEntries.First(x => x.DisplayName == "defaultValkueString").Validation;
+        var defaultValueValidation = entry.Parameters.SubEntries.First(x => x.DisplayName == "defaultValueString").Validation;
 
         // Assert
-        Assert.That(demoValidation.IsRequired, Is.True);
-        Assert.That(exampleValidation.IsRequired, Is.True);
-        Assert.That(nullableValidation.IsRequired, Is.False);
-        Assert.That(defaultValueValidation.IsRequired, Is.False);
+        Assert.Multiple(() =>
+        {
+            Assert.That(plainParameterValidation.IsRequired, Is.True ,"Plain parameter should be reuired");
+            Assert.That(requiredParameterValidation.IsRequired, Is.True , "Required parameter should be required");
+            Assert.That(nullableValidation.IsRequired, Is.False, "Nullable parameter should not be required");
+            Assert.That(defaultValueValidation.IsRequired, Is.False, "Default value shuold not be required");
+        });
     }
 
 }

--- a/src/Tests/Moryx.Tests/Serialization/EntryConvertSerializationTests.cs
+++ b/src/Tests/Moryx.Tests/Serialization/EntryConvertSerializationTests.cs
@@ -128,5 +128,27 @@ public class EntryConvertSerializationTests
         Assert.That(singleWithProvider, Is.EqualTo(3.14f).Within(1e-5));
         Assert.That(doubleWithFallback, Is.EqualTo(3.14d).Within(1e-10));
     }
+     
+    [Test]
+    public void ParametersShouldRespectRequiredAttribute()
+    {
+        // Arrange
+        var myClass = typeof(EntrySerialize_Methods);
+        var method = myClass.GetMethod(nameof(EntrySerialize_Methods.MethodWithRequiredAndOptionalParameters));
+
+        // Act
+        var entry = EntryConvert.EncodeMethod(method);
+      
+        var demoValidation = entry.Parameters.SubEntries.First(x => x.DisplayName == "demo").Validation;
+        var exampleValidation = entry.Parameters.SubEntries.First(x => x.DisplayName == "exmaplestring").Validation;
+        var nullableValidation = entry.Parameters.SubEntries.First(x => x.DisplayName == "nullableString").Validation;
+        var defaultValueValidation = entry.Parameters.SubEntries.First(x => x.DisplayName == "defaultValkueString").Validation;
+
+        // Assert
+        Assert.That(demoValidation.IsRequired, Is.True);
+        Assert.That(exampleValidation.IsRequired, Is.True);
+        Assert.That(nullableValidation.IsRequired, Is.False);
+        Assert.That(defaultValueValidation.IsRequired, Is.False);
+    }
 
 }

--- a/src/Tests/Moryx.Tests/Serialization/EntrySerializeDummies.cs
+++ b/src/Tests/Moryx.Tests/Serialization/EntrySerializeDummies.cs
@@ -1,6 +1,7 @@
 // Copyright (c) 2026 Phoenix Contact GmbH & Co. KG
 // Licensed under the Apache License, Version 2.0
 
+using System.ComponentModel.DataAnnotations;
 using System.Threading.Tasks;
 using Moryx.Serialization;
 
@@ -169,5 +170,11 @@ public class EntrySerialize_Methods : EntrySerialize_InheritedBase
     public Task<string> AsyncWithStringResult()
     {
         return Task.FromResult("Test");
+    }
+
+    [EntrySerialize]
+    public async Task<string> MethodWithRequiredAndOptionalParameters(string demo, [Required] string exmaplestring, string nullableString = null, string defaultValkueString = "Some test string")
+    {
+        return "Done";
     }
 }

--- a/src/Tests/Moryx.Tests/Serialization/EntrySerializeDummies.cs
+++ b/src/Tests/Moryx.Tests/Serialization/EntrySerializeDummies.cs
@@ -173,7 +173,7 @@ public class EntrySerialize_Methods : EntrySerialize_InheritedBase
     }
 
     [EntrySerialize]
-    public async Task<string> MethodWithRequiredAndOptionalParameters(string demo, [Required] string exmaplestring, string nullableString = null, string defaultValkueString = "Some test string")
+    public async Task<string> MethodWithRequiredAndOptionalParameters(string plainParameter, [Required] string requiredParameter, string nullableString = null, string defaultValueString = "Some test string")
     {
         return "Done";
     }


### PR DESCRIPTION
1) Updated required flag logic in EntryConvert.ConvertParameter.
2) Replaced default value check with [Required] attribute-based validation.
3) Improved handling of null/default values.
4) Cleaned and simplified validation logic.