### PR TITLE
Load module items once lazily in Launcher

### DIFF
--- a/src/Moryx.Launcher/ShellNavigator.cs
+++ b/src/Moryx.Launcher/ShellNavigator.cs
@@ -1,6 +1,7 @@
 // Copyright (c) 2026 Phoenix Contact GmbH & Co. KG
 // Licensed under the Apache License, Version 2.0
 
+using System.Linq;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.RazorPages;
@@ -21,13 +22,90 @@ public class ShellNavigator : IShellNavigator, ILauncher
 {
     private const string NotificationsBarName = "NotificationsBar";
 
-    private readonly ILogger _logger;
     private readonly MoryxAccessManagementClient _client;
-    private readonly IReadOnlyList<ExternalModuleItem> _externalModules;
-    private readonly LauncherConfig _launcherConfig;
+    private static LauncherConfig _launcherConfig;
 
-    private readonly EndpointDataSource _endpointsDataSource;
-    private readonly PageLoader _pageLoader;
+    private static ILogger _logger;
+    private static readonly Lazy<RegionItem[]> _configuredRegions = new(LoadRegions, LazyThreadSafetyMode.ExecutionAndPublication);
+
+    /// <summary>
+    /// Load configured launcher regions
+    /// </summary>
+    private static RegionItem[] LoadRegions()
+    {
+        var availableAssemblies = ReflectionTool.GetAssemblies();
+
+        // Retrieve views
+        var partialViews = new List<Type>(availableAssemblies.Length * 30);
+        foreach (var assembly in availableAssemblies)
+        {
+            try
+            {
+                var types = assembly.GetTypes().Where(t => t.IsClass && t.GetCustomAttribute<LauncherRegionAttribute>() != null);
+                partialViews.AddRange(types);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to check for partial views classes in assembly {name}.", assembly.FullName);
+            }
+        }
+
+        // Transform to models
+        var regions = (from pV in partialViews
+                       let regionAttr = pV.GetCustomAttribute<LauncherRegionAttribute>()
+                       let config = _launcherConfig.Regions.FirstOrDefault(x => x.Name == regionAttr.Name)
+                       where config != null
+                       select new RegionItem { PartialView = regionAttr.Name, Region = config.Region }).ToArray();
+
+        return regions;
+    }
+
+    private static EndpointDataSource _endpointsDataSource;
+    private static PageLoader _pageLoader;
+    private static readonly Lazy<PageActionDescriptorAndModuleItem[]> _descriptorsAndModules =
+        new(LoadCompiledActionDescriptors, LazyThreadSafetyMode.ExecutionAndPublication);
+
+    /// <summary>
+    /// Load the full set of <see cref="CompiledPageActionDescriptor"/>s to be filtered by permissions later on
+    /// </summary>
+    private static PageActionDescriptorAndModuleItem[] LoadCompiledActionDescriptors()
+    {
+        // Filter for pages hosted by the application
+        var pageActionDescriptors = _endpointsDataSource.Endpoints.SelectMany(endpoint => endpoint.Metadata)
+            .OfType<PageActionDescriptor>()
+            .Where(pad => !pad.ViewEnginePath.Contains("Index"));
+
+        // Retrieve metaata for pages
+        var descriptors = Task.WhenAll(pageActionDescriptors.Select(async pad =>
+            await _pageLoader.LoadAsync(pad, EndpointMetadataCollection.Empty))).GetAwaiter().GetResult();
+
+        // Construct mappings between metadata and module items
+        var descriptorModuleTuples = descriptors.Select(d => new PageActionDescriptorAndModuleItem(d, CreateWebModuleItem(d)))
+            .Where((dam) => dam.ModuleItem != null).ToList();
+
+        // Append external modules without metadata
+        var externalModuleTuples = _launcherConfig.ExternalModules?
+            .Select(c => new PageActionDescriptorAndModuleItem(null, CreateExternalModuleItem(c))) ?? [];
+        descriptorModuleTuples.AddRange(externalModuleTuples);
+
+        // Sort by module item sort indices (and title if sort index is not set)
+        var index = _launcherConfig.ModuleSortIndices.Select(i => i.SortIndex).Max();
+        foreach (var descriptorAndModule in descriptorModuleTuples.OrderBy(t => t.ModuleItem.Title))
+        {
+            var module  = descriptorAndModule.ModuleItem;
+            var route = module is ExternalModuleItem ? module.Route.Replace("external/", "") : module.Route;
+            var indexConfig = _launcherConfig.ModuleSortIndices.FirstOrDefault(m => m.Route == route);
+            if (indexConfig != null)
+            {
+                module.SortIndex = indexConfig.SortIndex;
+                continue;
+            }
+
+            module.SortIndex = ++index;
+        }
+
+        return [.. descriptorModuleTuples.OrderBy(t => t.ModuleItem.SortIndex)];
+    }
 
     public ShellNavigator(
         EndpointDataSource endpointsDataSource,
@@ -50,100 +128,39 @@ public class ShellNavigator : IShellNavigator, ILauncher
         }
 
         _launcherConfig = GetConfiguration(configManager);
-        _externalModules = LoadExternalModules();
     }
 
     /// <inheritdoc />
-    public async Task<IReadOnlyList<ModuleItem>> GetModuleItemsAsync(HttpContext context)
+    public async Task<IReadOnlyList<ModuleItem>> GetModuleItemsAsync(HttpContext context) => await FilterModuleItems(context);
+
+    /// <summary>
+    /// Filter <see cref="_descriptorsAndModules"/> by user permissions
+    /// </summary>
+    /// <param name="context">HttpContext used to extract the users identity tokens</param>
+    /// <returns>A filtered array of <see cref="ModuleItem"/>s the user has permission to see</returns>
+    private async Task<ModuleItem[]> FilterModuleItems(HttpContext context)
     {
-        var compiledPageActionDescriptors = await CompiledPageActionDescriptors(context);
+        var descriptorsAndModules = _descriptorsAndModules.Value;
 
-        // Load modules
-        var modules = compiledPageActionDescriptors.Select(CreateWebModuleItem)
-            .Where(m => m != null).ToList<ModuleItem>();
-
-        modules.AddRange(_externalModules);
-
-        // Rudimentary sorting
-        var index = 0;
-        foreach (var module in modules.OrderBy(m => m.Title))
+        // No authorization is configured
+        if (context is null || _client is null)
         {
-            var route = module is ExternalModuleItem ? module.Route.Replace("external/", "") : module.Route;
-            var indexConfig = _launcherConfig.ModuleSortIndices.FirstOrDefault(m => m.Route == route);
-            if (indexConfig != null)
-            {
-                module.SortIndex = indexConfig.SortIndex;
-                continue;
-            }
-
-            module.SortIndex = index++;
+            return [.. descriptorsAndModules.Select(t => t.ModuleItem)];
         }
 
-        return modules;
-    }
+        var token = context.Request.Cookies[MoryxIdentityDefaults.JWT_COOKIE_NAME];
+        var refreshToken = context.Request.Cookies[MoryxIdentityDefaults.REFRESH_TOKEN_COOKIE_NAME];
 
-    private async Task<CompiledPageActionDescriptor[]> CompiledPageActionDescriptors(HttpContext context)
-    {
-        // Filter pages
-        var pageActionDescriptors = _endpointsDataSource.Endpoints.SelectMany(endpoint => endpoint.Metadata)
-            .OfType<PageActionDescriptor>()
-            .Where(pad => !pad.ViewEnginePath.Contains("Index"));
-        // Retrieve all Metadata
-        var compiledPageActionDescriptors = await Task.WhenAll(pageActionDescriptors.Select(async pad =>
-            await _pageLoader.LoadAsync(pad, EndpointMetadataCollection.Empty)));
-
-        // Filter permission
-        if (context is not null && _client is not null)
+        var permissions = await _client.GetPermissionsAsync(token, refreshToken);
+        return [.. descriptorsAndModules.Where(t =>
         {
-            var token = context.Request.Cookies[MoryxIdentityDefaults.JWT_COOKIE_NAME];
-            var refreshToken = context.Request.Cookies[MoryxIdentityDefaults.REFRESH_TOKEN_COOKIE_NAME];
-
-            var permissions = await _client.GetPermissionsAsync(token, refreshToken);
-            compiledPageActionDescriptors = compiledPageActionDescriptors.Where(cpad =>
-            {
-                var requiredPolicy =
-                    (cpad.EndpointMetadata.SingleOrDefault(a => a is AuthorizeAttribute) as AuthorizeAttribute)?.Policy;
-                return requiredPolicy is null || permissions?.Contains(requiredPolicy) == true;
-            }).ToArray();
-        }
-
-        return compiledPageActionDescriptors;
+            var requiredPolicy =
+                (t.Cpad.EndpointMetadata.SingleOrDefault(a => a is AuthorizeAttribute) as AuthorizeAttribute)?.Policy;
+            return requiredPolicy is null || permissions?.Contains(requiredPolicy) == true;
+        }).Select(t => t.ModuleItem)];
     }
 
-    RegionItem ILauncher.GetRegion(LauncherRegion region)
-    {
-        var availableAssemblies = ReflectionTool.GetAssemblies();
-
-        // Retrieve views
-        var partialViews = new List<Type>(availableAssemblies.Length * 30);
-        foreach (var assembly in availableAssemblies)
-        {
-            try
-            {
-                var types = assembly.GetTypes().Where(t => t.IsClass && t.GetCustomAttribute<LauncherRegionAttribute>() != null);
-                partialViews.AddRange(types);
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "Failed to check for partial views classes in assembly {name}.", assembly.FullName);
-            }
-        }
-
-        // Transform to models
-        var configuredRegions = from pV in partialViews
-                                let regionAttr = pV.GetCustomAttribute<LauncherRegionAttribute>()
-                                let config = _launcherConfig.Regions.FirstOrDefault(x => x.Name == regionAttr.Name)
-                                where config != null
-                                select new RegionItem { PartialView = regionAttr.Name, Region = config.Region };
-
-        return configuredRegions.FirstOrDefault(r => r.Region == region);
-    }
-
-    private ExternalModuleItem[] LoadExternalModules()
-    {
-        var externalModuleConfigs = _launcherConfig.ExternalModules;
-        return externalModuleConfigs?.Select(CreateExternalModuleItem).ToArray() ?? [];
-    }
+    RegionItem ILauncher.GetRegion(LauncherRegion region) => _configuredRegions.Value.FirstOrDefault(r => r.Region == region);
 
     private static ExternalModuleItem CreateExternalModuleItem(ExternalModuleConfig externalModuleConfig)
     {
@@ -157,6 +174,7 @@ public class ShellNavigator : IShellNavigator, ILauncher
             Route = $"external/{externalModuleConfig.Route}"
         };
     }
+
     private static WebModuleItem CreateWebModuleItem(CompiledPageActionDescriptor pageActionDescriptor)
     {
         var webModuleAttribute =
@@ -216,4 +234,6 @@ public class ShellNavigator : IShellNavigator, ILauncher
             configManager.SaveConfiguration(launcherConfig);
         }
     }
+
+    private record struct PageActionDescriptorAndModuleItem(CompiledPageActionDescriptor Cpad, ModuleItem ModuleItem) { }
 }


### PR DESCRIPTION
Increases the performance when switching between modules in the launcher by caching module items and regions in the `IShellNavigator` service. This also removes recurring error logs caused by repeated assembly scans.

**Note:** I feel bad making the launcher config static, but it provides a significant benefit in the static Lazy context. Also the service is usually registered as a singleton and the config is one retrieved once from the config manager. Still, I'm open for suggestions to improve