### PR TITLE
show navigation bar instead of hiding it

### DIFF
--- a/src/Moryx.VisualInstructions.Web/app/src/styles.scss
+++ b/src/Moryx.VisualInstructions.Web/app/src/styles.scss
@@ -41,7 +41,7 @@ app-root {
   }
 }
 
-.navigation-bar {
+.navigation-bar:has(> .navigation-bar-item:only-child) {
   display: none !important;
 }
 


### PR DESCRIPTION
The css was hiding the navigation bar even though the url is working. Now we hide the parent based on its children (if it has 1 or more children)