### PR TITLE
Tweaks in ValueProviderExecutor and config providers

### DIFF
--- a/docs/articles/framework/configuration.md
+++ b/docs/articles/framework/configuration.md
@@ -142,6 +142,17 @@ or alternatively
 }
 ```
 
+> [!CAUTION]
+> The collection integration works **if and only if** the list is null or if all the needed entries in the list already exist and can be modified.
+> Due to the way configuration management in MORYX works, it is impossible to add an additional entry that is only defined through ConfigurationProviders to a List.
+
+> [!CAUTION]
+> The alternative syntax can be much shorter for long existing lists, where you want to make sparse changes.  
+> It is only equivalent to the first assuming the type strategies already exist in the MORYX Config.  
+> If no list exists yet, the entries that have no values are pruned away by Microsofts binding mechanism.  
+> You might expect TypeStrategies to be [null, null, { "PluginName": "ExamplePlugin" }], but it's actually [{ "PluginName": "ExamplePlugin" }].  
+> This could lead to subsequent problems, because the indices in the conifg keys do not match the indices in the instantiated objects.
+
 ### Customizing Key Mapping with ProvidedConfigAttribute
 The default key mapping can be customized using the ProvidedConfigAttribute.
 

--- a/src/Moryx.Runtime.Kernel/KernelServiceCollectionExtensions.cs
+++ b/src/Moryx.Runtime.Kernel/KernelServiceCollectionExtensions.cs
@@ -32,8 +32,8 @@ public static class KernelServiceCollectionExtensions
                     var manager = ActivatorUtilities.CreateInstance<ConfigManager>(serviceProvider);
                     return manager.ConfigureValueProviders(original => [
                         manager._sharedProvider,
-                        new ActivatorValueProvider(),
                         ActivatorUtilities.CreateInstance<MicrosoftExtensionsConfigProvider>(serviceProvider),
+                        new ActivatorValueProvider(),
                         new DefaultValueAttributeProvider(),
                     ]);
                 });

--- a/src/Moryx/Configuration/ValueProvider/ValueProviderExecutor.cs
+++ b/src/Moryx/Configuration/ValueProvider/ValueProviderExecutor.cs
@@ -90,23 +90,27 @@ public class ValueProviderExecutor : IEmptyPropertyProvider
             }
 
             var value = property.GetValue(target);
-            // Iterate each item of an enumerable
-            if (value is IEnumerable enumerable)
+
+            if (!property.PropertyType.IsPrimitive && property.PropertyType != typeof(string))
             {
-                int i = 0;
-                foreach (var item in enumerable)
+                // Iterate each item of an enumerable
+                if (value is IEnumerable enumerable)
                 {
-                    stack.Push(new ExecutorLevel(enumerable, null, new() { [IndexKey] = i++ }));
-                    if (item != null)
+                    int i = 0;
+                    foreach (var item in enumerable)
                     {
-                        Iterate(item, settings, stack);
+                        stack.Push(new ExecutorLevel(enumerable, null, new() { [IndexKey] = i++ }));
+                        if (item != null)
+                        {
+                            Iterate(item, settings, stack);
+                        }
+                        stack.Pop();
                     }
-                    stack.Pop();
                 }
-            }
-            else if (value != null && property.PropertyType.IsClass && property.PropertyType != typeof(string))
-            {
-                Iterate(value, settings, stack);
+                else if (value != null && property.PropertyType.IsClass)
+                {
+                    Iterate(value, settings, stack);
+                }
             }
             stack.Pop();
         }

--- a/src/Tests/Moryx.Runtime.Kernel.Tests/Configuration/ConfigManagerWithConfigProviderTests.cs
+++ b/src/Tests/Moryx.Runtime.Kernel.Tests/Configuration/ConfigManagerWithConfigProviderTests.cs
@@ -3,7 +3,9 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
+using System.Text;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Moryx.Configuration;
@@ -88,6 +90,8 @@ public class ConfigManagerWithConfigProviderTests
     [Test(Description = "Makes sure injected secrets are not stored to disk (as long as they are marked with IgnoreDataMemberAttribute)")]
     public void SavingConfigurationDoesNotWriteSecretToFile()
     {
+        // Arrange
+
         var json = """
         {
             "NormalSetting": "from-json",
@@ -106,8 +110,13 @@ public class ConfigManagerWithConfigProviderTests
         var config = manager.GetConfiguration<SecretConfigWithAttribute>(
             name: "SecretConfig",
             getCopy: false);
+
+        // Act
+
         manager.SaveConfiguration(config, name: "SecretConfig");
         var writtenConfig = File.ReadAllText(configPath);
+
+        // Assert
 
         using var _ = Assert.EnterMultipleScope();
         Assert.That(config.ServiceApiKey, Is.EqualTo("from-provider"));
@@ -117,6 +126,8 @@ public class ConfigManagerWithConfigProviderTests
     [Test(Description = "Applies provider values to generated configs when no JSON file exists.")]
     public void ReceivesValuesFromConfiguration()
     {
+        // Arrange
+
         var configuration = MicrosoftExtensionConfigProviderTests.BuildConfig(new()
         {
             ["Secrets:ApiKey"] = "from-provider"
@@ -124,9 +135,13 @@ public class ConfigManagerWithConfigProviderTests
 
         var manager = CreateManager(configuration);
 
+        // Act
+
         var config = manager.GetConfiguration<SecretConfigWithAttribute>(
             name: "SecretConfig",
             getCopy: true);
+
+        // Assert
 
         using var _ = Assert.EnterMultipleScope();
         Assert.That(config.ServiceApiKey, Is.EqualTo("from-provider"));
@@ -136,6 +151,8 @@ public class ConfigManagerWithConfigProviderTests
     [Test(Description = "Configurable config key is supported through second field")]
     public void CanReceiveFromConfigurableConfigKey()
     {
+        // Arrange
+
         const string configKey = "TotallyArbitrary:Secret:Key";
         const string expected = "blablabalablabla";
 
@@ -158,11 +175,154 @@ public class ConfigManagerWithConfigProviderTests
 
         var manager = CreateManager(configuration);
 
+        // Act
+
         var config = manager.GetConfiguration<SecretConfigWithOtherValueTypes>(
             getCopy: true,
             name: "SecretConfig"
         );
 
+        // Assert
+
         Assert.That(config.Password, Is.EqualTo(expected));
+    }
+
+    [Test(Description = "Lists are prepopulated by configuration values")]
+    public void ListArePrepopulatedByConfigurationValues()
+    {
+        // Arrange
+
+        double expected = 0.5;
+
+        var moryxConfig = $$"""
+        {
+        }
+        """;
+        var configPath = Path.Combine(_tempDir, "ExampleConfig.json");
+        File.WriteAllText(configPath, moryxConfig);
+
+        var appsettings = $$"""
+        {
+            "ListConfig:Content": [
+                null,
+                {
+                    "DummyDouble": {{expected.ToString(CultureInfo.InvariantCulture)}}
+                }
+            ]
+        }
+        """;
+        var stream = new MemoryStream(Encoding.UTF8.GetBytes(appsettings));
+
+        var configuration = new ConfigurationBuilder()
+            .AddJsonStream(stream)
+            .Build();
+
+        var manager = CreateManager(configuration);
+
+        // Act
+
+        var config = manager.GetConfiguration<ListConfig>(
+            getCopy: true,
+            name: "ExampleConfig"
+        );
+
+        // Assert
+
+        using var _ = Assert.EnterMultipleScope();
+        Assert.That(config.Content.Count, Is.EqualTo(2));
+        Assert.That(config.Content[0].DummyDouble, Is.EqualTo(DefaultValues.Decimal));
+        Assert.That(config.Content[1].DummyDouble, Is.EqualTo(expected));
+    }
+
+    [Test(Description = """
+    This test only serves to visualize the current behavior. 
+    If this test fails, you can remove the matching "Caution" section in 'docs\articles\framework\configuration.md' "Nested Properties and Collections"
+    that no new entries can be added to a list from ConfigProviders.
+    """)]
+    public void ListsAreNotExtendedFromConfigProviders()
+    {
+        // Arrange
+
+        double expected = 0.5;
+
+        var json = $$"""
+        {
+            Content: [
+                {
+                    "DummyDouble": {{expected.ToString(CultureInfo.InvariantCulture)}}
+                }
+            ]
+        }
+        """;
+        var configPath = Path.Combine(_tempDir, "ExampleConfig.json");
+        File.WriteAllText(configPath, json);
+
+        var configDict = new Dictionary<string, string?>
+        {
+            ["ListConfig:Content:1:DummyDouble"] = expected.ToString(CultureInfo.InvariantCulture),
+        };
+
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(configDict)
+            .Build();
+
+        var manager = CreateManager(configuration);
+
+        // Act
+
+        var config = manager.GetConfiguration<ListConfig>(
+            getCopy: true,
+            name: "ExampleConfig"
+        );
+
+        // Assert
+
+        using var _ = Assert.EnterMultipleScope();
+        Assert.That(config.Content.Count, Is.EqualTo(1));
+        Assert.That(config.Content[0].DummyDouble, Is.EqualTo(expected));
+    }
+
+    [Test(Description = """
+    This test only serves to visualize the current behavior. 
+    If this test fails, you can remove the matching "Caution" section in 'docs\articles\framework\configuration.md' "Nested Properties and Collections"
+    that not configured list entries are ignored and the indices in the resulting List don't necessarily match the once you specified.
+    """)]
+    public void NotConfiguredIndicesInListsAreIgnored()
+    {
+        // Arrange
+
+        double expected = 0.5;
+
+        var json = $$"""
+        {
+        }
+        """;
+        var configPath = Path.Combine(_tempDir, "ExampleConfig.json");
+        File.WriteAllText(configPath, json);
+
+        var configDict = new Dictionary<string, string?>
+        {
+            ["ListConfig:Content:1:DummyDouble"] = expected.ToString(CultureInfo.InvariantCulture),
+            ["ListConfig:Content:3:DummyDouble"] = 0.3.ToString(CultureInfo.InvariantCulture),
+        };
+
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(configDict)
+            .Build();
+
+        var manager = CreateManager(configuration);
+
+        // Act
+
+        var config = manager.GetConfiguration<ListConfig>(
+            getCopy: true,
+            name: "ExampleConfig"
+        );
+
+        // Assert
+
+        using var _ = Assert.EnterMultipleScope();
+        Assert.That(config.Content.Count, Is.EqualTo(2));
+        Assert.That(config.Content[0].DummyDouble, Is.EqualTo(expected));
     }
 }

--- a/src/Tests/Moryx.Runtime.Kernel.Tests/Configuration/TestConfig.cs
+++ b/src/Tests/Moryx.Runtime.Kernel.Tests/Configuration/TestConfig.cs
@@ -1,6 +1,7 @@
 // Copyright (c) 2026 Phoenix Contact GmbH & Co. KG
 // Licensed under the Apache License, Version 2.0
 
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Runtime.Serialization;
 using Moryx.Configuration;
@@ -131,4 +132,12 @@ public class ChildConfig : UpdatableEntry
 
 public class NonPersistedTestConfig : TestConfig
 {
+}
+
+[DataContract]
+[ProvidedConfig("ListConfig")]
+public class ListConfig : ConfigBase
+{
+    [DataMember]
+    public List<ChildConfig> Content { get; set; }
 }


### PR DESCRIPTION
Optimize ValueProviderExecutor to not iterate over chars in string

Additionally fix a bug with the ValueProviders created by configurationIntegration = true.
Due to the ActivationProvider being first lists wouldn't be null and thus not created by the MicrosoftExtensionConfigProvider
even if keys for that List exist