### PR TITLE
Fix generation of the `SimpleGraph` in the factory monitor

### DIFF
--- a/src/Moryx.FactoryMonitor.Endpoints/Converter/Converter.cs
+++ b/src/Moryx.FactoryMonitor.Endpoints/Converter/Converter.cs
@@ -14,19 +14,10 @@ namespace Moryx.FactoryMonitor.Endpoints.Converter;
 /// <summary>
 /// Provide convertion for resources and models
 /// </summary>
-internal class Converter
+/// <param name="serialization">Serialization for resource entry conversions</param>
+internal class Converter(ICustomSerialization serialization)
 {
-
-    /// <summary>
-    /// Constructor
-    /// </summary>
-    /// <param name="serialization"></param>
-    public Converter(ICustomSerialization serialization)
-    {
-        Serialization = serialization;
-    }
-
-    protected ICustomSerialization Serialization { get; }
+    protected ICustomSerialization Serialization { get; } = serialization;
 
     public ResourceChangedModel ToResourceChangedModel(Resource current)
     {
@@ -39,26 +30,6 @@ internal class Converter
             Id = current.Id,
             CellPropertySettings = ToCellPropertySettings(cellEntry, current.GetType()),
             CellName = current.Name,
-        };
-    }
-
-    public static ActivityChangedModel ToActivityChangedModel(ICell current)
-    {
-        if (current == null) return null;
-
-        return new ActivityChangedModel
-        {
-            ResourceId = current.Id,
-        };
-    }
-
-    public static CellStateChangedModel ToCellStateChangedModel(Resource current)
-    {
-        if (current == null) return null;
-
-        return new CellStateChangedModel
-        {
-            Id = current.Id,
         };
     }
 
@@ -159,21 +130,6 @@ internal class Converter
     }
 
     /// <summary>
-    /// Convert Transport path to TransportModelPath
-    /// </summary>
-    /// <param name="transportPath"></param>
-    /// <returns><see cref="TransportPathModel"/></returns>
-    public static TransportPathModel ToTransportPathModel(ITransportPath transportPath)
-    {
-        return new TransportPathModel
-        {
-            Destination = ToCellLocationModel(transportPath.Destination),
-            Origin = ToCellLocationModel(transportPath.Origin),
-            WayPoints = transportPath.WayPoints
-        };
-    }
-
-    /// <summary>
     /// Convert TransportPathModel to TransportRouteModel
     /// </summary>
     /// <param name="pathModel"></param>
@@ -187,6 +143,4 @@ internal class Converter
             Paths = pathModel.WayPoints
         };
     }
-
-    public static FactoryStateModel ToFactoryStateModel(IManufacturingFactory factory) => new() { Id = factory.Id };
 }

--- a/src/Moryx.FactoryMonitor.Endpoints/Extensions/CellExtensions.cs
+++ b/src/Moryx.FactoryMonitor.Endpoints/Extensions/CellExtensions.cs
@@ -9,7 +9,6 @@ using Moryx.ControlSystem.Activities;
 using Moryx.ControlSystem.Cells;
 using Moryx.ControlSystem.Processes;
 using Moryx.ControlSystem.Recipes;
-using Moryx.Factory;
 using Moryx.FactoryMonitor.Endpoints.Models;
 
 namespace Moryx.FactoryMonitor.Endpoints.Extensions;
@@ -18,52 +17,26 @@ internal static class CellExtensions
 {
     extension(ICell cell)
     {
-        public ResourceChangedModel GetResourceChangedModel(Converter.Converter converter,
-            IResourceManagement resourceManager,
-            Func<IMachineLocation, bool> cellFilter)
+        public CellStateChangedModel GetCellStateChangedModel() => new()
         {
+            Id = cell.Id,
+            State = GetCellState(cell)
+        };
 
-            var resourceChangedCellModel = resourceManager.ReadUnsafe(cell.Id, converter.ToResourceChangedModel);
-
-            var machineLocation = resourceManager
-                .GetResources(cellFilter)
-                .FirstOrDefault(x => x.Machine?.Id == cell.Id);
-            resourceChangedCellModel.Location = Converter.Converter.ToCellLocationModel(machineLocation);
-            resourceChangedCellModel.CellLocation = resourceChangedCellModel.Location;
-            resourceChangedCellModel.CellImageURL = machineLocation.Image;
-            resourceChangedCellModel.IconName = machineLocation.SpecificIcon;
-            resourceChangedCellModel.CellIconName = resourceChangedCellModel.IconName;
-            resourceChangedCellModel.FactoryId = GetFactoryId(cell, resourceManager);
-
-            return resourceChangedCellModel;
-        }
-
-        public long GetFactoryId(IResourceManagement resourceManagement)
+        public CellStateChangedModel GetCellStateChangedModel(ActivityProgress activityProgress) => new()
         {
-            var resource = resourceManagement.ReadUnsafe(cell, x => x.GetFactory());
-            return resource?.Id ?? -1;
-        }
-
-        public CellStateChangedModel GetCellStateChangedModel(Resource resource)
-        {
-            var cellStateChangedModel = Converter.Converter.ToCellStateChangedModel(resource);
-            cellStateChangedModel.State = GetCellState(cell);
-            return cellStateChangedModel;
-        }
-
-        public CellStateChangedModel GetCellStateChangedModel(ActivityProgress activityProgress, Resource resource)
-        {
-            var model = GetCellStateChangedModel(cell, resource);
-            model.State = GetCellState(cell, activityProgress);
-
-            return model;
-        }
+            Id = cell.Id,
+            State = GetCellState(cell, activityProgress)
+        };
 
         public ActivityChangedModel GetActivityChangedModel(Activity activity,
             List<OrderModel> orderModels)
         {
-            var activityChangedModel = Converter.Converter.ToActivityChangedModel(cell);
-            activityChangedModel.Id = activity.Id;
+            var activityChangedModel = new ActivityChangedModel
+            {
+                ResourceId = cell.Id,
+                Id = activity.Id
+            };
 
             if (activity.Process is ProductionProcess)
                 activityChangedModel.Classification = ActivityClassification.Production;
@@ -79,7 +52,7 @@ internal static class CellExtensions
             return activityChangedModel;
         }
 
-        public CellState GetCellState(ActivityProgress activityProgress)
+        private CellState GetCellState(ActivityProgress activityProgress)
         {
             var state = GetCellState(cell);
             if (state is CellState.NotReadyToWork)
@@ -93,7 +66,7 @@ internal static class CellExtensions
             return CellState.Idle;
         }
 
-        public CellState GetCellState()
+        private CellState GetCellState()
         {
             var currentCapabilities = cell.Capabilities.GetAll();
             if ((currentCapabilities.Count() == 1 && currentCapabilities.Single() is NullCapabilities) || !currentCapabilities.Any())

--- a/src/Moryx.FactoryMonitor.Endpoints/Extensions/FactoryMonitorHelper.cs
+++ b/src/Moryx.FactoryMonitor.Endpoints/Extensions/FactoryMonitorHelper.cs
@@ -1,6 +1,7 @@
 // Copyright (c) 2026 Phoenix Contact GmbH & Co. KG
 // Licensed under the Apache License, Version 2.0
 
+using System.Resources;
 using Moryx.AbstractionLayer.Resources;
 using Moryx.ControlSystem.Cells;
 using Moryx.ControlSystem.Processes;
@@ -40,7 +41,7 @@ internal static class FactoryMonitorHelper
         broadcast(Cell_State_Event_Type_Key, cellModel);
     }
 
-    public static void ActivityUpdated(ActivityUpdatedEventArgs activityEventArg, List<ICell> cells, Resource resource,
+    public static void ActivityUpdated(ActivityUpdatedEventArgs activityEventArg, List<ICell> cells,
         List<OrderModel> orderModels, Action<string, object> broadcast)
     {
         if (activityEventArg.Progress == ActivityProgress.Ready)
@@ -48,12 +49,8 @@ internal static class FactoryMonitorHelper
             return;
         }
 
-        if (cells.All(x => x.Id != activityEventArg.Activity.Tracing.ResourceId))
-        {
-            return;
-        }
-
-        if (resource is not ICell cell)
+        var cell = cells.FirstOrDefault(x => x.Id == activityEventArg.Activity.Tracing.ResourceId);
+        if (cell is null)
         {
             return;
         }
@@ -61,20 +58,24 @@ internal static class FactoryMonitorHelper
         var activityChangedModel = cell.GetActivityChangedModel(activityEventArg.Activity, orderModels);
         broadcast(Activity_Event_Type_Key, activityChangedModel);
 
-        var cellStateChangedModel = cell.GetCellStateChangedModel(activityEventArg.Progress, resource);
+        var cellStateChangedModel = cell.GetCellStateChangedModel(activityEventArg.Progress);
         broadcast(Cell_State_Event_Type_Key, cellStateChangedModel);
     }
 
     public static void ResourceUpdated(IResourceManagement resourceManager,
-        Func<IMachineLocation, bool> cellFilter, Converter.Converter converter, Action<string, object> broadcast)
+        Func<IEnumerable<IMachineLocation>, Dictionary<IMachineLocation, ICell>> mapCellsTo,
+        Converter.Converter converter,
+        Action<string, object> broadcast)
     {
-        var cells = resourceManager.GetResources(cellFilter)
-            .Select(location => location.Machine)
-            .Cast<ICell>();
+        var locations = resourceManager.GetResources<IMachineLocation>();
+        // ToDo: Added and removed resources not reflected
+        var locationToCellMappings = mapCellsTo(locations);
 
-        foreach (var cell in cells)
+        foreach (var l2cMapping in locationToCellMappings)
         {
-            var resourceChangedModel = cell.GetResourceChangedModel(converter, resourceManager, cellFilter);
+            var cell = l2cMapping.Value;
+            var location = l2cMapping.Key;
+            var resourceChangedModel = cell.GetResourceChangedModel(converter, resourceManager, location);
             broadcast(Recource_Event_Type_Key, resourceChangedModel);
         }
     }

--- a/src/Moryx.FactoryMonitor.Endpoints/Extensions/OrderManagementExtensions.cs
+++ b/src/Moryx.FactoryMonitor.Endpoints/Extensions/OrderManagementExtensions.cs
@@ -10,13 +10,15 @@ internal static class OrderManagementExtensions
 {
     public static List<OrderModel> GetOrderModels(this IOrderManagement orderManager, string[] colorPalette)
     {
-        var orders = orderManager.GetOperations(x => x.State is OperationStateClassification.Running)
-            .Select(Converter.Converter.ToOrderModel).ToList();
+        var orderModels = orderManager.GetOperations(x => x.State is OperationStateClassification.Running)
+                .Select(Converter.Converter.ToOrderModel).OrderBy(x => x.Order).ThenBy(x => x.Operation).ToList();
 
         // Assign color to order
-        for (int i = 0; i < orders.Count; i++)
-            orders[i].Color = colorPalette[i % colorPalette.Length];
+        for (var i = 0; i < orderModels.Count; i++)
+        {
+            orderModels[i].Color = colorPalette[i % colorPalette.Length];
+        }
 
-        return orders;
+        return orderModels;
     }
 }

--- a/src/Moryx.FactoryMonitor.Endpoints/Extensions/ResourceExtensions.cs
+++ b/src/Moryx.FactoryMonitor.Endpoints/Extensions/ResourceExtensions.cs
@@ -2,27 +2,44 @@
 // Licensed under the Apache License, Version 2.0
 
 using Moryx.AbstractionLayer.Resources;
+using Moryx.ControlSystem.Cells;
 using Moryx.Factory;
+using Moryx.FactoryMonitor.Endpoints.Models;
 
 namespace Moryx.FactoryMonitor.Endpoints.Extensions;
 
 internal static class ResourceExtensions
 {
-    public static Resource GetFactory(this Resource resource)
+    extension(Resource resource)
     {
-        var parent = resource.Parent;
-        if (parent is null)
+        public Resource GetFactory() => resource.Parent switch
         {
-            return null;
+            null => null,
+            IManufacturingFactory => resource.Parent,
+            _ => GetFactory(resource.Parent),
+        };
+    }
+
+    extension(IResource resource)
+    {
+        public ResourceChangedModel GetResourceChangedModel(Converter.Converter converter,
+            IResourceManagement resourceManager,
+            IMachineLocation machineLocation)
+        {
+            var resourceChangedCellModel = resourceManager.ReadUnsafe(resource.Id, converter.ToResourceChangedModel);
+
+            resourceChangedCellModel.Location = Converter.Converter.ToCellLocationModel(machineLocation);
+            resourceChangedCellModel.CellImageURL = machineLocation.Image;
+            resourceChangedCellModel.IconName = machineLocation.SpecificIcon;
+            resourceChangedCellModel.FactoryId = GetFactoryId(resource, resourceManager);
+
+            return resourceChangedCellModel;
         }
 
-        if (parent is IManufacturingFactory)
+        public long GetFactoryId(IResourceManagement resourceManagement)
         {
-            return parent;
-        }
-        else
-        {
-            return GetFactory(parent);
+            var factory = resourceManagement.ReadUnsafe(resource, x => x.GetFactory());
+            return factory?.Id ?? -1;
         }
     }
 }

--- a/src/Moryx.FactoryMonitor.Endpoints/Extensions/ResourceManagementExtensions.cs
+++ b/src/Moryx.FactoryMonitor.Endpoints/Extensions/ResourceManagementExtensions.cs
@@ -12,7 +12,7 @@ internal static class ResourceManagementExtensions
 {
     public static IManufacturingFactory GetRootFactory(this IResourceManagement resourceManagement)
     {
-        var rootFactory = resourceManagement.GetResource<IManufacturingFactory>(x => (x as ManufacturingFactory).Parent is null);
+        var rootFactory = resourceManagement.GetResource<IManufacturingFactory>(x => (x as Resource).Parent is null);
 
         return rootFactory is null ? throw new NoRootFactoryException(Strings.ResourceManagementExtensions_NoRootFactoryException) : rootFactory;
     }

--- a/src/Moryx.FactoryMonitor.Endpoints/FactoryMonitorController.cs
+++ b/src/Moryx.FactoryMonitor.Endpoints/FactoryMonitorController.cs
@@ -49,7 +49,7 @@ public class FactoryMonitorController : ControllerBase
         Converters = { new JsonStringEnumConverter() }
     };
 
-    private List<ICell> _cells;
+    private Dictionary<IMachineLocation, ICell> _locationToCellMappings;
     private Timer _resourceChangedTimer;
     private readonly ILogger<FactoryMonitorController> _logger;
 
@@ -74,29 +74,27 @@ public class FactoryMonitorController : ControllerBase
         var resourceChangedModels = new List<ResourceChangedModel>();
 
         var locations = _resourceManager.GetResources<IMachineLocation>();
-        var cells = locations.Where(CellFilterBaseOnLocation)
-            .Select(l => l.Machine)
-            .Cast<ICell>().ToList();
-        var orders = _orderManager.GetOrderModels(_colorPalette).OrderBy(x => x.Order).ThenBy(x => x.Operation).ToList();
-        var activities = _processControl.GetRunningProcesses()
-            .Select(p => p.CurrentActivity())
-            .Where(a => a is not null && a.Tracing is not null);
+        var locationsToCellMappings = MapCellsTo(locations);
+        var orders = TryGetOrders();
+        var activities = TryGetActivities();
         var converter = new Converter.Converter(_serialization);
 
-        foreach (var cell in cells)
+        foreach (var l2cMapping in locationsToCellMappings)
         {
-            if (activities.Any(a => a.Tracing.ResourceId == cell.Id && a.Tracing.Started is not null && a.Tracing.Completed is null))
+            var location = l2cMapping.Key;
+            var cell = l2cMapping.Value;
+            var activity = activities.FirstOrDefault(a => a.Tracing.ResourceId == cell.Id && a.Tracing.Started is not null && a.Tracing.Completed is null);
+            if (activity is not null)
             {
-                var activity = activities.FirstOrDefault(a => a.Tracing.ResourceId == cell.Id);
                 //to-do: handle multiple activities in one cell
                 activityChangedModels.Add(cell.GetActivityChangedModel(activity, orders));
-                cellStateChangedModels.Add(cell.GetCellStateChangedModel(ActivityProgress.Running, _resourceManager.ReadUnsafe(cell.Id, r => r)));
+                cellStateChangedModels.Add(cell.GetCellStateChangedModel(ActivityProgress.Running));
             }
             else
             {
-                cellStateChangedModels.Add(cell.GetCellStateChangedModel(_resourceManager.ReadUnsafe(cell.Id, r => r)));
+                cellStateChangedModels.Add(cell.GetCellStateChangedModel());
             }
-            resourceChangedModels.Add(cell.GetResourceChangedModel(converter, _resourceManager, CellFilterBaseOnLocation));
+            resourceChangedModels.Add(cell.GetResourceChangedModel(converter, _resourceManager, location));
         }
 
         activityChangedModels = [.. activityChangedModels.OrderBy(x => x.ResourceId)];
@@ -105,7 +103,7 @@ public class FactoryMonitorController : ControllerBase
 
         var factory = _resourceManager.GetRootFactory();
 
-        var model = Converter.Converter.ToFactoryStateModel(factory);
+        var model = new FactoryStateModel() { Id = factory.Id };
         model.ActivityChangedModels = activityChangedModels;
         model.CellStateChangedModels = cellStateChangedModels;
         model.ResourceChangedModels = resourceChangedModels;
@@ -113,6 +111,42 @@ public class FactoryMonitorController : ControllerBase
 
         return model;
     }
+
+    private IEnumerable<AbstractionLayer.Activities.Activity> TryGetActivities()
+    {
+        try
+        {
+            return _processControl.GetRunningProcesses()
+                .Select(p => p.CurrentActivity())
+                .Where(a => a is not null && a.Tracing is not null);
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e, "Could not retrieve activity information in {name}", nameof(FactoryMonitorController));
+            // We want to fail gracefully, if e.g. the facade is not yet available
+            return [];
+        }
+    }
+
+    private List<OrderModel> TryGetOrders()
+    {
+        try
+        {
+            return _orderManager.GetOrderModels(_colorPalette);
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e, "Could not retrieve order information in {name}", nameof(FactoryMonitorController));
+            // We want to fail gracefully, if e.g. the facade is not yet available
+            return [];
+        }
+    }
+
+    // ToDo: This is sub-optimal as IMachineLocation does not require a cell to be referenced (and shouldn't) but we
+    // assume each location to have a cell in this endpoint and the UI. Could be changed for MORYX 12;
+    // Also this constitutes duplicate scan-through-the-resource-graph-logic as in the SimpleGraph implementation, this should be unified
+    private Dictionary<IMachineLocation, ICell> MapCellsTo(IEnumerable<IMachineLocation> locations) =>
+        locations.ToDictionary(l => l, GetReferencedCellOrChildCell).Where(kv => kv.Value is not null).ToDictionary();
 
     // Currently returns a list of all visualizable items and is not used, so remove or at least rename in MORYX 12
     /// <summary>
@@ -122,11 +156,12 @@ public class FactoryMonitorController : ControllerBase
     [HttpGet("cells")]
     public ActionResult<List<VisualizableItemModel>> AllCells()
     {
-        var cells = _resourceManager.GetResources<IMachineLocation>()
-            .Where(CellFilterBaseOnLocation);
+        var locations = _resourceManager.GetResources<IMachineLocation>();
+        var locationToCellMappings = MapCellsTo(locations);
 
         var converter = new Converter.Converter(_serialization);
-        return cells.Select(x => new SimpleGraph { Id = x.Id }.ToVisualItemModel(_resourceManager, _logger, converter, CellFilterBaseOnLocation)).ToList();
+        return locationToCellMappings.Select(l2cMapping => new SimpleGraph { Id = l2cMapping.Key.Id }
+            .ToVisualItemModel(_resourceManager, _logger, converter)).ToList();
     }
 
     // ToDo: Endpoints usually return arrays and pagination would be good.
@@ -142,29 +177,12 @@ public class FactoryMonitorController : ControllerBase
         {
             return NotFound(Strings.FactoryMonitorController_FactoryNotFound_);
         }
-        var converter = new Converter.Converter(_serialization);
 
-        var root = _resourceManager.GetRootFactory();
-        // ToDo: Cannot assume ManufacturingFactory base class
+        var converter = new Converter.Converter(_serialization);
         var graph = _resourceManager.ReadUnsafe(factory.Id, SimpleGraph.Create);
 
-        //root level (Factory)
-        if (root.Id == factoryId)
-        {
-            return graph.Children
-                .Select(e => e.ToVisualItemModel(_resourceManager, _logger, converter, CellFilterBaseOnLocation))
-                .Where(x => x is not null).ToList();
-        }
-
-        // 1 level tree graph
-        graph = graph.GetSubGraphById(factoryId);
-        if (graph is null)
-        {
-            return NotFound();
-        }
-
         var output = graph.Children
-            .Select(e => e.ToVisualItemModel(_resourceManager, _logger, converter, CellFilterBaseOnLocation))
+            .Select(e => e.ToVisualItemModel(_resourceManager, _logger, converter))
             .Where(x => x is not null).ToList();
 
         return output;
@@ -216,11 +234,10 @@ public class FactoryMonitorController : ControllerBase
     {
         // Early validation - check if there are cells to monitor
         var locations = _resourceManager.GetResources<IMachineLocation>();
-        _cells = locations.Where(CellFilterBaseOnLocation)
-            .Select(l => l.Machine)
-            .Cast<ICell>().ToList();
+        // ToDo: Added and removed resources not reflected
+        _locationToCellMappings = MapCellsTo(locations);
 
-        if (_cells.Count == 0)
+        if (_locationToCellMappings.Count == 0)
         {
             Response.Headers.Append("Retry-After", "5");
             return;
@@ -231,21 +248,21 @@ public class FactoryMonitorController : ControllerBase
 
         // Define event handlers using helper methods
         var resourceEventHandler = new ElapsedEventHandler((_, _) =>
-            FactoryMonitorHelper.ResourceUpdated(_resourceManager, CellFilterBaseOnLocation, converter, Broadcast));
+            FactoryMonitorHelper.ResourceUpdated(_resourceManager, l => MapCellsTo(l), converter, Broadcast));
 
         var capabilitiesEventHandler = new EventHandler<ICapabilities>((sender, _) =>
-            FactoryMonitorHelper.PublishCellUpdate((sender as ICell).GetCellStateChangedModel(_resourceManager.ReadUnsafe((sender as ICell).Id, r => r)),
-                Broadcast));
+            FactoryMonitorHelper.PublishCellUpdate((sender as ICell)?.GetCellStateChangedModel(), Broadcast));
 
         var orderStartedEventHandler = new EventHandler<OperationStartedEventArgs>((_, eventArgs) =>
-            FactoryMonitorHelper.OrderStarted(eventArgs, _orderManager.GetOrderModels(_colorPalette), Broadcast));
+            FactoryMonitorHelper.OrderStarted(eventArgs, TryGetOrders(), Broadcast));
 
         var orderEventHandler = new EventHandler<OperationChangedEventArgs>((sender, eventArgs) =>
             FactoryMonitorHelper.OrderUpdated(eventArgs, Broadcast));
 
+        // ToDo: This breaks if new cells were added and process activities
         var activityEventHandler = new EventHandler<ActivityUpdatedEventArgs>((sender, eventArgs) =>
-            FactoryMonitorHelper.ActivityUpdated(eventArgs, _cells, _resourceManager.ReadUnsafe(eventArgs.Activity.Tracing.ResourceId, r => r),
-                _orderManager.GetOrderModels(_colorPalette), Broadcast));
+            FactoryMonitorHelper.ActivityUpdated(eventArgs, [.. _locationToCellMappings.Values],
+                TryGetOrders(), Broadcast));
 
         // Setup timer
         _resourceChangedTimer = new();
@@ -258,9 +275,9 @@ public class FactoryMonitorController : ControllerBase
             var result = TypedResults.ServerSentEvents(Subscribe(cancellationToken));
 
             // Register event handlers after result creation but before execution to ensure finally cleanup
-            foreach (var cell in _cells)
+            foreach (var l2cMapping in _locationToCellMappings)
             {
-                cell.CapabilitiesChanged += capabilitiesEventHandler;
+                l2cMapping.Value.CapabilitiesChanged += capabilitiesEventHandler;
             }
 
             _orderManager.OperationStarted += orderStartedEventHandler;
@@ -273,9 +290,9 @@ public class FactoryMonitorController : ControllerBase
         finally
         {
             // Unregister handlers
-            foreach (var cell in _cells)
+            foreach (var l2cMapping in _locationToCellMappings)
             {
-                cell.CapabilitiesChanged -= capabilitiesEventHandler;
+                l2cMapping.Value.CapabilitiesChanged -= capabilitiesEventHandler;
             }
 
             _orderManager.OperationStarted -= orderStartedEventHandler;
@@ -379,6 +396,7 @@ public class FactoryMonitorController : ControllerBase
         return converter.ToResourceChangedModel(cell)?.CellPropertySettings;
     }
 
+    // ToDo: Unused in MORYX 10 can be removed. If transports should be reflected, use different model
     /// <summary>
     /// Traces the route between 2 machines locations
     /// </summary>
@@ -449,26 +467,47 @@ public class FactoryMonitorController : ControllerBase
         return FactoryMonitorHelper.CreateRoutes(locations);
     }
 
-    private bool CellFilterBaseOnLocation(IMachineLocation locationParam)
+    private ICell GetReferencedCellOrChildCell(IMachineLocation location)
     {
-        var location = _resourceManager.ReadUnsafe(locationParam.Id, e => e as IMachineLocation);
+        var resource = _resourceManager.ReadUnsafe(location.Id, e => e);
 
-        if (location is null)
+        if (resource is not IMachineLocation locationResource)
         {
-            return false;
-        }
-        else if (location is ICell)
-        {
-            return true;
+            throw new ArgumentException($"This cannot happen, unless there is a bug in the {_resourceManager}", nameof(location));
         }
 
-        var machine = (location as Resource).Children.FirstOrDefault(x => x is ICell);
-
-        if (machine is null)
+        // Location is referencing a cell directly
+        if (locationResource.Machine is ICell referencedCell)
         {
-            return false;
+            // ToDo: Return Resource Proxy instead
+            return referencedCell;
         }
 
-        return true;
+        // Use a child cell instead
+        return GetChildCell(resource);
+    }
+
+    private static ICell GetChildCell(Resource resource)
+    {
+        // Location has no children so we don't have a referenced cell
+        if (!resource.Children.Any())
+        {
+            return null;
+        }
+
+        var childCell = resource.Children.FirstOrDefault(x => x is ICell) as ICell;
+        if (childCell is null)
+        {
+            foreach (var notACell in resource.Children)
+            {
+                var cell = GetChildCell(notACell);
+                if (cell is not null)
+                {
+                    return cell;
+                }
+            }
+        }
+
+        return childCell;
     }
 }

--- a/src/Moryx.FactoryMonitor.Endpoints/Models/ResourceChangedModel.cs
+++ b/src/Moryx.FactoryMonitor.Endpoints/Models/ResourceChangedModel.cs
@@ -16,17 +16,18 @@ public class ResourceChangedModel : VisualizableItemModel
 
     // ToDo: Verify why this is duplicated and not using the location of the visual item
     [DataMember]
-    public virtual string CellIconName { get; set; }
+    public virtual string CellIconName { get => base.IconName; set => base.IconName = value; }
 
     [DataMember]
     public virtual string CellImageURL { get; set; }
 
+    // ToDo: Verify why this is duplicated and not using the location of the visual item
     [DataMember]
-    public long Id { get; set; }
+    public long Id { get => base.Id; set => base.Id = value; }
 
     // ToDo: Verify why this is duplicated and not using the location of the visual item
     [DataMember]
-    public CellLocationModel CellLocation { get; set; }
+    public CellLocationModel CellLocation { get => base.Location; set => base.Location = value; }
 
     [DataMember]
     public Dictionary<string, CellPropertySettings> CellPropertySettings { get; set; }

--- a/src/Moryx.FactoryMonitor.Endpoints/Models/SimpleFactoryGraph.cs
+++ b/src/Moryx.FactoryMonitor.Endpoints/Models/SimpleFactoryGraph.cs
@@ -28,5 +28,5 @@ public class SimpleFactoryGraph
     /// <summary>
     /// Contains the elements that should be displayed in the current factory
     /// </summary>
-    public List<SimpleFactoryGraph> Children { get; set; } = new List<SimpleFactoryGraph>();
+    public List<SimpleFactoryGraph> Children { get; set; } = [];
 }

--- a/src/Moryx.FactoryMonitor.Endpoints/Models/SimpleGraph.cs
+++ b/src/Moryx.FactoryMonitor.Endpoints/Models/SimpleGraph.cs
@@ -30,10 +30,10 @@ internal class SimpleGraph
     /// <summary>
     /// Contains the elements that should be displayed in the current factory
     /// </summary>
-    public List<SimpleGraph> Children { get; set; } = new List<SimpleGraph>();
+    public List<SimpleGraph> Children { get; set; } = [];
 
     /// <summary>
-    /// Creates a full simple Graph from the <paramref name="resource"/>
+    /// Creates a full <see cref="SimpleGraph"/> from the <paramref name="resource"/>
     /// </summary>
     public static SimpleGraph Create(Resource resource)
     {
@@ -47,60 +47,54 @@ internal class SimpleGraph
             Id = factory.Id,
             Type = nameof(IManufacturingFactory)
         };
-        resource.Children.ForEach(graph.Append);
+        resource.Children.ForEach(graph.AppendLocation);
         return graph;
     }
 
+    // ToDo: Use existing graph model
     public VisualizableItemModel ToVisualItemModel(IResourceManagement resourceManager,
         ILogger<FactoryMonitorController> logger,
-        Converter.Converter converter,
-        Func<IMachineLocation, bool> filter)
+        Converter.Converter converter)
     {
-        var result = resourceManager.ReadUnsafe(Id, resource =>
+        if (Type is not nameof(IMachineLocation))
         {
-            if (resource is not IMachineLocation machineLocation)
-            {
-                return null;
-            }
+            return null;
+        }
 
-            var resourcesAtThisLocation = resource.Children.Where(x => x is ICell || x is IManufacturingFactory).ToArray();
-            if(resource is ICell || resource is IManufacturingFactory)
-            {
-                resourcesAtThisLocation = [resource];
-            }
-            else if (resourcesAtThisLocation.Length == 0)
-            {
-                logger.LogError("There is no resource type Cell or ManufacturingFactory found under Location '{Name}'",
-                    machineLocation.Name);
-                return null;
-            }
-            else if (resourcesAtThisLocation.Length > 1)
-            {
-                logger.Log(LogLevel.Warning, "More than one resource were found under Location '{Name}'. The first child will be used",
-                    machineLocation.Name);
-            }
+        if (Children.Count == 0)
+        {
+            logger.LogError("There is no resource of type {cell} or {factory} found under Location '{id}'",
+                nameof(ICell), nameof(ManufacturingFactory), Id);
+            return null;
+        }
 
-            var resourceAtThisLocation = resourcesAtThisLocation.First();
+        if (Children.Count > 1)
+        {
+            logger.Log(LogLevel.Warning, "More than one resource were found under {location} '{id}'. The first child will be used",
+                nameof(IMachineLocation), Id);
+        }
 
-            var model = new VisualizableItemModel();
-
-            switch (resourceAtThisLocation)
+        var location = resourceManager.GetResource<IMachineLocation>(Id);
+        var targetResourceId = Children.First().Id;
+        return resourceManager.ReadUnsafe<VisualizableItemModel>(targetResourceId, target =>
+        {
+            switch (target)
             {
                 case ICell cell:
-                    model = cell.GetResourceChangedModel(converter, resourceManager, filter);
+                    var model = cell.GetResourceChangedModel(converter, resourceManager, location);
                     model.IsACell = true;
-                    break;
+                    return model;
                 case IManufacturingFactory factory:
-                    model = Converter.Converter.ToFactoryStateModel(factory);
-                    break;
+                    return new FactoryStateModel
+                    {
+                        Id = factory.Id,
+                        Location = Converter.Converter.ToCellLocationModel(location),
+                        IconName = location.SpecificIcon
+                    };
+                default:
+                    return null;
             }
-            model.IconName = machineLocation.SpecificIcon;
-            model.Id = resourceAtThisLocation.Id;
-            model.Location = Converter.Converter.ToCellLocationModel(machineLocation);
-            return model;
         });
-
-        return result;
     }
 
     public SimpleGraph GetSubGraphById(long id)
@@ -121,35 +115,89 @@ internal class SimpleGraph
         return null;
     }
 
+    /// <summary>
+    /// Appends a non-location layer, currently only <see cref="IManufacturingFactory"/> and
+    /// <see cref="ICell"/>, the latter of which denote leave notes
+    /// </summary>
+    /// <param name="addition">A possible <see cref="IManufacturingFactory"/>, <see cref="ICell"/> or a parent resource of one</param>
     public void Append(Resource addition)
     {
         switch (addition)
         {
-            case IMachineLocation:
             case IManufacturingFactory:
             case ICell:
                 AddSubGraph(addition);
                 return;
 
-            case IMachineGroup group:
+            default:
                 addition.Children?.ForEach(Append);
                 return;
         }
     }
 
+    /// <summary>
+    /// Appends a location level to the current <see cref="SimpleGraph"/>
+    /// </summary>
+    /// <param name="addition">A possible <see cref="IMachineLocation"/> or a parent resource of one</param>
+    public void AppendLocation(Resource addition)
+    {
+        if (addition is IMachineLocation)
+        {
+            AddSubGraph(addition);
+            return;
+        }
+
+        addition.Children?.ForEach(AppendLocation);
+        return;
+    }
+
     private void AddSubGraph(Resource addition)
+    {
+        // Add the node itself
+        var subGraph = AddSubGraphRoot(addition);
+
+        // Proceed through the resource tree
+        switch (addition)
+        {
+            // Prefer machine property as target of the location before using children
+            // This unifies behaviour with the gathering of resource changed models in the controller
+            // ToDo: With MORYX 12 locations shhould hold a list of targets which should be used exclusively instead of children here
+            case IMachineLocation { Machine: Resource child }:
+                subGraph.Append(child);
+                return;
+            // Keep fallback behaviour to use machine location children
+            case IMachineLocation:
+                addition.Children.ForEach(subGraph.Append);
+                return;
+            // In factories we first need locations
+            case IManufacturingFactory:
+                addition.Children.ForEach(subGraph.AppendLocation);
+                return;
+            // Cells denote leave nodes in the Graph
+            // ToDo: MORYX 12: Change behaviour to make all none IManufacturingFactory resources leaves
+            case ICell:
+                return;
+            // Skip layers of resources without meaning for the factory monitor
+            default:
+                addition.Children.ForEach(subGraph.Append);
+                return;
+        }
+    }
+
+    private SimpleGraph AddSubGraphRoot(Resource addition)
     {
         var subGraph = new SimpleGraph
         {
             Id = addition.Id,
-            Type = addition.GetType().Name
+            Type = addition switch
+            {
+                IManufacturingFactory => nameof(IManufacturingFactory),
+                IMachineLocation => nameof(IMachineLocation),
+                ICell => nameof(ICell),
+                _ => throw new InvalidOperationException()
+            }
         };
-
-        if (addition is not ICell)
-        {
-            addition.Children.ForEach(subGraph.Append);
-        }
-
         Children.Add(subGraph);
+        return subGraph;
     }
 }

--- a/src/Moryx.FactoryMonitor.Endpoints/Models/TransportPathModel.cs
+++ b/src/Moryx.FactoryMonitor.Endpoints/Models/TransportPathModel.cs
@@ -21,5 +21,5 @@ public class TransportPathModel
     public virtual CellLocationModel Destination { get; set; }
 
     [DataMember]
-    public virtual List<Position> WayPoints { get; set; } = new List<Position>();
+    public virtual List<Position> WayPoints { get; set; } = [];
 }

--- a/src/Moryx.Launcher/libman.json
+++ b/src/Moryx.Launcher/libman.json
@@ -19,7 +19,7 @@
       ]
     },
     {
-      "library": "material-symbols@0.40.2",
+      "library": "material-symbols@0.44.12",
       "destination": "wwwroot/lib/material-symbols",
       "files": [
         "outlined.css",

--- a/src/Tests/Moryx.FactoryMonitor.Endpoints.Tests/BaseTest.cs
+++ b/src/Tests/Moryx.FactoryMonitor.Endpoints.Tests/BaseTest.cs
@@ -80,7 +80,7 @@ public abstract class BaseTest
         _resourceManagementMock.Setup(rm =>
                 rm.GetResource<IMachineLocation>(It.Is<Func<IMachineLocation, bool>>(f => f(_assemblyCellLocation))))
             .Returns(_assemblyCellLocation);
-        _resourceManagementMock.Setup(rm => rm.ReadUnsafe(_assemblyCellLocation.Id, It.IsAny<Func<Resource, IMachineLocation>>()))
+        _resourceManagementMock.Setup(rm => rm.ReadUnsafe(_assemblyCellLocation.Id, It.IsAny<Func<Resource, IResource>>()))
             .Returns(_assemblyCellLocation);
         //_solderingCell location
         _solderingCellLocation = _graph.Instantiate<MachineLocation>();
@@ -91,7 +91,7 @@ public abstract class BaseTest
         _resourceManagementMock.Setup(rm =>
                 rm.GetResource<IMachineLocation>(It.Is<Func<IMachineLocation, bool>>(f => f(_solderingCellLocation))))
             .Returns(_solderingCellLocation);
-        _resourceManagementMock.Setup(rm => rm.ReadUnsafe(_solderingCellLocation.Id, It.IsAny<Func<Resource, IMachineLocation>>()))
+        _resourceManagementMock.Setup(rm => rm.ReadUnsafe(_solderingCellLocation.Id, It.IsAny<Func<Resource, IResource>>()))
             .Returns(_solderingCellLocation);
 
         // resource management cells
@@ -101,15 +101,15 @@ public abstract class BaseTest
             .Returns(GetLocations());
         _resourceManagementMock.Setup(rm => rm.GetResources(It.IsAny<Func<IMachineLocation, bool>>()))
             .Returns(GetLocations());
-        _resourceManagementMock.Setup(rm => rm.ReadUnsafe(_assemblyCellId, It.IsAny<Func<Resource, Resource>>()))
+        _resourceManagementMock.Setup(rm => rm.ReadUnsafe(_assemblyCellId, It.IsAny<Func<Resource, IResource>>()))
             .Returns(_assemblyCell);
         _resourceManagementMock.Setup(rm => rm.ReadUnsafe(_assemblyCellId, It.IsAny<Func<Resource, ResourceChangedModel>>()))
             .Returns(converter.ToResourceChangedModel(_assemblyCell));
-        _resourceManagementMock.Setup(rm => rm.ReadUnsafe(_solderingCellId, It.IsAny<Func<Resource, Resource>>()))
+        _resourceManagementMock.Setup(rm => rm.ReadUnsafe(_solderingCellId, It.IsAny<Func<Resource, IResource>>()))
             .Returns(_solderingCell);
         _resourceManagementMock.Setup(rm => rm.ReadUnsafe(_solderingCellId, It.IsAny<Func<Resource, ResourceChangedModel>>()))
             .Returns(converter.ToResourceChangedModel(_solderingCell));
-        _resourceManagementMock.Setup(rm => rm.ReadUnsafe(_manufactoringFactoryId, It.IsAny<Func<Resource, Resource>>()))
+        _resourceManagementMock.Setup(rm => rm.ReadUnsafe(_manufactoringFactoryId, It.IsAny<Func<Resource, IResource>>()))
             .Returns(_manufactoringFactory);
         _resourceManagementMock.Setup(rm => rm.ReadUnsafe(_manufactoringFactoryId, It.IsAny<Func<Resource, ResourceChangedModel>>()))
             .Returns(converter.ToResourceChangedModel(_manufactoringFactory));


### PR DESCRIPTION
Currently the `SimpleGraph` and the factory state generation have a duplicate implementation of the logic to scan the resource graph.
After the logic was fixed for the state models in #1238 we now follow up on the generation of the `SimpleGraph`.

With this PR we prioratize the machine property of the locations over scanning the resource children. Also we add robustness to custom implementations of the interfaces in which a resource can implement both `IMachineLocation` and `ICell`, in these cases the graph now adds the location first and then either the target cell or a cell underneath the location.

Also this commit cleans up a lot of code, e.g. duplicate generation of the simple graph, unnecessary calls to the unsafe resource facade apis, unused code, unnecessary restrictive extensions, unnecessary resource fetching of already retrieved resources...