### PR TITLE
Add ListSessions Method to ProcessEngine ModuleConsole

### DIFF
--- a/src/Moryx.AbstractionLayer/Constraints/ExpressionConstraint.cs
+++ b/src/Moryx.AbstractionLayer/Constraints/ExpressionConstraint.cs
@@ -1,6 +1,9 @@
 // Copyright (c) 2026 Phoenix Contact GmbH & Co. KG
 // Licensed under the Apache License, Version 2.0
 
+using System.Runtime.CompilerServices;
+using Moryx.Serialization;
+
 namespace Moryx.AbstractionLayer.Constraints;
 
 /// <summary>
@@ -11,28 +14,28 @@ public static class ExpressionConstraint
     /// <summary>
     /// Create a constraint that checks if an expression equals the compare value
     /// </summary>
-    public static IConstraint Equals<TContext>(Func<TContext, object> expression, object compareValue)
+    public static IConstraint Equals<TContext>(Func<TContext, object> expression, object compareValue, [CallerArgumentExpression(nameof(expression))]string expressionString = null)
         where TContext : class, IConstraintContext
     {
-        return new ExpressionEqualsConstraint<TContext>(expression, compareValue);
+        return new ExpressionEqualsConstraint<TContext>(expression, compareValue, expressionString);
     }
 
     /// <summary>
     /// Create a constraint, that checks if an expression is less or equal to the return value
     /// </summary>
-    public static IConstraint LessOrEqual<TContext>(Func<TContext, IComparable> expression, IComparable compareValue)
+    public static IConstraint LessOrEqual<TContext>(Func<TContext, IComparable> expression, IComparable compareValue, [CallerArgumentExpression(nameof(expression))] string expressionString = null)
         where TContext : class, IConstraintContext
     {
-        return new ExpressionLessConstraint<TContext>(expression, compareValue);
+        return new ExpressionLessConstraint<TContext>(expression, compareValue, expressionString);
     }
 
     /// <summary>
     /// Create a constraint, that checks if an expression is greater or equal to the return value
     /// </summary>
-    public static IConstraint GreaterOrEqual<TContext>(Func<TContext, IComparable> expression, IComparable compareValue)
+    public static IConstraint GreaterOrEqual<TContext>(Func<TContext, IComparable> expression, IComparable compareValue, [CallerArgumentExpression(nameof(expression))] string expressionString = null)
         where TContext : class, IConstraintContext
     {
-        return new ExpressionGreaterConstraint<TContext>(expression, compareValue);
+        return new ExpressionGreaterConstraint<TContext>(expression, compareValue, expressionString);
     }
 
     /// <summary>
@@ -45,20 +48,29 @@ public static class ExpressionConstraint
         /// <summary>
         /// Value the expressions return value is compared to
         /// </summary>
-        protected object Value { get; }
+        [EntrySerialize]
+        public object Value { get; }
 
         /// <summary>
         /// Expression to retrieve the value
         /// </summary>
+        [EntrySerialize(EntrySerializeMode.Never)]
         protected Func<TContext, object> Expression { get; }
+
+        /// <summary>
+        /// String used for showing the expression to the user
+        /// </summary>
+        [EntrySerialize]
+        public string ExpressionString { get; }
 
         /// <summary>
         /// Create a new expression constraint
         /// </summary>
-        protected ExpressionConstraintBase(Func<TContext, object> expression, object value)
+        protected ExpressionConstraintBase(Func<TContext, object> expression, object value, string expressionString)
         {
             Expression = expression;
             Value = value;
+            ExpressionString = expressionString;
         }
 
         /// <summary>
@@ -74,6 +86,13 @@ public static class ExpressionConstraint
         /// Typed constraint check
         /// </summary>
         protected abstract bool CheckConstraint(TContext context);
+
+        protected abstract string OperatorString { get; }
+
+        public override string ToString()
+        {
+            return $"{ExpressionString} {OperatorString} {Value}";
+        }
     }
 
     /// <summary>
@@ -82,9 +101,15 @@ public static class ExpressionConstraint
     private class ExpressionEqualsConstraint<TContext> : ExpressionConstraintBase<TContext>
         where TContext : class, IConstraintContext
     {
-        public ExpressionEqualsConstraint(Func<TContext, object> expression, object value) : base(expression, value)
+        public ExpressionEqualsConstraint(Func<TContext, object> expression, object value) : this(expression, value, "Unknown")
         {
         }
+
+        public ExpressionEqualsConstraint(Func<TContext, object> expression, object value, string expressionString) : base(expression, value, expressionString)
+        {
+        }
+
+        protected override string OperatorString => "=";
 
         protected override bool CheckConstraint(TContext context)
         {
@@ -98,9 +123,11 @@ public static class ExpressionConstraint
     private class ExpressionLessConstraint<TContext> : ExpressionConstraintBase<TContext>
         where TContext : class, IConstraintContext
     {
-        public ExpressionLessConstraint(Func<TContext, object> expression, object value) : base(expression, value)
+        public ExpressionLessConstraint(Func<TContext, object> expression, object value, string expressionString) : base(expression, value, expressionString)
         {
         }
+
+        protected override string OperatorString => "<=";
 
         protected override bool CheckConstraint(TContext context)
         {
@@ -116,9 +143,11 @@ public static class ExpressionConstraint
     private class ExpressionGreaterConstraint<TContext> : ExpressionConstraintBase<TContext>
         where TContext : class, IConstraintContext
     {
-        public ExpressionGreaterConstraint(Func<TContext, object> expression, object value) : base(expression, value)
+        public ExpressionGreaterConstraint(Func<TContext, object> expression, object value, string expressionString) : base(expression, value, expressionString)
         {
         }
+
+        protected override string OperatorString => ">=";
 
         protected override bool CheckConstraint(TContext context)
         {

--- a/src/Moryx.AbstractionLayer/Constraints/ExpressionConstraint.cs
+++ b/src/Moryx.AbstractionLayer/Constraints/ExpressionConstraint.cs
@@ -48,19 +48,16 @@ public static class ExpressionConstraint
         /// <summary>
         /// Value the expressions return value is compared to
         /// </summary>
-        [EntrySerialize]
         public object Value { get; }
 
         /// <summary>
         /// Expression to retrieve the value
         /// </summary>
-        [EntrySerialize(EntrySerializeMode.Never)]
         protected Func<TContext, object> Expression { get; }
 
         /// <summary>
         /// String used for showing the expression to the user
         /// </summary>
-        [EntrySerialize]
         public string ExpressionString { get; }
 
         /// <summary>

--- a/src/Moryx.AbstractionLayer/Constraints/ExpressionConstraint.cs
+++ b/src/Moryx.AbstractionLayer/Constraints/ExpressionConstraint.cs
@@ -14,7 +14,7 @@ public static class ExpressionConstraint
     /// <summary>
     /// Create a constraint that checks if an expression equals the compare value
     /// </summary>
-    public static IConstraint Equals<TContext>(Func<TContext, object> expression, object compareValue, [CallerArgumentExpression(nameof(expression))]string expressionString = null)
+    public static IConstraint Equals<TContext>(Func<TContext, object> expression, object compareValue, [CallerArgumentExpression(nameof(expression))] string expressionString = null)
         where TContext : class, IConstraintContext
     {
         return new ExpressionEqualsConstraint<TContext>(expression, compareValue, expressionString);
@@ -98,9 +98,6 @@ public static class ExpressionConstraint
     private class ExpressionEqualsConstraint<TContext> : ExpressionConstraintBase<TContext>
         where TContext : class, IConstraintContext
     {
-        public ExpressionEqualsConstraint(Func<TContext, object> expression, object value) : this(expression, value, "Unknown")
-        {
-        }
 
         public ExpressionEqualsConstraint(Func<TContext, object> expression, object value, string expressionString) : base(expression, value, expressionString)
         {

--- a/src/Moryx.ControlSystem.ProcessEngine/ModuleController/ModuleConsole.cs
+++ b/src/Moryx.ControlSystem.ProcessEngine/ModuleController/ModuleConsole.cs
@@ -1,9 +1,13 @@
 // Copyright (c) 2026 Phoenix Contact GmbH & Co. KG
 // Licensed under the Apache License, Version 2.0
 
+using Moryx.AbstractionLayer.Constraints;
+using Moryx.ControlSystem.Activities;
+using Moryx.ControlSystem.Cells;
 using Moryx.ControlSystem.ProcessEngine.Jobs;
 using Moryx.ControlSystem.ProcessEngine.Processes;
 using Moryx.Runtime.Modules;
+using Moryx.Serialization;
 
 namespace Moryx.ControlSystem.ProcessEngine;
 
@@ -16,121 +20,44 @@ internal class ModuleConsole : IServerModuleConsole
 
     public IActivityDispatcher ActivityDispatcher { get; set; }
 
-    public void ExecuteCommand(string[] args, Action<string> outputStream)
+    public class SessionExport
     {
-        if (!args.Any())
-            outputStream("ProcessEngine console requires arguments");
+        public long ResourceId { get; set; }
+        public string ResourceName { get; set; }
+        public ActivityClassification Mode { get; set; }
+        public ReadyToWorkType Type { get; set; }
 
-        switch (args[0])
+        public IConstraint[] Constraints { get; set; }
+
+        public override string ToString()
         {
-            case "processes":
-                PrintProcesses(args.Skip(1).ToArray(), outputStream);
-                break;
-            case "jobs":
-                PrintJobs(args.Skip(1).ToArray(), outputStream);
-                break;
-            case "sessions":
-                PrintSessions(args.Skip(1).ToArray(), outputStream);
-                return;
+            return $"{ResourceName}({ResourceId}) | {Mode} | {Type}";
         }
     }
 
-    private void PrintSessions(string[] args, Action<string> outputStream)
+    [EntrySerialize]
+    public List<SessionExport> ListSessions()
     {
-        outputStream(" Resource Id : Name                     | Mode           | Type  | Constraint ");
+        List<SessionExport> result = [];
 
         var sessions = ActivityDispatcher.ExportSessions();
         foreach (var session in sessions)
         {
-            outputStream($"  {session.Resource.Id:D4} : {session.Resource.Name,-30}| {session.ReadyToWork.AcceptedClassification,-15}| {session.ReadyToWork.ReadyToWorkType,-6}| {session.ReadyToWork.Constraints.FirstOrDefault()?.GetType().Name}");
-        }
-    }
-
-    private void PrintJobs(string[] args, Action<string> outputStream)
-    {
-        if (args.Length <= 0)
-            return;
-
-        var operation = args[0].ToLower();
-
-        switch (operation)
-        {
-            case "list":
-                PrintJobList(outputStream);
-                break;
-        }
-
-    }
-
-    private void PrintJobList(Action<string> outputStream)
-    {
-        var currentJobs = JobList.ToArray();
-        if (!currentJobs.Any())
-        {
-            outputStream("Id | State | Running | Success | Failed | Reworked | Progress   ");
-            return;
-        }
-
-        var stateLengthCount = currentJobs.Max(j => j.State.ToString().Length);
-
-        var title = $" Id    |{" State ".PadRight(stateLengthCount + 2, ' ')}| Running | Success | Failed | Reworked | Progress   ";
-        outputStream(title);
-        outputStream("".PadRight(title.Length, '='));
-        foreach (var jobData in currentJobs)
-        {
-            if (jobData is IProductionJobData productionJob)
+            if (session.ReadyToWork is null)
             {
-                int finishedChars = 0;
-                if (productionJob.SuccessCount > 0 || productionJob.FailureCount > 0)
-                {
-                    var percent = ((decimal)productionJob.SuccessCount + (decimal)productionJob.FailureCount) * 10 / jobData.Amount;
-                    finishedChars = Convert.ToInt32(Math.Ceiling(percent));
-                }
-
-                outputStream($" {productionJob.Id,-5} |" +
-                             $" {jobData.State.ToString().PadRight(stateLengthCount, ' ')} |" +
-                             $" {productionJob.RunningProcesses.Count,-7} |" +
-                             $" {productionJob.SuccessCount,-7} |" +
-                             $" {productionJob.FailureCount,-6} |" +
-                             $" {productionJob.ReworkedCount,-8} |" +
-                             " ".PadRight(finishedChars, '#') + "");
-            }
-
-            if (jobData is ISetupJobData setupJob)
-            {
-                outputStream($" {setupJob.Id,-5} |" +
-                             $" {jobData.State.ToString().PadRight(stateLengthCount, ' ')} |" +
-                             $" {setupJob.RunningCount,-7} |");
-            }
-        }
-    }
-
-    private void PrintProcesses(string[] args, Action<string> outputStream)
-    {
-        var processes = ActivityPool.Processes;
-
-        outputStream("ProcessId    | State         | ActivityId      | ResourceIds    | ActivityState   | Type");
-        foreach (var processData in processes)
-        {
-            outputStream($" {processData.Id,11} | {processData.State,-13} |                 |                |                 |");
-            foreach (var activityData in processData.Activities)
-            {
-                if (args.Any(a => a == "-r") && activityData.State > ActivityState.Running)
-                    continue;
-
-                var possibleResources = activityData.Targets
-                    .Select(pr => pr.Id).ToArray();
-
-                outputStream($"                             | {activityData.Id,15} | {string.Join(",", possibleResources),-14} | {activityData.State,-15} | {activityData.Activity.GetType().Name} ");
-            }
-
-            var reportedSessions = processData.ReportedSessions.ToArray();
-
-            if (reportedSessions.Length == 0)
+                // Technically the session can be a Session type besides a RTW that is not yet processed
                 continue;
+            }
 
-            foreach (var session in reportedSessions)
-                outputStream($"    {session.Resource.Id:D5} | {session.Resource.Name,-14}| {session.ReadyToWork.AcceptedClassification,-11}| {session.ReadyToWork.ReadyToWorkType}");
+            result.Add(new()
+            {
+                ResourceId = session.Resource.Id,
+                ResourceName = session.Resource.Name,
+                Mode = session.ReadyToWork.AcceptedClassification,
+                Type = session.ReadyToWork.ReadyToWorkType,
+                Constraints = session.ReadyToWork.Constraints.ToArray()
+            });
         }
+        return result;
     }
 }

--- a/src/Moryx.ControlSystem.ProcessEngine/ModuleController/ModuleConsole.cs
+++ b/src/Moryx.ControlSystem.ProcessEngine/ModuleController/ModuleConsole.cs
@@ -1,6 +1,7 @@
 // Copyright (c) 2026 Phoenix Contact GmbH & Co. KG
 // Licensed under the Apache License, Version 2.0
 
+using System.ComponentModel.DataAnnotations;
 using Moryx.AbstractionLayer.Constraints;
 using Moryx.ControlSystem.Activities;
 using Moryx.ControlSystem.Cells;
@@ -23,11 +24,14 @@ internal class ModuleConsole : IServerModuleConsole
     public class SessionExport
     {
         public long ResourceId { get; set; }
+
         public string ResourceName { get; set; }
+
         public ActivityClassification Mode { get; set; }
+
         public ReadyToWorkType Type { get; set; }
 
-        public IConstraint[] Constraints { get; set; }
+        public string[] Constraints { get; set; }
 
         public override string ToString()
         {
@@ -36,7 +40,8 @@ internal class ModuleConsole : IServerModuleConsole
     }
 
     [EntrySerialize]
-    public List<SessionExport> ListSessions()
+    [Display(Name = "Export Sessions", Description = "Sessions that were reported during ProcessEngineAttached or as RTW.Push but could not yet be processed")]
+    public List<SessionExport> ReportedSessions()
     {
         List<SessionExport> result = [];
 
@@ -55,7 +60,7 @@ internal class ModuleConsole : IServerModuleConsole
                 ResourceName = session.Resource.Name,
                 Mode = session.ReadyToWork.AcceptedClassification,
                 Type = session.ReadyToWork.ReadyToWorkType,
-                Constraints = session.ReadyToWork.Constraints.ToArray()
+                Constraints = session.ReadyToWork.Constraints.Select(c => c?.ToString() ?? "null").ToArray()
             });
         }
         return result;

--- a/src/Moryx.ControlSystem.ProcessEngine/Processes/Implementation/ActivityDispatcher.cs
+++ b/src/Moryx.ControlSystem.ProcessEngine/Processes/Implementation/ActivityDispatcher.cs
@@ -50,7 +50,7 @@ internal sealed class ActivityDispatcher : IActivityPoolListener, IActivityDispa
     private readonly List<ICell> _cells = new();
 
     /// <summary>
-    /// Sessions that were reported during ControlSystemSync or as RTW.Push but could not yet be processed
+    /// Sessions that were reported during ProcessEngineAttached or as RTW.Push but could not yet be processed
     /// </summary>
     private List<ResourceAndSession> _reportedSessions;
 


### PR DESCRIPTION

### Summary

<!-- 
Summarize the feature.
-->

Reintroduces the option from the pre Asp.Net Core Version of Moryx to show 
the currently known ReadyToWorks in the ProcessEngine ModuleConsole.
Removed the methods to list jobs and processes, because they are handled through the Process UI.

### Linked Issues

<!-- 
Link to any related issues or feature requests using GitHub keywords (e.g., Closes #123).
-->

#946 

### Relevant logs and/or screenshots

<!-- 
Paste any relevant logs - please use code blocks (```) to format console output, logs, and code.

Paste images of the new features.
-->
<img width="866" height="612" alt="image" src="https://github.com/user-attachments/assets/7466fd7e-e292-4770-82e0-8ce037b0a80a" />
### Breaking Changes

<!-- 
Does this PR introduce any breaking changes? If yes, describe them.
-->

I am not 100% sure if adding optional parameters to static methods is considered breaking.

### Checklist for Submitter

- [x] I have tested these changes locally
- [x] I have updated documentation as needed
- [x] I have added or updated tests as appropriate
- [x] I have used clear and descriptive commit messages

### Review

**Typical tasks**

- [ ] Merge request is well described
- [ ] Added `Obsolete` attributes if necessary
- [ ] Critical sections are *documented in code*
- [ ] *Tests* available or extended
- [ ] *Documentation* is created / updated
- [ ] Running in test environment
- [ ] *Manual* is created / updated
- [ ] Ports to other maintained versions are created

**Clean code**

- [ ] *All* unused references are removed
- [ ] Clean code rules are respected with passion (naming, ...)
- [ ] Avoid *copy and pasted* code snippets