### PR TITLE
Update resource reference UI layout also add the target and source icon.

### DIFF
--- a/src/Moryx.Resources.Web/app/src/app/components/details-view/resource-references/resource-references.html
+++ b/src/Moryx.Resources.Web/app/src/app/components/details-view/resource-references/resource-references.html
@@ -7,9 +7,22 @@
         (opened)="onReferenceChanged(ref)"
         [expanded]="selectedReferenceType()?.name === ref.name"
         >
-        <mat-expansion-panel-header>
-          <mat-panel-title> {{ ref.displayName }} </mat-panel-title>
-          <mat-panel-description class="references-description"> {{ ref.description }} </mat-panel-description>
+        <mat-expansion-panel-header collapsedHeight="56px" expandedHeight="56px">
+          <div class="card-layout">
+            <div class="image-section">
+              <mat-icon>
+                {{ ref.role === ResourceReferenceRole.Target ? 'line_end_circle':'line_start_circle' }}
+              </mat-icon>
+            </div>
+            <div class="content-section">
+              <mat-panel-title class="resource-name">
+                {{ ref.displayName }}
+              </mat-panel-title>
+              <mat-panel-description class="resource-meta">
+                {{ getMetaText(ref) }}
+              </mat-panel-description>
+            </div>
+          </div>
         </mat-expansion-panel-header>
         @if (selectedReferenceType()?.isCollection) {
           <table mat-table #table [dataSource]="selectedReference()?.targets ?? []">

--- a/src/Moryx.Resources.Web/app/src/app/components/details-view/resource-references/resource-references.scss
+++ b/src/Moryx.Resources.Web/app/src/app/components/details-view/resource-references/resource-references.scss
@@ -46,10 +46,48 @@
   align-items: center;
   justify-content: center;
 }
-.references-description{
-  width: auto;
+
+.card-layout {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  min-width: 0;
+  gap: 12px;
+  padding-inline-end: 12px;
+  box-sizing: border-box;
+}
+
+.image-section {
+  flex: 0 0 40px;
+  width: 40px;
+  height: 40px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.content-section {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+}
+
+.resource-name {
+  display: block;
+  margin: 0;
+  width: 100%;
+  min-width: 0%;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  height: 100%;
+}
+
+.resource-meta {
+  margin: 0;
+  width: 100%;
+  min-width: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: block;
 }

--- a/src/Moryx.Resources.Web/app/src/app/components/details-view/resource-references/resource-references.ts
+++ b/src/Moryx.Resources.Web/app/src/app/components/details-view/resource-references/resource-references.ts
@@ -8,7 +8,7 @@ import { toSignal } from '@angular/core/rxjs-interop';
 import { MatTable, MatTableModule } from '@angular/material/table';
 import { TranslatePipe } from '@ngx-translate/core';
 import { TranslationConstants } from '@app/extensions/translation-constants.extensions';
-import { ReferenceTypeModel, ResourceModel, ResourceReferenceModel } from '../../../api/models';
+import { ReferenceTypeModel, ResourceModel, ResourceReferenceModel, ResourceReferenceRole } from '@api/models';
 import { CacheResourceService } from '@app/services/cache-resource.service';
 import { EditResourceService } from '@app/services/edit-resource.service';
 import { Router } from '@angular/router';
@@ -19,6 +19,7 @@ import { MatExpansionModule } from '@angular/material/expansion';
 
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatButtonModule } from '@angular/material/button';
+
 
 @Component({
   selector: 'app-resource-references',
@@ -39,7 +40,7 @@ import { MatButtonModule } from '@angular/material/button';
 export class ResourceReferences {
   private cacheResourceService = inject(CacheResourceService);
   private editResourceService = inject(EditResourceService);
-
+  protected readonly ResourceReferenceRole = ResourceReferenceRole;
   resource: ResourceModel | undefined;
   references: ResourceReferenceModel[] | null | undefined;
   selectedTarget: ResourceModel | undefined;
@@ -75,7 +76,6 @@ export class ResourceReferences {
       this.router.navigate([`/details/${resource.id}`]);
       return;
     }
-
     this.resource = resource;
     this.references = resource.references;
     this.referenceTypes.update(() => resourceType?.references);
@@ -174,4 +174,27 @@ export class ResourceReferences {
 
     return supportedSubTypes;
   }
+
+  private truncateDescription(description: string): string {
+    const maxLength = 35;
+    return description.length > maxLength
+      ? `${description.substring(0, maxLength)}...`
+      : description;
+  }
+
+  protected getMetaText(referenceType: ReferenceTypeModel): string {
+    const reference = this.references?.find(
+      r => r.name === referenceType.name
+    );
+    const description = referenceType.description?.trim() ?? '';
+    const resourceText = reference?.targets
+      ?.map(target => target.name)
+      .filter(Boolean)
+      .join(', ') ?? '';
+    if (description && resourceText) {
+      return `${this.truncateDescription(description)} • ${resourceText}`;
+    }
+    return description || resourceText;
+  }
+
 }


### PR DESCRIPTION

<img width="1063" height="437" alt="NewUI" src="https://github.com/user-attachments/assets/43802e5b-082b-4cbb-8cc2-8bbd039a109f" />
<img width="1445" height="612" alt="Old UI" src="https://github.com/user-attachments/assets/bfa402f3-aadd-4989-828f-85245517219e" />

- **Before/ Dev Branch**
 The references header only displayed the reference name and description. Linked resources were visible only after expanding the panel.

- **After / Local Branch**
The references header now shows a relation role icon, reference name, and a single-line description and linked resource names.

The design follows the material design guide, inspiration taken from [this section](https://m3.material.io/components/lists/specs#b0426459-87b0-43d0-af39-d29282ac6e08)