### PR TITLE
Remove wrong logging in ResourceSynchronizationService

### DIFF
--- a/src/Moryx.AbstractionLayer.Resources.Mqtt.Endpoints/ResourceSynchronizationService.cs
+++ b/src/Moryx.AbstractionLayer.Resources.Mqtt.Endpoints/ResourceSynchronizationService.cs
@@ -271,6 +271,7 @@ public class ResourceSynchronizationService : IMqttService
     {
         return resourceManagement.ModifyUnsafeAsync(matchingResource.Id, resource =>
         {
+            _logger.LogInformation("Updating local resource with identity '{identity}'", (resource as IIdentifiableObject)?.Identity?.Identifier); 
             SetInstanceValue(jsonProperties, resource);
             return Task.FromResult(true);
         });
@@ -280,6 +281,7 @@ public class ResourceSynchronizationService : IMqttService
     {
         var message = MqttMessageSerialization.GetJsonPayload(matchingResource, _options.JsonSerializerOptions);
         TryAddToMessageCache(GetHashString(message));
+        _logger.LogInformation("Removing local resource with identity '{identity}'", (matchingResource as IIdentifiableObject)?.Identity?.Identifier);
 
         return resourceManagement.DeleteAsync(matchingResource.Id);
     }
@@ -388,6 +390,10 @@ public class ResourceSynchronizationService : IMqttService
     private Resource ProcessResource(Resource resource, string topic)
     {
         var synchronizationAttribute = resource.GetType().GetCustomAttribute<ResourceSynchronizationAttribute>();
+        if (synchronizationAttribute is null)
+        {
+            return resource;
+        }
         if (synchronizationAttribute?.SynchronizationTypeId is null)
         {
             _logger.LogError("Resource of type {resourceType} is marked for synchronization but has no SynchronizationTypeId defined.", resource.GetType().FullName);


### PR DESCRIPTION
The service sent a log message whenever a resource was created that was not set as synchronizable simply because the equation with null for SynchronizationTypeId matches when no attribute was set at all. When creating new processholders for example instead of recycling existing ones because they are not supposed to be set at all times will just fill the log rather frequently if they are not marked as synchronizable.
Additionally added logging for updating and removing local resources because we noticed that in one instance the synchronisation was suddenly not registered anymore for some reason after orders were newly pulled and assigned. We want to see those instances more clearly in our log. This will be watched further internally.