### PR TITLE
Remove deprecated provideAnimationsAsync()

### DIFF
--- a/src/Moryx.ControlSystem.ProcessEngine.Web/app/package-lock.json
+++ b/src/Moryx.ControlSystem.ProcessEngine.Web/app/package-lock.json
@@ -8,7 +8,6 @@
       "name": "moryx.controlsystem.processengine.web",
       "version": "10.0.0",
       "dependencies": {
-        "@angular/animations": "^22.0.0",
         "@angular/cdk": "^22.0.0",
         "@angular/common": "^22.0.0",
         "@angular/compiler": "^22.0.0",
@@ -448,21 +447,6 @@
         "@typescript-eslint/utils": "^8.0.0",
         "eslint": "^9.0.0 || ^10.0.0",
         "typescript": "*"
-      }
-    },
-    "node_modules/@angular/animations": {
-      "version": "22.0.0",
-      "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-22.0.0.tgz",
-      "integrity": "sha512-Klo9ZiRj5ykXPliUmwy0eXvDad079YMy+Ob4EITSFSXVLRy55qv64/8SvWNtKEQPelF50H9O2vULoqpIvdWoAw==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": "^22.22.3 || ^24.15.0 || >=26.0.0"
-      },
-      "peerDependencies": {
-        "@angular/core": "22.0.0"
       }
     },
     "node_modules/@angular/build": {

--- a/src/Moryx.ControlSystem.ProcessEngine.Web/app/package.json
+++ b/src/Moryx.ControlSystem.ProcessEngine.Web/app/package.json
@@ -13,7 +13,6 @@
   },
   "private": true,
   "dependencies": {
-    "@angular/animations": "^22.0.0",
     "@angular/cdk": "^22.0.0",
     "@angular/common": "^22.0.0",
     "@angular/compiler": "^22.0.0",

--- a/src/Moryx.ControlSystem.ProcessEngine.Web/app/src/app.config.ts
+++ b/src/Moryx.ControlSystem.ProcessEngine.Web/app/src/app.config.ts
@@ -18,7 +18,6 @@ import { MatSlideToggleModule } from "@angular/material/slide-toggle";
 import { MatSnackBarModule } from "@angular/material/snack-bar";
 import { MatTableModule } from "@angular/material/table";
 import { BrowserModule } from "@angular/platform-browser";
-import { provideAnimationsAsync } from "@angular/platform-browser/animations/async";
 import { ApiInterceptor, API_INTERCEPTOR_PROVIDER } from "@moryx/ngx-web-framework/interceptors";
 import { ApiModule } from "@api/api.module";
 import { environment } from "./environments/environment";
@@ -62,7 +61,6 @@ export const appConfig: ApplicationConfig = {
       }),
       fallbackLang: 'en'
     }),
-    provideAnimationsAsync(),
     provideAppInitializer(() => {
       // Use material-symbols as default icon font
       const iconRegistry = inject(MatIconRegistry);

--- a/src/Moryx.FactoryMonitor.Web/app/package-lock.json
+++ b/src/Moryx.FactoryMonitor.Web/app/package-lock.json
@@ -8,7 +8,6 @@
       "name": "moryx.factorymonitor.web",
       "version": "10.0.0",
       "dependencies": {
-        "@angular/animations": "^22.0.0",
         "@angular/common": "^22.0.0",
         "@angular/compiler": "^22.0.0",
         "@angular/core": "^22.0.0",
@@ -447,21 +446,6 @@
         "@typescript-eslint/utils": "^8.0.0",
         "eslint": "^9.0.0 || ^10.0.0",
         "typescript": "*"
-      }
-    },
-    "node_modules/@angular/animations": {
-      "version": "22.0.0",
-      "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-22.0.0.tgz",
-      "integrity": "sha512-Klo9ZiRj5ykXPliUmwy0eXvDad079YMy+Ob4EITSFSXVLRy55qv64/8SvWNtKEQPelF50H9O2vULoqpIvdWoAw==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": "^22.22.3 || ^24.15.0 || >=26.0.0"
-      },
-      "peerDependencies": {
-        "@angular/core": "22.0.0"
       }
     },
     "node_modules/@angular/build": {

--- a/src/Moryx.FactoryMonitor.Web/app/package.json
+++ b/src/Moryx.FactoryMonitor.Web/app/package.json
@@ -13,7 +13,6 @@
   },
   "private": true,
   "dependencies": {
-    "@angular/animations": "^22.0.0",
     "@angular/common": "^22.0.0",
     "@angular/compiler": "^22.0.0",
     "@angular/core": "^22.0.0",

--- a/src/Moryx.FactoryMonitor.Web/app/src/app/app.config.ts
+++ b/src/Moryx.FactoryMonitor.Web/app/src/app/app.config.ts
@@ -15,7 +15,6 @@ import { MatListModule } from '@angular/material/list';
 import { MatSnackBarModule } from '@angular/material/snack-bar';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { BrowserModule } from '@angular/platform-browser';
-import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
 import { provideRouter } from '@angular/router';
 import { provideTranslateService } from '@ngx-translate/core';
 import { provideTranslateHttpLoader } from '@ngx-translate/http-loader';
@@ -61,7 +60,6 @@ export const appConfig: ApplicationConfig = {
       }),
       fallbackLang: 'en'
     }),
-    provideAnimationsAsync(),
     provideAppInitializer(() => {
       // Use material-symbols as default icon font
       const iconRegistry = inject(MatIconRegistry);

--- a/src/Moryx.Media.Web/app/package-lock.json
+++ b/src/Moryx.Media.Web/app/package-lock.json
@@ -8,7 +8,6 @@
       "name": "moryx.media.web",
       "version": "10.0.0",
       "dependencies": {
-        "@angular/animations": "^22.0.0",
         "@angular/cdk": "^22.0.0",
         "@angular/common": "^22.0.0",
         "@angular/compiler": "^22.0.0",
@@ -449,21 +448,6 @@
         "@typescript-eslint/utils": "^8.0.0",
         "eslint": "^9.0.0 || ^10.0.0",
         "typescript": "*"
-      }
-    },
-    "node_modules/@angular/animations": {
-      "version": "22.0.0",
-      "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-22.0.0.tgz",
-      "integrity": "sha512-Klo9ZiRj5ykXPliUmwy0eXvDad079YMy+Ob4EITSFSXVLRy55qv64/8SvWNtKEQPelF50H9O2vULoqpIvdWoAw==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": "^22.22.3 || ^24.15.0 || >=26.0.0"
-      },
-      "peerDependencies": {
-        "@angular/core": "22.0.0"
       }
     },
     "node_modules/@angular/build": {

--- a/src/Moryx.Media.Web/app/package.json
+++ b/src/Moryx.Media.Web/app/package.json
@@ -13,7 +13,6 @@
   },
   "private": true,
   "dependencies": {
-    "@angular/animations": "^22.0.0",
     "@angular/cdk": "^22.0.0",
     "@angular/common": "^22.0.0",
     "@angular/compiler": "^22.0.0",

--- a/src/Moryx.Media.Web/app/src/app/app.config.ts
+++ b/src/Moryx.Media.Web/app/src/app/app.config.ts
@@ -23,7 +23,6 @@ import { MatSnackBarModule } from "@angular/material/snack-bar";
 import { MatToolbarModule } from "@angular/material/toolbar";
 import { MatTooltipModule } from "@angular/material/tooltip";
 import { BrowserModule } from "@angular/platform-browser";
-import { provideAnimationsAsync } from "@angular/platform-browser/animations/async";
 import { provideRouter } from "@angular/router";
 import { ApiInterceptor, API_INTERCEPTOR_PROVIDER } from "@moryx/ngx-web-framework/interceptors";
 import { SnackbarService } from "@moryx/ngx-web-framework/services";
@@ -71,7 +70,6 @@ export const appConfig: ApplicationConfig = {
       }),
       fallbackLang: 'en'
     }),
-    provideAnimationsAsync(),
     provideAppInitializer(() => {
       // Use material-symbols as default icon font
       const iconRegistry = inject(MatIconRegistry);

--- a/src/Moryx.Notifications.Web/app/package-lock.json
+++ b/src/Moryx.Notifications.Web/app/package-lock.json
@@ -8,7 +8,6 @@
       "name": "moryx.notifications.web",
       "version": "10.0.0",
       "dependencies": {
-        "@angular/animations": "^22.0.0",
         "@angular/cdk": "^22.0.0",
         "@angular/common": "^22.0.0",
         "@angular/compiler": "^22.0.0",
@@ -449,21 +448,6 @@
         "@typescript-eslint/utils": "^8.0.0",
         "eslint": "^9.0.0 || ^10.0.0",
         "typescript": "*"
-      }
-    },
-    "node_modules/@angular/animations": {
-      "version": "22.0.0",
-      "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-22.0.0.tgz",
-      "integrity": "sha512-Klo9ZiRj5ykXPliUmwy0eXvDad079YMy+Ob4EITSFSXVLRy55qv64/8SvWNtKEQPelF50H9O2vULoqpIvdWoAw==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": "^22.22.3 || ^24.15.0 || >=26.0.0"
-      },
-      "peerDependencies": {
-        "@angular/core": "22.0.0"
       }
     },
     "node_modules/@angular/build": {

--- a/src/Moryx.Notifications.Web/app/package.json
+++ b/src/Moryx.Notifications.Web/app/package.json
@@ -13,7 +13,6 @@
   },
   "private": true,
   "dependencies": {
-    "@angular/animations": "^22.0.0",
     "@angular/cdk": "^22.0.0",
     "@angular/common": "^22.0.0",
     "@angular/compiler": "^22.0.0",

--- a/src/Moryx.Notifications.Web/app/src/app/app.config.ts
+++ b/src/Moryx.Notifications.Web/app/src/app/app.config.ts
@@ -16,7 +16,6 @@ import { MatProgressSpinnerModule } from "@angular/material/progress-spinner";
 import { MatSidenavModule } from "@angular/material/sidenav";
 import { MatSnackBarModule } from "@angular/material/snack-bar";
 import { MatToolbarModule } from "@angular/material/toolbar";
-import { provideAnimationsAsync } from "@angular/platform-browser/animations/async";
 import { ApiInterceptor, API_INTERCEPTOR_PROVIDER } from "@moryx/ngx-web-framework/interceptors";
 import { SnackbarService } from "@moryx/ngx-web-framework/services";
 import { ApiModule } from "@api/api.module";
@@ -51,7 +50,6 @@ export const appConfig: ApplicationConfig = {
       fallbackLang: 'en'
     }),
     provideMarkdown(),
-    provideAnimationsAsync(),
     provideAppInitializer(() => {
       // Use material-symbols as default icon font
       const iconRegistry = inject(MatIconRegistry);

--- a/src/Moryx.Operators.Web/app/package-lock.json
+++ b/src/Moryx.Operators.Web/app/package-lock.json
@@ -8,7 +8,6 @@
       "name": "moryx.operators.web",
       "version": "10.0.0",
       "dependencies": {
-        "@angular/animations": "^22.0.0",
         "@angular/cdk": "^22.0.0",
         "@angular/common": "^22.0.0",
         "@angular/compiler": "^22.0.0",
@@ -466,21 +465,6 @@
         "@typescript-eslint/utils": "^8.0.0",
         "eslint": "^9.0.0 || ^10.0.0",
         "typescript": "*"
-      }
-    },
-    "node_modules/@angular/animations": {
-      "version": "22.0.0",
-      "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-22.0.0.tgz",
-      "integrity": "sha512-Klo9ZiRj5ykXPliUmwy0eXvDad079YMy+Ob4EITSFSXVLRy55qv64/8SvWNtKEQPelF50H9O2vULoqpIvdWoAw==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": "^22.22.3 || ^24.15.0 || >=26.0.0"
-      },
-      "peerDependencies": {
-        "@angular/core": "22.0.0"
       }
     },
     "node_modules/@angular/build": {

--- a/src/Moryx.Operators.Web/app/package.json
+++ b/src/Moryx.Operators.Web/app/package.json
@@ -13,7 +13,6 @@
   },
   "private": true,
   "dependencies": {
-    "@angular/animations": "^22.0.0",
     "@angular/cdk": "^22.0.0",
     "@angular/common": "^22.0.0",
     "@angular/compiler": "^22.0.0",

--- a/src/Moryx.Operators.Web/app/src/app/app.config.ts
+++ b/src/Moryx.Operators.Web/app/src/app/app.config.ts
@@ -29,7 +29,6 @@ import { MatTableModule } from "@angular/material/table";
 import { MatToolbarModule } from "@angular/material/toolbar";
 import { MatTooltipModule } from "@angular/material/tooltip";
 import { BrowserModule } from "@angular/platform-browser";
-import { provideAnimationsAsync } from "@angular/platform-browser/animations/async";
 import { AppStoreService } from "./services/app-store.service";
 import { TranslateService } from '@ngx-translate/core';
 import { provideRouter, withComponentInputBinding } from "@angular/router";
@@ -78,7 +77,6 @@ export const appConfig: ApplicationConfig = {
       }),
       fallbackLang: 'en'
     }),
-    provideAnimationsAsync(),
     provideAppInitializer(() => {
       // Use material-symbols as default icon font
       const iconRegistry = inject(MatIconRegistry);

--- a/src/Moryx.Orders.Web/app/package-lock.json
+++ b/src/Moryx.Orders.Web/app/package-lock.json
@@ -8,7 +8,6 @@
       "name": "moryx.orders.web",
       "version": "10.0.0",
       "dependencies": {
-        "@angular/animations": "^22.0.0",
         "@angular/cdk": "^22.0.0",
         "@angular/common": "^22.0.0",
         "@angular/compiler": "^22.0.0",
@@ -449,21 +448,6 @@
         "@typescript-eslint/utils": "^8.0.0",
         "eslint": "^9.0.0 || ^10.0.0",
         "typescript": "*"
-      }
-    },
-    "node_modules/@angular/animations": {
-      "version": "22.0.0",
-      "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-22.0.0.tgz",
-      "integrity": "sha512-Klo9ZiRj5ykXPliUmwy0eXvDad079YMy+Ob4EITSFSXVLRy55qv64/8SvWNtKEQPelF50H9O2vULoqpIvdWoAw==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": "^22.22.3 || ^24.15.0 || >=26.0.0"
-      },
-      "peerDependencies": {
-        "@angular/core": "22.0.0"
       }
     },
     "node_modules/@angular/build": {

--- a/src/Moryx.Orders.Web/app/package.json
+++ b/src/Moryx.Orders.Web/app/package.json
@@ -13,7 +13,6 @@
   },
   "private": true,
   "dependencies": {
-    "@angular/animations": "^22.0.0",
     "@angular/cdk": "^22.0.0",
     "@angular/common": "^22.0.0",
     "@angular/compiler": "^22.0.0",

--- a/src/Moryx.Orders.Web/app/src/app/app.config.ts
+++ b/src/Moryx.Orders.Web/app/src/app/app.config.ts
@@ -26,7 +26,6 @@ import { MatSnackBarModule } from "@angular/material/snack-bar";
 import { MatTableModule } from "@angular/material/table";
 import { MatToolbarModule } from "@angular/material/toolbar";
 import { BrowserModule } from "@angular/platform-browser";
-import { provideAnimationsAsync } from "@angular/platform-browser/animations/async";
 import { SnackbarService } from "@moryx/ngx-web-framework/services";
 import { ApiInterceptor, API_INTERCEPTOR_PROVIDER } from "@moryx/ngx-web-framework/interceptors";
 import { NgxDocViewerModule } from "ngx-doc-viewer";
@@ -82,7 +81,6 @@ export const appConfig: ApplicationConfig = {
       }),
       fallbackLang: 'en'
     }),
-    provideAnimationsAsync(),
     provideAppInitializer(() => {
       // Use material-symbols as default icon font
       const iconRegistry = inject(MatIconRegistry);

--- a/src/Moryx.Products.Web/app/package-lock.json
+++ b/src/Moryx.Products.Web/app/package-lock.json
@@ -8,7 +8,6 @@
       "name": "moryx.products.web",
       "version": "10.0.0",
       "dependencies": {
-        "@angular/animations": "^22.0.0",
         "@angular/cdk": "^22.0.0",
         "@angular/common": "^22.0.0",
         "@angular/compiler": "^22.0.0",
@@ -448,21 +447,6 @@
         "@typescript-eslint/utils": "^8.0.0",
         "eslint": "^9.0.0 || ^10.0.0",
         "typescript": "*"
-      }
-    },
-    "node_modules/@angular/animations": {
-      "version": "22.0.0",
-      "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-22.0.0.tgz",
-      "integrity": "sha512-Klo9ZiRj5ykXPliUmwy0eXvDad079YMy+Ob4EITSFSXVLRy55qv64/8SvWNtKEQPelF50H9O2vULoqpIvdWoAw==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": "^22.22.3 || ^24.15.0 || >=26.0.0"
-      },
-      "peerDependencies": {
-        "@angular/core": "22.0.0"
       }
     },
     "node_modules/@angular/build": {

--- a/src/Moryx.Products.Web/app/package.json
+++ b/src/Moryx.Products.Web/app/package.json
@@ -13,7 +13,6 @@
   },
   "private": true,
   "dependencies": {
-    "@angular/animations": "^22.0.0",
     "@angular/cdk": "^22.0.0",
     "@angular/common": "^22.0.0",
     "@angular/compiler": "^22.0.0",

--- a/src/Moryx.Products.Web/app/src/app/app.config.ts
+++ b/src/Moryx.Products.Web/app/src/app/app.config.ts
@@ -27,7 +27,6 @@ import { MatToolbarModule } from "@angular/material/toolbar";
 import { MatTooltipModule } from "@angular/material/tooltip";
 import { MatTreeModule } from "@angular/material/tree";
 import { BrowserModule } from "@angular/platform-browser";
-import { provideAnimationsAsync } from "@angular/platform-browser/animations/async";
 import { ApiInterceptor, API_INTERCEPTOR_PROVIDER } from "@moryx/ngx-web-framework/interceptors";
 import { SnackbarService } from "@moryx/ngx-web-framework/services";
 import { environment } from "../environments/environment";
@@ -86,7 +85,6 @@ export const appConfig: ApplicationConfig = {
         maxHeight: '90vh'
       }
     },
-    provideAnimationsAsync(),
     provideAppInitializer(() => {
       // Use material-symbols as default icon font
       const iconRegistry = inject(MatIconRegistry);

--- a/src/Moryx.Resources.Web/app/package-lock.json
+++ b/src/Moryx.Resources.Web/app/package-lock.json
@@ -8,7 +8,6 @@
       "name": "moryx.resources.web",
       "version": "10.0.0",
       "dependencies": {
-        "@angular/animations": "^22.0.0",
         "@angular/cdk": "^22.0.0",
         "@angular/common": "^22.0.0",
         "@angular/compiler": "^22.0.0",
@@ -448,21 +447,6 @@
         "@typescript-eslint/utils": "^8.0.0",
         "eslint": "^9.0.0 || ^10.0.0",
         "typescript": "*"
-      }
-    },
-    "node_modules/@angular/animations": {
-      "version": "22.0.0",
-      "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-22.0.0.tgz",
-      "integrity": "sha512-Klo9ZiRj5ykXPliUmwy0eXvDad079YMy+Ob4EITSFSXVLRy55qv64/8SvWNtKEQPelF50H9O2vULoqpIvdWoAw==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": "^22.22.3 || ^24.15.0 || >=26.0.0"
-      },
-      "peerDependencies": {
-        "@angular/core": "22.0.0"
       }
     },
     "node_modules/@angular/build": {

--- a/src/Moryx.Resources.Web/app/package.json
+++ b/src/Moryx.Resources.Web/app/package.json
@@ -13,7 +13,6 @@
   },
   "private": true,
   "dependencies": {
-    "@angular/animations": "^22.0.0",
     "@angular/cdk": "^22.0.0",
     "@angular/common": "^22.0.0",
     "@angular/compiler": "^22.0.0",

--- a/src/Moryx.Resources.Web/app/src/app/app.config.ts
+++ b/src/Moryx.Resources.Web/app/src/app/app.config.ts
@@ -4,7 +4,6 @@
 */
 
 import { ApplicationConfig, provideEnvironmentInitializer } from "@angular/core";
-import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { MatTreeModule } from '@angular/material/tree';
 import { MatButtonModule } from '@angular/material/button';
@@ -89,7 +88,6 @@ export const appConfig: ApplicationConfig = {
       }),
       fallbackLang: 'en'
     }),
-    provideAnimationsAsync(),
     provideAppInitializer(() => {
       // Use material-symbols as default icon font
       const iconRegistry = inject(MatIconRegistry);

--- a/src/Moryx.Shifts.Web/app/package-lock.json
+++ b/src/Moryx.Shifts.Web/app/package-lock.json
@@ -8,7 +8,6 @@
       "name": "moryx.shifts.web",
       "version": "10.0.0",
       "dependencies": {
-        "@angular/animations": "^22.0.0",
         "@angular/cdk": "^22.0.0",
         "@angular/common": "^22.0.0",
         "@angular/compiler": "^22.0.0",
@@ -467,21 +466,6 @@
         "@typescript-eslint/utils": "^8.0.0",
         "eslint": "^9.0.0 || ^10.0.0",
         "typescript": "*"
-      }
-    },
-    "node_modules/@angular/animations": {
-      "version": "22.0.0",
-      "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-22.0.0.tgz",
-      "integrity": "sha512-Klo9ZiRj5ykXPliUmwy0eXvDad079YMy+Ob4EITSFSXVLRy55qv64/8SvWNtKEQPelF50H9O2vULoqpIvdWoAw==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": "^22.22.3 || ^24.15.0 || >=26.0.0"
-      },
-      "peerDependencies": {
-        "@angular/core": "22.0.0"
       }
     },
     "node_modules/@angular/build": {

--- a/src/Moryx.Shifts.Web/app/package.json
+++ b/src/Moryx.Shifts.Web/app/package.json
@@ -13,7 +13,6 @@
   },
   "private": true,
   "dependencies": {
-    "@angular/animations": "^22.0.0",
     "@angular/cdk": "^22.0.0",
     "@angular/common": "^22.0.0",
     "@angular/compiler": "^22.0.0",

--- a/src/Moryx.Shifts.Web/app/src/app/app.config.ts
+++ b/src/Moryx.Shifts.Web/app/src/app/app.config.ts
@@ -24,7 +24,6 @@ import { MatSidenavModule } from "@angular/material/sidenav";
 import { MatTabsModule } from "@angular/material/tabs";
 import { MatTooltipModule } from "@angular/material/tooltip";
 import { BrowserModule } from "@angular/platform-browser";
-import { provideAnimationsAsync } from "@angular/platform-browser/animations/async";
 import { environment } from "../environments/environment";
 import { ApiModule } from "@api/api.module";
 import { AppStoreService } from "./services/app-store.service";
@@ -70,7 +69,6 @@ export const appConfig: ApplicationConfig = {
       }),
       fallbackLang: 'en'
     }),
-    provideAnimationsAsync(),
     provideNativeDateAdapter(),
     ShiftService,
     AppStoreService,

--- a/src/Moryx.VisualInstructions.Web/app/package-lock.json
+++ b/src/Moryx.VisualInstructions.Web/app/package-lock.json
@@ -8,7 +8,6 @@
       "name": "moryx.visualinstructions.web",
       "version": "10.0.0",
       "dependencies": {
-        "@angular/animations": "^22.0.0",
         "@angular/cdk": "^22.0.0",
         "@angular/common": "^22.0.0",
         "@angular/compiler": "^22.0.0",
@@ -450,21 +449,6 @@
         "@typescript-eslint/utils": "^8.0.0",
         "eslint": "^9.0.0 || ^10.0.0",
         "typescript": "*"
-      }
-    },
-    "node_modules/@angular/animations": {
-      "version": "22.0.0",
-      "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-22.0.0.tgz",
-      "integrity": "sha512-Klo9ZiRj5ykXPliUmwy0eXvDad079YMy+Ob4EITSFSXVLRy55qv64/8SvWNtKEQPelF50H9O2vULoqpIvdWoAw==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": "^22.22.3 || ^24.15.0 || >=26.0.0"
-      },
-      "peerDependencies": {
-        "@angular/core": "22.0.0"
       }
     },
     "node_modules/@angular/build": {

--- a/src/Moryx.VisualInstructions.Web/app/package.json
+++ b/src/Moryx.VisualInstructions.Web/app/package.json
@@ -13,7 +13,6 @@
   },
   "private": true,
   "dependencies": {
-    "@angular/animations": "^22.0.0",
     "@angular/cdk": "^22.0.0",
     "@angular/common": "^22.0.0",
     "@angular/compiler": "^22.0.0",

--- a/src/Moryx.VisualInstructions.Web/app/src/app/app.config.ts
+++ b/src/Moryx.VisualInstructions.Web/app/src/app/app.config.ts
@@ -16,7 +16,6 @@ import { MatIconModule, MatIconRegistry } from "@angular/material/icon";
 import { MatListModule } from "@angular/material/list";
 import { MatProgressSpinnerModule } from "@angular/material/progress-spinner";
 import { MatSnackBarModule } from "@angular/material/snack-bar";
-import { provideAnimationsAsync } from "@angular/platform-browser/animations/async";
 import { SnackbarService } from "@moryx/ngx-web-framework/services";
 import { ApiInterceptor, API_INTERCEPTOR_PROVIDER } from "@moryx/ngx-web-framework/interceptors";
 import { NgxDocViewerModule } from "ngx-doc-viewer";
@@ -56,7 +55,6 @@ export const appConfig: ApplicationConfig = {
       fallbackLang: 'en'
     }),
     provideMarkdown(),
-    provideAnimationsAsync(),
     provideAppInitializer(() => {
       // Use material-symbols as default icon font
       const iconRegistry = inject(MatIconRegistry);

--- a/src/Moryx.Workplans.Web/app/package-lock.json
+++ b/src/Moryx.Workplans.Web/app/package-lock.json
@@ -8,7 +8,6 @@
       "name": "moryx.workplans.web",
       "version": "10.0.0",
       "dependencies": {
-        "@angular/animations": "^22.0.0",
         "@angular/cdk": "^22.0.0",
         "@angular/common": "^22.0.0",
         "@angular/compiler": "^22.0.0",
@@ -450,21 +449,6 @@
         "@typescript-eslint/utils": "^8.0.0",
         "eslint": "^9.0.0 || ^10.0.0",
         "typescript": "*"
-      }
-    },
-    "node_modules/@angular/animations": {
-      "version": "22.0.0",
-      "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-22.0.0.tgz",
-      "integrity": "sha512-Klo9ZiRj5ykXPliUmwy0eXvDad079YMy+Ob4EITSFSXVLRy55qv64/8SvWNtKEQPelF50H9O2vULoqpIvdWoAw==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": "^22.22.3 || ^24.15.0 || >=26.0.0"
-      },
-      "peerDependencies": {
-        "@angular/core": "22.0.0"
       }
     },
     "node_modules/@angular/build": {

--- a/src/Moryx.Workplans.Web/app/package.json
+++ b/src/Moryx.Workplans.Web/app/package.json
@@ -13,7 +13,6 @@
   },
   "private": true,
   "dependencies": {
-    "@angular/animations": "^22.0.0",
     "@angular/cdk": "^22.0.0",
     "@angular/common": "^22.0.0",
     "@angular/compiler": "^22.0.0",

--- a/src/Moryx.Workplans.Web/app/src/app/app.config.ts
+++ b/src/Moryx.Workplans.Web/app/src/app/app.config.ts
@@ -25,7 +25,6 @@ import { MatTabsModule } from '@angular/material/tabs';
 import { MatToolbarModule } from '@angular/material/toolbar';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { BrowserModule } from '@angular/platform-browser';
-import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
 import { ApiInterceptor, API_INTERCEPTOR_PROVIDER } from '@moryx/ngx-web-framework/interceptors';
 import { environment } from '../environments/environment';
 import { ApiModule } from '@api/api.module';
@@ -77,7 +76,6 @@ export const appConfig: ApplicationConfig = {
       }),
       fallbackLang: 'en'
     }),
-    provideAnimationsAsync(),
     provideAppInitializer(() => {
       // Use material-symbols as default icon font
       const iconRegistry = inject(MatIconRegistry);


### PR DESCRIPTION
for #1061

Remove deprecated provideAnimationsAsync() from all web projects

  - Removed provideAnimationsAsync() import and call from all web project app.config.ts files                                                                                   
  - Angular Material has migrated all its components to native CSS animations and no longer depends on `@angular/animations` (https://github.com/angular/components/pull/30459)
  - No custom @angular/animations usage exists anywhere in our codebase, making this removal safe
  - provideAnimationsAsync was deprecated in Angular v20.2 and will be removed in v23

Result: 

  - Eliminates deprecation warnings
  - Reduces runtime overhead and fewer change detections