### PR TITLE
Use version from assembly manifest

### DIFF
--- a/src/Moryx.Runtime.Endpoints/Common/CommonController.cs
+++ b/src/Moryx.Runtime.Endpoints/Common/CommonController.cs
@@ -5,6 +5,7 @@ using System.Globalization;
 using System.Reflection;
 using System.Runtime.Versioning;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Moryx.Runtime.Endpoints.Common.Response;
 
@@ -32,22 +33,26 @@ public class CommonController : ControllerBase
 
     [HttpGet("info/application")]
     [Authorize(Policy = RuntimePermissions.CanGetGeneralInformation)]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
     public ActionResult<ApplicationInformationResponse> GetApplicationInfo()
     {
-        var startAssembly = Assembly.GetEntryAssembly();
-        var version = new Version(startAssembly.GetCustomAttribute<AssemblyVersionAttribute>()?.Version ?? "1.0.0");
+        var entryAssembly = Assembly.GetEntryAssembly();
+        if (entryAssembly is null)
+            return BadRequest("Entry assembly could not be determined.");
+
         return new ApplicationInformationResponse
         {
-            AssemblyProduct = startAssembly.GetCustomAttribute<AssemblyProductAttribute>()?.Product ?? "N/A",
-            AssemblyVersion = version.ToString(3),
-            AssemblyInformationalVersion = version.ToString(3),
-            AssemblyDescription = startAssembly.GetCustomAttribute<AssemblyDescriptionAttribute>()?.Description ?? "N/A",
-            AssemblyConfiguration =  startAssembly?.GetCustomAttribute<AssemblyConfigurationAttribute>()?.Configuration ?? "N/A",
-            TargetFramework =  startAssembly?.GetCustomAttribute<TargetFrameworkAttribute>()?.FrameworkName ?? "N/A",
-            AssemblyCopyright =  startAssembly?.GetCustomAttribute<AssemblyCopyrightAttribute>()?.Copyright ?? "N/A",
-            AssemblyTrademark =  startAssembly?.GetCustomAttribute<AssemblyTrademarkAttribute>()?.Trademark ?? "N/A",
-            AssemblyTitle = startAssembly?.GetCustomAttribute<AssemblyTitleAttribute>()?.Title ?? "N/A",
-            AssemblyCompanyName = startAssembly?.GetCustomAttribute<AssemblyCompanyAttribute>()?.Company ?? "N/A"
+            AssemblyVersion = entryAssembly.GetName().Version?.ToString() ?? "N/A",
+            AssemblyInformationalVersion = entryAssembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion ?? "N/A",
+            AssemblyProduct = entryAssembly.GetCustomAttribute<AssemblyProductAttribute>()?.Product ?? "N/A",
+            AssemblyDescription = entryAssembly.GetCustomAttribute<AssemblyDescriptionAttribute>()?.Description ?? "N/A",
+            AssemblyConfiguration = entryAssembly.GetCustomAttribute<AssemblyConfigurationAttribute>()?.Configuration ?? "N/A",
+            TargetFramework = entryAssembly.GetCustomAttribute<TargetFrameworkAttribute>()?.FrameworkName ?? "N/A",
+            AssemblyCopyright = entryAssembly.GetCustomAttribute<AssemblyCopyrightAttribute>()?.Copyright ?? "N/A",
+            AssemblyTrademark = entryAssembly.GetCustomAttribute<AssemblyTrademarkAttribute>()?.Trademark ?? "N/A",
+            AssemblyTitle = entryAssembly.GetCustomAttribute<AssemblyTitleAttribute>()?.Title ?? "N/A",
+            AssemblyCompanyName = entryAssembly.GetCustomAttribute<AssemblyCompanyAttribute>()?.Company ?? "N/A"
         };
     }
 


### PR DESCRIPTION
Since .NET Core/.NET 5+ the AssemblyVersionAttribute is compiled into the assembly manifest, not as a retrievable custom attribute. Fixed also InformationalVersion