### PR TITLE
Improved order dialogs

### DIFF
--- a/src/Moryx.Orders.Web/app/src/app/components/dialog-context/dialog-context.scss
+++ b/src/Moryx.Orders.Web/app/src/app/components/dialog-context/dialog-context.scss
@@ -2,7 +2,6 @@
   display: grid;
   grid-template-columns: 1fr;
   gap: 8px;
-  margin-bottom: 18px;
 }
 
 .dialog-context-item {

--- a/src/Moryx.Orders.Web/app/src/app/components/operator-selector/operator-selector.html
+++ b/src/Moryx.Orders.Web/app/src/app/components/operator-selector/operator-selector.html
@@ -1,4 +1,4 @@
-@if (providesOperatorSelection) {
+@if (providesOperatorSelection()) {
   <mat-form-field class="outer-field" appearance="outline">
     <mat-label>
       {{ TranslationConstants.OPERATOR_SELECTOR.OPERATOR_SELECTOR_LABEL | translate }}

--- a/src/Moryx.Orders.Web/app/src/app/components/operator-selector/operator-selector.ts
+++ b/src/Moryx.Orders.Web/app/src/app/components/operator-selector/operator-selector.ts
@@ -3,7 +3,7 @@
  * Licensed under the Apache License, Version 2.0
 */
 
-import { Component, inject, OnInit, ChangeDetectionStrategy, DestroyRef, model, effect, input, output } from "@angular/core";
+import { Component, inject, OnInit, ChangeDetectionStrategy, DestroyRef, model, effect, input, output, signal } from "@angular/core";
 import { TranslatePipe } from "@ngx-translate/core";
 import { TranslationConstants } from "@app/extensions/translation-constants.extensions";
 import { AssignableOperator } from "@api/models";
@@ -42,7 +42,7 @@ export class OperatorSelector implements OnInit {
   public selectedOperatorId = model<string|null>(null);
   public creatingOperatorFailed = output<boolean>();
 
-  protected providesOperatorSelection: boolean = false;
+  protected providesOperatorSelection = signal<boolean>(false);
   protected operatorFormControl = new FormControl('');
   protected operators: AssignableOperator[] = [];
   protected filteredOperators!: Observable<AssignableOperator[]>;
@@ -73,7 +73,7 @@ export class OperatorSelector implements OnInit {
         );
 
     this.operatorService.getOperators().then(o => {
-      this.providesOperatorSelection = this.operatorService.available;
+      this.providesOperatorSelection.set(this.operatorService.available);
       this.operators = o;
     });
 

--- a/src/Moryx.Orders.Web/app/src/app/dialogs/begin-dialog/begin-dialog.html
+++ b/src/Moryx.Orders.Web/app/src/app/dialogs/begin-dialog/begin-dialog.html
@@ -128,11 +128,8 @@
     }
   </mat-form-field>
 
-  <app-operator-selector class="full-width"
-    [isEnabled]="canBegin"
-    [(selectedOperatorId)]="selectedOperatorId"
-    (creatingOperatorFailed)="creatingOperatorFailed.set($event)">
-  </app-operator-selector>
+  <app-operator-selector class="full-width top-spaced" [isEnabled]="canBegin"
+    [(selectedOperatorId)]="selectedOperatorId" (creatingOperatorFailed)="creatingOperatorFailed.set($event)"/>
 </mat-dialog-content>
 
 <div mat-dialog-actions align="end">

--- a/src/Moryx.Orders.Web/app/src/app/dialogs/begin-dialog/begin-dialog.html
+++ b/src/Moryx.Orders.Web/app/src/app/dialogs/begin-dialog/begin-dialog.html
@@ -30,7 +30,7 @@
     </div>
   }
 
-  <app-dialog-context [operationModel]="operation.model"></app-dialog-context>
+  <app-dialog-context class="full-width dialog-context" [operationModel]="operation.model"></app-dialog-context>
 
   <mat-grid-list cols="3" rowHeight="50px">
     <mat-grid-tile>
@@ -128,7 +128,7 @@
     }
   </mat-form-field>
 
-  <app-operator-selector class="operator-selector"
+  <app-operator-selector class="full-width"
     [isEnabled]="canBegin"
     [(selectedOperatorId)]="selectedOperatorId"
     (creatingOperatorFailed)="creatingOperatorFailed.set($event)">

--- a/src/Moryx.Orders.Web/app/src/app/dialogs/create-dialog/create-dialog.html
+++ b/src/Moryx.Orders.Web/app/src/app/dialogs/create-dialog/create-dialog.html
@@ -15,7 +15,7 @@
       />
   </mat-form-field>
 
-  <h3 class="intermediate-header">
+  <h3 class="top-spaced">
     {{ TranslationConstants.CREATE_DIALOG.OPERATION_DETAILS | translate }}
   </h3>
   <!-- Operation Number -->
@@ -43,7 +43,7 @@
   </mat-form-field>
   
   <!-- Product Selection -->
-  <mat-form-field appearance="outline" class="full-width">
+  <mat-form-field appearance="outline" class="full-width top-spaced">
     <mat-label>{{ TranslationConstants.CREATE_DIALOG.PRODUCT | translate }}</mat-label>
     <input 
       #productInput
@@ -75,7 +75,7 @@
   </mat-form-field>
 
   <!-- Recipe Selection -->
-  <mat-form-field appearance="outline" class="full-width">
+  <mat-form-field appearance="outline" class="full-width top-spaced">
     <mat-label>{{ TranslationConstants.CREATE_DIALOG.RECIPE | translate }}</mat-label>
     <input 
       #recipeInput
@@ -103,13 +103,13 @@
     </mat-autocomplete>
   </mat-form-field>
 
-  <mat-form-field appearance="outline" class="full-width">
+  <mat-form-field appearance="outline" class="full-width top-spaced">
     <mat-label>{{ TranslationConstants.CREATE_DIALOG.AMOUNT | translate }}</mat-label>
     <input type="number" matInput [(ngModel)]="amount" [disabled]="isLoading()"/>
   </mat-form-field>
 
   @if(operations().length > 0) {
-    <h3 class="intermediate-header">
+    <h3 class="top-spaced">
       {{ TranslationConstants.CREATE_DIALOG.ADDED_OPERATIONS | translate }} 
       ({{ operations().length }})
     </h3>

--- a/src/Moryx.Orders.Web/app/src/app/dialogs/dialog-styles.scss
+++ b/src/Moryx.Orders.Web/app/src/app/dialogs/dialog-styles.scss
@@ -2,6 +2,10 @@
   width: 100%;
 }
 
+.top-spaced {
+  margin-top: 8px;
+}
+
 .suffix-icon {
   margin-right: 6px;
 }
@@ -21,7 +25,7 @@
 }
 
 .dialog-context {
-    margin-bottom: 18px;
+    margin-bottom: 16px;
 }
 
 

--- a/src/Moryx.Orders.Web/app/src/app/dialogs/dialog-styles.scss
+++ b/src/Moryx.Orders.Web/app/src/app/dialogs/dialog-styles.scss
@@ -1,6 +1,5 @@
 .full-width {
   width: 100%;
-  margin-bottom: 8px;
 }
 
 .suffix-icon {
@@ -12,7 +11,7 @@
 }
 
 .intermediate-header {
-  margin-top: -12px;
+  margin-top: 0px;
 }
 
 .dialog-container {
@@ -21,6 +20,8 @@
     flex-direction: column;
 }
 
-.operator-selector {
-    align-self: stretch;
+.dialog-context {
+    margin-bottom: 18px;
 }
+
+

--- a/src/Moryx.Orders.Web/app/src/app/dialogs/interrupt-dialog/interrupt-dialog.html
+++ b/src/Moryx.Orders.Web/app/src/app/dialogs/interrupt-dialog/interrupt-dialog.html
@@ -2,7 +2,7 @@
   {{ TranslationConstants.INTERRUPT_DIALOG.TITLE | translate }}
 </h2>
 <mat-dialog-content>
-  <app-dialog-context [operationModel]="data.operation.model"></app-dialog-context>
+  <app-dialog-context class="full-width dialog-context" [operationModel]="data.operation.model"></app-dialog-context>
 
   <p>
     {{ TranslationConstants.INTERRUPT_DIALOG.PROMPT | translate }}

--- a/src/Moryx.Orders.Web/app/src/app/dialogs/report-dialog/report-dialog.html
+++ b/src/Moryx.Orders.Web/app/src/app/dialogs/report-dialog/report-dialog.html
@@ -3,7 +3,7 @@
 </h2>
 
 <mat-dialog-content class="dialog-container">
-  <app-dialog-context [operationModel]="data.operation.model"></app-dialog-context>
+  <app-dialog-context class="full-width dialog-context" [operationModel]="data.operation.model"></app-dialog-context>
 
   <div class="report-dialog-amounts-row">
     <div class="amounts-data-entry">
@@ -48,6 +48,12 @@
     <textarea matInput [(ngModel)]="comment" [disabled]="isLoading()"></textarea>
   </mat-form-field>
 
+  <app-operator-selector class="full-width"
+    [isEnabled]="canReport()"
+    [(selectedOperatorId)]="selectedOperatorId"
+    (creatingOperatorFailed)="creatingOperatorFailed.set($event)">
+  </app-operator-selector>
+
   <h3 class="radio-group-header">{{ TranslationConstants.REPORT_DIALOG.CONFIRMATION | translate }}</h3>
   <mat-radio-group class="radio-group" aria-label="Select an report option" [(ngModel)]="confirmationType">
     <mat-radio-button [disabled]="!reportContext()?.canPartial || isLoading()" value="partial">
@@ -57,12 +63,6 @@
       {{ TranslationConstants.REPORT_DIALOG.FINAL | translate }}
     </mat-radio-button>
   </mat-radio-group>
-
-  <app-operator-selector class="operator-selector"
-    [isEnabled]="canReport()"
-    [(selectedOperatorId)]="selectedOperatorId"
-    (creatingOperatorFailed)="creatingOperatorFailed.set($event)">
-  </app-operator-selector>
 
   @for (restriction of reportContext()?.restrictions; track restriction) {
     <mat-list>

--- a/src/Moryx.Orders.Web/app/src/app/dialogs/report-dialog/report-dialog.html
+++ b/src/Moryx.Orders.Web/app/src/app/dialogs/report-dialog/report-dialog.html
@@ -43,16 +43,13 @@
     </mat-form-field>
   </div>
 
-  <mat-form-field appearance="outline" class="full-width">
+  <mat-form-field appearance="outline" class="full-width top-spaced">
     <mat-label>{{ TranslationConstants.REPORT_DIALOG.COMMENT | translate }}</mat-label>
     <textarea matInput [(ngModel)]="comment" [disabled]="isLoading()"></textarea>
   </mat-form-field>
 
-  <app-operator-selector class="full-width"
-    [isEnabled]="canReport()"
-    [(selectedOperatorId)]="selectedOperatorId"
-    (creatingOperatorFailed)="creatingOperatorFailed.set($event)">
-  </app-operator-selector>
+  <app-operator-selector class="full-width top-spaced" [isEnabled]="canReport()"
+    [(selectedOperatorId)]="selectedOperatorId" (creatingOperatorFailed)="creatingOperatorFailed.set($event)"/>
 
   <h3 class="radio-group-header">{{ TranslationConstants.REPORT_DIALOG.CONFIRMATION | translate }}</h3>
   <mat-radio-group class="radio-group" aria-label="Select an report option" [(ngModel)]="confirmationType">

--- a/src/Moryx.Orders.Web/app/src/app/dialogs/report-dialog/report-dialog.scss
+++ b/src/Moryx.Orders.Web/app/src/app/dialogs/report-dialog/report-dialog.scss
@@ -3,7 +3,7 @@
 .report-dialog-amounts-row {
     display: flex;
     width: 100%;
-    margin-bottom: 8px;
+    margin-bottom: 16px;
 }
 
 .amounts-data-entry {
@@ -11,13 +11,9 @@
     font-size: 16px;
 }
 
-mat-form-field {
-    margin-bottom: 8px;
-}
-
 .radio-group-header {
-    margin-top: -12px;
-    margin-bottom: 0px;
+    margin-top: 0px;
+    margin-bottom: 8px;
 }
 
 .radio-group {

--- a/src/Moryx.Orders.Web/app/src/app/dialogs/report-dialog/report-dialog.scss
+++ b/src/Moryx.Orders.Web/app/src/app/dialogs/report-dialog/report-dialog.scss
@@ -12,7 +12,7 @@
 }
 
 .radio-group-header {
-    margin-top: 0px;
+    margin-top: 8px;
     margin-bottom: 8px;
 }
 


### PR DESCRIPTION
1) Removed a flicker in the begin order dialog causd by late operator field visibility evaluation
2) Moved confirmation radio group in the report dialog to the end
3) Updated spacing between mat form fields and comparable controls to be the same across dialogs

<img width="701" height="746" alt="image" src="https://github.com/user-attachments/assets/a6af60a9-f9a8-4020-9106-96cc8e98d782" />

<img width="706" height="807" alt="image" src="https://github.com/user-attachments/assets/4e1090db-1276-4085-8b63-058df399b07b" />

<img width="710" height="391" alt="image" src="https://github.com/user-attachments/assets/edce9aac-72d0-44af-a2ae-3922a2fcf20c" />

<img width="705" height="798" alt="image" src="https://github.com/user-attachments/assets/6aad0920-034f-4172-a5c9-0459b18461a7" />


