### PR TITLE
Ignore typescript 7 in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -40,6 +40,8 @@ updates:
         update-types:
           - "version-update:semver-minor"
           - "version-update:semver-patch"
+      - dependency-name: "typescript" # Not supported by Angular 22 until https://github.com/angular/angular/issues/69719
+        versions: [">=7"]
     groups:
       npm-major:
         update-types: ["major"]
@@ -60,6 +62,8 @@ updates:
         update-types:
           - "version-update:semver-minor"
           - "version-update:semver-patch"
+      - dependency-name: "typescript" # Not supported by Angular 22 until https://github.com/angular/angular/issues/69719
+        versions: [">=7"]
     groups:
       npm-major:
         update-types: ["major"]
@@ -80,6 +84,8 @@ updates:
         update-types:
           - "version-update:semver-minor"
           - "version-update:semver-patch"
+      - dependency-name: "typescript" # Not supported by Angular 22 until https://github.com/angular/angular/issues/69719
+        versions: [">=7"]
     groups:
       npm-major:
         update-types: ["major"]
@@ -100,6 +106,8 @@ updates:
         update-types:
           - "version-update:semver-minor"
           - "version-update:semver-patch"
+      - dependency-name: "typescript" # Not supported by Angular 22 until https://github.com/angular/angular/issues/69719
+        versions: [">=7"]
     groups:
       npm-major:
         update-types: ["major"]
@@ -120,6 +128,8 @@ updates:
         update-types:
           - "version-update:semver-minor"
           - "version-update:semver-patch"
+      - dependency-name: "typescript" # Not supported by Angular 22 until https://github.com/angular/angular/issues/69719
+        versions: [">=7"]
     groups:
       npm-major:
         update-types: ["major"]
@@ -140,6 +150,8 @@ updates:
         update-types:
           - "version-update:semver-minor"
           - "version-update:semver-patch"
+      - dependency-name: "typescript" # Not supported by Angular 22 until https://github.com/angular/angular/issues/69719
+        versions: [">=7"]
     groups:
       npm-major:
         update-types: ["major"]
@@ -160,6 +172,8 @@ updates:
         update-types:
           - "version-update:semver-minor"
           - "version-update:semver-patch"
+      - dependency-name: "typescript" # Not supported by Angular 22 until https://github.com/angular/angular/issues/69719
+        versions: [">=7"]
     groups:
       npm-major:
         update-types: ["major"]
@@ -180,6 +194,8 @@ updates:
         update-types:
           - "version-update:semver-minor"
           - "version-update:semver-patch"
+      - dependency-name: "typescript" # Not supported by Angular 22 until https://github.com/angular/angular/issues/69719
+        versions: [">=7"]
     groups:
       npm-major:
         update-types: ["major"]
@@ -200,6 +216,8 @@ updates:
         update-types:
           - "version-update:semver-minor"
           - "version-update:semver-patch"
+      - dependency-name: "typescript" # Not supported by Angular 22 until https://github.com/angular/angular/issues/69719
+        versions: [">=7"]
     groups:
       npm-major:
         update-types: ["major"]
@@ -220,6 +238,8 @@ updates:
         update-types:
           - "version-update:semver-minor"
           - "version-update:semver-patch"
+      - dependency-name: "typescript" # Not supported by Angular 22 until https://github.com/angular/angular/issues/69719
+        versions: [">=7"]
     groups:
       npm-major:
         update-types: ["major"]
@@ -240,6 +260,8 @@ updates:
         update-types:
           - "version-update:semver-minor"
           - "version-update:semver-patch"
+      - dependency-name: "typescript" # Not supported by Angular 22 until https://github.com/angular/angular/issues/69719
+        versions: [">=7"]
     groups:
       npm-major:
         update-types: ["major"]
@@ -260,6 +282,8 @@ updates:
         update-types:
           - "version-update:semver-minor"
           - "version-update:semver-patch"
+      - dependency-name: "typescript" # Not supported by Angular 22 until https://github.com/angular/angular/issues/69719
+        versions: [">=7"]
     groups:
       npm-major:
         update-types: ["major"]


### PR DESCRIPTION
 Angular 22 is not supporting typescript 7 and will not support it expected to last until angular 24/25. Upgrading is not possible until that happens. Typescript 6 is not end of life just released in march and the way to go. 