### PR TITLE
Sort resource reference list and update layout

### DIFF
--- a/src/Moryx.Resources.Web/app/src/app/components/details-view/resource-references/resource-references.html
+++ b/src/Moryx.Resources.Web/app/src/app/components/details-view/resource-references/resource-references.html
@@ -85,8 +85,15 @@
                   (selectionChange)="addTarget(table)"
                   >
                   @for (pr of possibleResources(); track pr) {
-                    <mat-option [value]="pr">
-                      {{ "#" + pr.id + " " + pr.name }}
+                    <mat-option [value]="pr" class="resource-option">
+                      <div class="resource-option-content">
+                        <span class="resource-option-name">
+                          #{{ pr.id }} {{ pr.name ?? 'null' }}
+                        </span>
+                        <span class="resource-option-type">
+                          {{ pr.type }}
+                        </span>
+                      </div>
                     </mat-option>
                   }
                 </mat-select>

--- a/src/Moryx.Resources.Web/app/src/app/components/details-view/resource-references/resource-references.scss
+++ b/src/Moryx.Resources.Web/app/src/app/components/details-view/resource-references/resource-references.scss
@@ -91,3 +91,28 @@
   text-overflow: ellipsis;
   display: block;
 }
+
+.resource-option {
+  min-height: 64px;
+}
+
+.resource-option-content {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  width: 100%;
+}
+
+.resource-option-name {
+  white-space: nowrap;
+  overflow: hidden;
+  line-height: 24px;
+}
+
+.resource-option-type {
+  font: var(--mat-sys-body-medium);
+  color: var(--mat-sys-on-surface-variant);
+  white-space: nowrap;
+  line-height: 20px;
+  text-overflow: ellipsis;
+}

--- a/src/Moryx.Resources.Web/app/src/app/components/details-view/resource-references/resource-references.ts
+++ b/src/Moryx.Resources.Web/app/src/app/components/details-view/resource-references/resource-references.ts
@@ -162,7 +162,9 @@ export class ResourceReferences {
     if (this.selectedReferenceType()?.isCollection) {
       possibleResources = possibleResources.filter(r => !this.selectedReference()?.targets?.find(t => t.id == r.id));
     }
-
+    possibleResources = possibleResources.sort((a, b) =>
+      (a.name ?? '').localeCompare(b.name ?? '', undefined, { sensitivity: 'base' })
+    );
     return possibleResources;
   }
 


### PR DESCRIPTION
Update the Linked resource selector options to improve the reference resource list layout and sorting alphabetically.

**Changes**

- Sorted possible resource options by resource name.
- Updated the `mat-option` content to use a two-line layout:
  - Primary text: `#id resource name`
  - Supporting text: resource `type`

-  Applied Material-style typography and `on-surface-variant` color for the supporting text.

