### PR TITLE
Fix `InvalidOperationException` in `ShellNavigator`

### DIFF
--- a/src/Moryx.Launcher/ShellNavigator.cs
+++ b/src/Moryx.Launcher/ShellNavigator.cs
@@ -143,7 +143,7 @@ public class ShellNavigator : IShellNavigator, ILauncher
         descriptorModuleTuples.AddRange(externalModuleTuples);
 
         // Sort by module item sort indices (and title if sort index is not set)
-        var index = _launcherConfig.ModuleSortIndices.Select(i => i.SortIndex).Max();
+        var index = _launcherConfig.ModuleSortIndices.Select(i => i.SortIndex).DefaultIfEmpty(0).Max();
         foreach (var descriptorAndModule in descriptorModuleTuples.OrderBy(t => t.ModuleItem.Title))
         {
             var module  = descriptorAndModule.ModuleItem;


### PR DESCRIPTION
If no sorting indices are configured for the module selection in the launcher, the shell navigator through an unhandled `InvalidOperationException`.