### PR TITLE
Validate workplan-step on setup workplan creation

### DIFF
--- a/docs/articles/module-setups/setup-triggers.md
+++ b/docs/articles/module-setups/setup-triggers.md
@@ -22,21 +22,20 @@ For example if you want to indicate a manual material change with modified capab
 ```cs
 public override SetupEvaluation Evaluate(ProductionRecipe recipe)
 {
-    return SetupEvaluation.Provide(new InsertHousingCapabilities{ Identifier = recipe.Product.Housing.Identitiy}, SetupClassification.Manual | SetupClassification.MaterialChange);
+    return SetupEvaluation.Provide(new InsertHousingCapabilities { Identifier = recipe.Product.Housing.Identitiy }, SetupClassification.Manual | SetupClassification.MaterialChange);
 }
 ```
 
 Because of defined implicit casts it is also possible to directly return `bool` or `SetupClassification` instead of the evaluation object.
 
 ```cs
-IWorkplanStep CreateStep(ProductionRecipe recipe);
+IReadOnlyList<IWorkplanStep> CreateSteps(IProductRecipe recipe);
 ```
 
-Provided that `Evaluate` indicates the need for a machine change, this method creates a `WorkplanStep` to alter a target resource in a way that it provides the necessary capabilities afterwards.
+Provided that `Evaluate` indicates the need for a machine change, this method creates `WorkplanStep`'s to alter a target resource in a way that it provides the necessary capabilities afterwards.
 
-**Return multiple setup steps**
-
-With the extended interface `IMultiSetupTrigger.CreateSteps` it is possible to return an array of steps.
+> [!IMPORTANT]
+> Each setup task / setup activity returned by `CreateSteps` must have exactly **3 outputs** to wire success, failure and technical error. The setup workplan wiring will fail if a step does not meet this requirement.
 
 ### Example of Setup Trigger using the WatchProduct example
 
@@ -68,22 +67,10 @@ internal class WatchFaceMountSetupTrigger : SetupTriggerBase<WatchFaceMountSetup
         return true; // return SetupClassification.Manual -- return SetupEvaluation.Provide(new MountWatchfaceCapabilities())  -- ...
     }
 
-    public override IWorkplanStep CreateStep(IProductRecipe recipe)
-    {
-        return new WatchFaceMountSetupTask
-        {
-            Parameters = new WatchFaceMountSetupParameters()
-            {
-                FinishedOrderNumber = ((WatchRecipe)recipe).OrderNumber
-            }
-        };
-    }
-
-    // Optional method for more than one setup task
     public IReadOnlyList<IWorkplanStep> CreateSteps(IProductRecipe recipe)
     {
-        return new IWorkplanStep[] 
-        { 
+        return new IWorkplanStep[]
+        {
             new WatchFaceMountSetupTask
             {
                 Parameters = new WatchFaceMountSetupParameters()

--- a/src/Moryx.ControlSystem.SetupProvider/Implementation/SetupManager.cs
+++ b/src/Moryx.ControlSystem.SetupProvider/Implementation/SetupManager.cs
@@ -129,10 +129,18 @@ internal partial class SetupManager : ISetupManager, ILoggingComponent
             Version = 1,
             State = WorkplanState.Released
         };
-        workplan.Add(stepGroups.SelectMany(sg => sg.Value).ToArray());
+        workplan.Add(stepGroups.SelectMany(sg => sg.Value).ToArray<IWorkplanNode>());
 
         // Wire steps within the workplan
-        WireWorkplan(workplan, stepGroups);
+        try
+        {
+            WireWorkplan(workplan, stepGroups);
+        }
+        catch (Exception e)
+        {
+            Logger.LogError(e, "Error creating setup workplan");
+            throw;
+        }
 
         // Create a setup recipe
         var setupRecipe = new SetupRecipe
@@ -207,6 +215,8 @@ internal partial class SetupManager : ISetupManager, ILoggingComponent
             {
                 // Default case: Single step for the sort order
                 var step = steps[0];
+                ValidateStep(step);
+
                 step.Inputs[0] = input;
                 step.Outputs[0] = output;
                 step.Outputs[1] = step.Outputs[2] = failed;
@@ -221,7 +231,7 @@ internal partial class SetupManager : ISetupManager, ILoggingComponent
                 workplan.Add(split, join);
 
                 // All parallel steps are inserted between split and join
-                for (int stepIndex = 0; stepIndex < steps.Count; stepIndex++)
+                for (var stepIndex = 0; stepIndex < steps.Count; stepIndex++)
                 {
                     var stepIn = WorkplanInstance.CreateConnector($"Split-{stepGroup.Key}-{stepIndex + 1}");
                     var stepOut = WorkplanInstance.CreateConnector($"Join-{stepGroup.Key}-{stepIndex + 1}");
@@ -231,6 +241,8 @@ internal partial class SetupManager : ISetupManager, ILoggingComponent
                     join.Inputs[stepIndex] = stepOut;
 
                     var step = steps[stepIndex];
+                    ValidateStep(step);
+
                     step.Inputs[0] = stepIn;
                     step.Outputs[0] = stepOut;
                     step.Outputs[1] = step.Outputs[2] = failed;
@@ -238,6 +250,17 @@ internal partial class SetupManager : ISetupManager, ILoggingComponent
             }
 
             input = output;
+        }
+
+        return;
+
+        void ValidateStep(IWorkplanStep step)
+        {
+            if (step.Outputs.Length != 3)
+            {
+                throw new InvalidOperationException($"Step {step.Name} does not have exactly 3 outputs to wire success, failure and technical error. " +
+                                                    "Exactly 3 outputs are required.");
+            }
         }
     }
 


### PR DESCRIPTION
Improvement for: https://github.com/PHOENIXCONTACT/MORYX-Framework/issues/1274

Will provide a better exception than IndexOutOfBounds if setup step has not exactly three outputs.
Added important note to docs.

close #1274