### PR TITLE
Fix generic JSON persistence and text column deserialization

### DIFF
--- a/MORYX-Framework.slnx
+++ b/MORYX-Framework.slnx
@@ -75,6 +75,7 @@
     <Project Path="src/Moryx.AbstractionLayer.Products.Endpoints/Moryx.AbstractionLayer.Products.Endpoints.csproj" />
     <Project Path="src/Moryx.Products.Management/Moryx.Products.Management.csproj" />
     <Project Path="src/Moryx.Products.Samples/Moryx.Products.Samples.csproj" />
+    <Project Path="src/Moryx.Products.TestProducts/Moryx.Products.TestProducts.csproj" />
     <Project Path="src/Moryx.Products.Web/Moryx.Products.Web.csproj" />
   </Folder>
   <Folder Name="/Resources/">
@@ -120,8 +121,8 @@
     <Project Path="src/Tests/Moryx.Shifts.Management.IntegrationTests/Moryx.Shifts.Management.IntegrationTests.csproj" />
   </Folder>
   <Folder Name="/Tests/UnitTests/">
-    <Project Path="src/Tests/Moryx.AspNetCore.Mqtt.Tests/Moryx.AspNetCore.Mqtt.Tests.csproj" />
     <Project Path="src/Tests/Moryx.AbstractionLayer.Tests/Moryx.AbstractionLayer.Tests.csproj" />
+    <Project Path="src/Tests/Moryx.AspNetCore.Mqtt.Tests/Moryx.AspNetCore.Mqtt.Tests.csproj" />
     <Project Path="src/Tests/Moryx.Container.Tests/Moryx.Container.Tests.csproj" />
     <Project Path="src/Tests/Moryx.ControlSystem.ProcessEngine.Tests/Moryx.ControlSystem.ProcessEngine.Tests.csproj" />
     <Project Path="src/Tests/Moryx.ControlSystem.SetupProvider.Tests/Moryx.ControlSystem.SetupProvider.Tests.csproj" />
@@ -146,11 +147,11 @@
     <Project Path="src/Tests/Moryx.Runtime.Tests/Moryx.Runtime.Tests.csproj" />
     <Project Path="src/Tests/Moryx.Simulation.Tests/Moryx.Simulation.Tests.csproj" />
     <Project Path="src/Tests/Moryx.Tests/Moryx.Tests.csproj" />
-    <Project Path="src/Tests/Moryx.VisualInstructions.Tests/Moryx.VisualInstructions.Tests.csproj" />
-    <Project Path="src/Tests/Moryx.Workplans.Editing.Tests/Moryx.Workplans.Editing.Tests.csproj" />
     <Project Path="src/Tests/Moryx.VisualInstructions.Controller.Tests/Moryx.VisualInstructions.Controller.Tests.csproj" />
     <Project Path="src/Tests/Moryx.VisualInstructions.Endpoints.Tests/Moryx.VisualInstructions.Endpoints.Tests.csproj" />
     <Project Path="src/Tests/Moryx.AbstractionLayer.Resources.Endpoints.Tests/Moryx.AbstractionLayer.Resources.Endpoints.Tests.csproj" />
+    <Project Path="src/Tests/Moryx.VisualInstructions.Tests/Moryx.VisualInstructions.Tests.csproj" />
+    <Project Path="src/Tests/Moryx.Workplans.Editing.Tests/Moryx.Workplans.Editing.Tests.csproj" />
   </Folder>
   <Folder Name="/TestTools/">
     <Project Path="src/Moryx.AbstractionLayer.TestTools/Moryx.AbstractionLayer.TestTools.csproj" />
@@ -166,11 +167,11 @@
     <Project Path="src/Tests/Moryx.Container.TestTools/Moryx.Container.TestTools.csproj" />
   </Folder>
   <Folder Name="/VisualInstructions/">
-    <Project Path="src/Moryx.VisualInstructions/Moryx.VisualInstructions.csproj" />
     <Project Path="src/Moryx.Resources.VisualInstructions/Moryx.Resources.VisualInstructions.csproj" />
     <Project Path="src/Moryx.VisualInstructions.Controller/Moryx.VisualInstructions.Controller.csproj" />
     <Project Path="src/Moryx.VisualInstructions.Endpoints/Moryx.VisualInstructions.Endpoints.csproj" />
     <Project Path="src/Moryx.VisualInstructions.Web/Moryx.VisualInstructions.Web.csproj" />
+    <Project Path="src/Moryx.VisualInstructions/Moryx.VisualInstructions.csproj" />
   </Folder>
   <Folder Name="/Workplans/">
     <Project Path="src/Moryx.Workplans.Editing/Moryx.Workplans.Editing.csproj" />

--- a/src/Moryx.Products.Management/Implementation/Storage/AutoConfigurator.cs
+++ b/src/Moryx.Products.Management/Implementation/Storage/AutoConfigurator.cs
@@ -1,6 +1,7 @@
 // Copyright (c) 2026 Phoenix Contact GmbH & Co. KG
 // Licensed under the Apache License, Version 2.0
 
+using System.Reflection;
 using Moryx.AbstractionLayer.Products;
 using Moryx.AbstractionLayer.Recipes;
 using Moryx.Configuration;
@@ -40,8 +41,10 @@ internal class AutoConfigurator
         var productTypes = ReflectionTool.GetPublicClasses<ProductType>();
         var product = productTypes.FirstOrDefault(p => p.FullName == productType);
         if (product == null)
+        {
             return $"Found no product type {productType ?? string.Empty}!\n" +
                    "Available types: " + string.Join(", ", productTypes.Select(t => t.FullName));
+        }
 
         var result = string.Empty;
         // First try to select the best type strategy
@@ -78,7 +81,10 @@ internal class AutoConfigurator
             {
                 var linkType = link.PropertyType;
                 if (typeof(IEnumerable<ProductPartLink>).IsAssignableFrom(linkType))
+                {
                     linkType = linkType.GetGenericArguments()[0];
+                }
+
                 var linkConfig = StrategyConfig<IProductLinkStrategy, ProductLinkConfiguration, ProductPartLink>(linkType);
                 if (linkConfig == null)
                 {
@@ -105,8 +111,10 @@ internal class AutoConfigurator
         var types = ReflectionTool.GetPublicClasses<ProductInstance>();
         var instance = types.FirstOrDefault(p => p.FullName == instanceType);
         if (instance == null)
+        {
             return $"Found no instance type {instanceType ?? string.Empty}!\n" +
                    "Available types: " + string.Join(", ", types.Select(t => t.FullName));
+        }
 
         var result = string.Empty;
         if (Config.InstanceStrategies.Any(s => s.TargetType == instanceType))
@@ -138,8 +146,10 @@ internal class AutoConfigurator
         var types = ReflectionTool.GetPublicClasses<IProductRecipe>();
         var recipe = types.FirstOrDefault(p => p.FullName == recipeType);
         if (recipe == null)
+        {
             return $"Found no recipe type {recipeType ?? string.Empty}!\n" +
                    "Available types: " + string.Join(", ", types.Select(t => t.FullName));
+        }
 
         var result = string.Empty;
         if (Config.RecipeStrategies.Any(s => s.TargetType == recipeType))
@@ -169,7 +179,9 @@ internal class AutoConfigurator
     {
         var tuple = CreateConfig<TStrategy, TConfig>(targetType);
         if (tuple == null)
+        {
             return null;
+        }
 
         var config = tuple.Item2;
         config.TargetType = targetType.FullName;
@@ -179,28 +191,49 @@ internal class AutoConfigurator
 
         // Optionally try to configure property mappers
         if (config is not IPropertyMappedConfiguration propertyMapperConfig)
+        {
             return config;
+        }
 
-        var remainingColumns = typeof(IGenericColumns).GetProperties()
-            .OrderBy(p => p.Name).ToList();
+        var jsonColumn = (config as IGenericMapperConfiguration)?.JsonColumn;
+
+        var remainingColumns = typeof(IGenericColumns)
+            .GetProperties()
+            .Where(p => string.IsNullOrEmpty(jsonColumn) ||
+                        !string.Equals(p.Name, jsonColumn, StringComparison.OrdinalIgnoreCase))
+            .OrderBy(p => p.Name)
+            .ToList();
 
         var baseTypeWrapper = Storage.GetTypeWrapper(typeof(TBaseType).FullName);
-        var baseProperties = baseTypeWrapper != null ? baseTypeWrapper.Properties.ToArray() : typeof(TBaseType).GetProperties();
+        var baseProperties = baseTypeWrapper?.Properties.ToArray() ?? typeof(TBaseType).GetProperties();
 
         var targetTypeWrapper = Storage.GetTypeWrapper(targetType.FullName);
-        var targetProperties = targetTypeWrapper != null ? targetTypeWrapper.Properties.ToArray() : targetType.GetProperties();
-        var filteredProperties = targetProperties
-            .Where(p => baseProperties.All(bp => bp.Name != p.Name))
-            .Where(p => p.GetSetMethod() != null)
-            .Where(p => !typeof(ProductPartLink).IsAssignableFrom(p.PropertyType) & !typeof(IEnumerable<ProductPartLink>).IsAssignableFrom(p.PropertyType))
-            .Where(p => !typeof(ProductInstance).IsAssignableFrom(p.PropertyType) & !typeof(IEnumerable<ProductInstance>).IsAssignableFrom(p.PropertyType))
+        var targetProperties = targetTypeWrapper?.Properties.ToArray() ?? targetType.GetProperties();
+
+        var excludedTypes = new[]
+        {
+            typeof(ProductPartLink),
+            typeof(IEnumerable<ProductPartLink>),
+            typeof(ProductInstance),
+            typeof(IEnumerable<ProductInstance>)
+        };
+
+        bool IsExcluded(PropertyInfo property) => excludedTypes.Any(t => t.IsAssignableFrom(property.PropertyType));
+        var filteredProperties = targetProperties.Where(p =>
+            baseProperties.All(bp => bp.Name != p.Name)
+            && p.GetSetMethod() != null
+            && !IsExcluded(p)
+            && (string.IsNullOrEmpty(jsonColumn)
+            || !string.Equals(p.Name, jsonColumn, StringComparison.OrdinalIgnoreCase)))
             .ToList();
 
         foreach (var property in filteredProperties)
         {
             var propertyTuple = CreateConfig<IPropertyMapper, PropertyMapperConfig>(property.PropertyType);
             if (propertyTuple == null)
+            {
                 continue;
+            }
 
             var strategy = propertyTuple.Item1;
             var propertyConfig = propertyTuple.Item2;
@@ -210,7 +243,9 @@ internal class AutoConfigurator
             var columnType = strategy.GetCustomAttribute<PropertyStrategyConfigurationAttribute>()?.ColumnType ?? typeof(string);
             var column = remainingColumns.FirstOrDefault(rc => rc.PropertyType == columnType);
             if (column == null)
+            {
                 continue;
+            }
 
             remainingColumns.Remove(column);
             propertyConfig.Column = column.Name;
@@ -227,7 +262,9 @@ internal class AutoConfigurator
         var strategies = Container.GetRegisteredImplementations(typeof(TStrategy));
         var typeStrategy = SelectStrategy(strategies, targetType);
         if (typeStrategy == null)
+        {
             return null;
+        }
 
         var configType = typeStrategy.GetCustomAttribute<ExpectedConfigAttribute>()?.ExpectedConfigType
                          ?? typeof(TConfig);

--- a/src/Moryx.Products.Management/Plugins/GenericStrategies/GenericEntityMapper.cs
+++ b/src/Moryx.Products.Management/Plugins/GenericStrategies/GenericEntityMapper.cs
@@ -2,11 +2,13 @@
 // Licensed under the Apache License, Version 2.0
 
 using System.Linq.Expressions;
+using Microsoft.Extensions.Logging;
 using Moryx.Container;
 using Moryx.Products.Management.Model;
 using Moryx.Serialization;
 using Moryx.Tools;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using static Moryx.Products.Management.ProductExpressionHelpers;
 
 namespace Moryx.Products.Management;
@@ -24,7 +26,10 @@ internal class GenericEntityMapper<TBase, TReference> : IGenericMapper
     /// </summary>
     public IPropertyMapperFactory MapperFactory { get; set; }
 
+    public ILogger Logger { get; set; }
+
     private IPropertyMapper[] _configuredMappers;
+
 
     private JsonSerializerSettings _jsonSettings;
 
@@ -37,25 +42,47 @@ internal class GenericEntityMapper<TBase, TReference> : IGenericMapper
         _jsonAccessor = ReflectionTool.PropertyAccessor<IGenericColumns, string>(jsonColumn);
 
         var baseProperties = typeof(TBase).GetProperties().Select(p => p.Name).ToArray();
-        var configuredProperties = config.PropertyConfigs.Select(cm => cm.PropertyName);
+
+        // Legacy compatibility:
+        // Historically some configurations used the JsonColumn both as JSON storage
+        // and as a regular property mapping. This remains supported until the next
+        // major release but should no longer be generated automatically.
+        // TODO: MORYX 12: Maybe remove support for using JsonColumn as a regular property mapping.
+        if (config.PropertyConfigs.Any(pc => string.Equals(pc.PropertyName, config.JsonColumn, StringComparison.OrdinalIgnoreCase)))
+        {
+            Logger.LogWarning(
+                "Detected a PropertyConfig for JsonColumn '{JsonColumn}'. " +
+                "This configuration is deprecated and may no longer be supported in a future major release.",
+                config.JsonColumn);
+        }
+
+        var configuredProperties = config.PropertyConfigs
+            .Select(cm => cm.PropertyName)
+            .ToArray();
 
         var readOnlyProperties = concreteType.GetProperties()
-            .Where(p => p.GetSetMethod() == null).Select(p => p.Name).ToArray();
+            .Where(p => p.GetSetMethod() == null)
+            .Select(p => p.Name)
+            .ToArray();
 
-        // The json should not contain base, configured nor readonly properties
         var jsonIgnoredProperties = baseProperties
             .Concat(configuredProperties)
-            .Concat(readOnlyProperties).ToArray();
+            .Concat(readOnlyProperties)
+            .ToArray();
 
         _jsonSettings = JsonSettings.Minimal
-            .Overwrite(j => j.ContractResolver = new DifferentialContractResolver<TReference>(jsonIgnoredProperties));
+            .Overwrite(j => j.ContractResolver =
+                new DifferentialContractResolver<TReference>(jsonIgnoredProperties));
 
         // Properties where no mapper should be created for: base and read only properties
         var mapperIgnoredProperties = baseProperties
-            .Concat(readOnlyProperties).ToArray();
+            .Concat(readOnlyProperties)
+            .ToArray();
 
-        _configuredMappers = config.PropertyConfigs.Where(pc => !mapperIgnoredProperties.Contains(pc.PropertyName))
-            .Select(pc => MapperFactory.Create(pc, concreteType)).ToArray();
+        _configuredMappers = config.PropertyConfigs
+            .Where(pc => !mapperIgnoredProperties.Contains(pc.PropertyName))
+            .Select(pc => MapperFactory.Create(pc, concreteType))
+            .ToArray();
     }
 
     public bool HasChanged(IGenericColumns storage, object instance)
@@ -116,32 +143,127 @@ internal class GenericEntityMapper<TBase, TReference> : IGenericMapper
         return Expression.Lambda(body, columnParam) as Expression<Func<IGenericColumns, bool>>;
     }
 
+    /// <inheritdoc />
     public void ReadValue(IGenericColumns source, object target)
     {
-        // Use all configured mappers
-        var properties = source;
+        // Read all directly mapped properties
         foreach (var mapper in _configuredMappers)
         {
-            mapper.ReadValue(properties, target);
+            mapper.ReadValue(source, target);
         }
 
-        // Fill the rest from JSON
+        // Reading JSON from the JsonColumn
         var json = _jsonAccessor.ReadProperty(source);
-        if (!string.IsNullOrEmpty(json))
-            JsonConvert.PopulateObject(json, target, _jsonSettings);
+        if (string.IsNullOrEmpty(json))
+        {
+            return;
+        }
 
+        // Legacy compatibility:
+        // Older systems may contain plain text in the JsonColumn.
+        // In this case simply ignore the content and continue loading
+        // the directly mapped properties.
+        if (!(json.StartsWith("{") || json.StartsWith("[")))
+        {
+            Logger.LogWarning("Ignoring non-JSON content in JsonColumn '{Column}'. Value: '{Value}'", _jsonAccessor.Property.Name, json);
+            return;
+        }
+
+        // Populate remaining properties from the JsonColumn JSON payload
+        try
+        {
+            JsonConvert.PopulateObject(json, target, _jsonSettings);
+        }
+        catch (JsonException ex)
+        {
+            throw new InvalidOperationException(
+                $"Failed to deserialize JSON from column '{_jsonAccessor.Property.Name}' for target type '{target.GetType().FullName}'. " +
+                $"Stored value: '{json}'", ex);
+        }
     }
 
+    /// <inheritdoc/>>
     public void WriteValue(object source, IGenericColumns target)
     {
-        // Convert and write JSON
-        var json = JsonConvert.SerializeObject(source, _jsonSettings);
-        _jsonAccessor.WriteProperty(target, json);
-
-        // Execute property mappers
+        // First, write all the directly mapped properties
         foreach (var mapper in _configuredMappers)
         {
             mapper.WriteValue(source, target);
         }
+
+        // Generate JSON from the rest of the object
+        var mappedNames = _configuredMappers
+            .Select(m => m.Property.Name)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        // JSON for all other props
+        var jsonObject = new JObject();
+
+        foreach (var prop in source.GetType().GetProperties())
+        {
+            if (!prop.CanRead)
+            {
+                continue;
+            }
+
+            if (!prop.CanWrite)
+            {
+                continue;
+            }
+
+            // Do not include base, read-only, or directly mapped properties in the JSON
+            if (mappedNames.Contains(prop.Name))
+            {
+                continue;
+            }
+
+            // jump Indexer 
+            if (prop.GetIndexParameters().Length > 0)
+            {
+                continue;
+            }
+
+            // jump Read-only Props
+            if (prop.GetSetMethod() == null)
+            {
+                continue;
+            }
+
+            var value = prop.GetValue(source);
+
+            // "Not set yet" -> null in JSON
+            if (IsDefaultOrNull(prop.PropertyType, value))
+            {
+                jsonObject[prop.Name] = JValue.CreateNull();
+            }
+            else
+            {
+                jsonObject[prop.Name] = JToken.FromObject(value, JsonSerializer.Create(_jsonSettings));
+            }
+        }
+
+        // Write JSON to the Json - Column
+        _jsonAccessor.WriteProperty(target, jsonObject.ToString(Formatting.None));
+    }
+
+    private static bool IsDefaultOrNull(Type propertyType, object value)
+    {
+        if (value == null)
+        {
+            return true;
+        }
+
+        var underlyingType = Nullable.GetUnderlyingType(propertyType);
+        var effectiveType = underlyingType ?? propertyType;
+
+        // Reference type
+        if (!effectiveType.IsValueType)
+        {
+            return false;
+        }
+
+        // Value type: handle Default as "not set yet"
+        var defaultValue = Activator.CreateInstance(effectiveType);
+        return Equals(value, defaultValue);
     }
 }

--- a/src/Moryx.Products.Management/Plugins/GenericStrategies/TextColumnMapper.cs
+++ b/src/Moryx.Products.Management/Plugins/GenericStrategies/TextColumnMapper.cs
@@ -18,35 +18,64 @@ internal class TextColumnMapper : ColumnMapper<string>
 {
     public TextColumnMapper(Type targetType) : base(targetType)
     {
-
     }
 
     protected override IPropertyAccessor<object, string> CreatePropertyAccessor(PropertyInfo objectProp)
     {
         var propType = objectProp.PropertyType;
-        // Convert return value to string
+
+        // Convert Guid to string
         if (propType == typeof(Guid))
-            return new ConversionAccessor<string, Guid>(objectProp,
+        {
+            return new ConversionAccessor<string, Guid>(
+                objectProp,
                 guid => guid != Guid.Empty ? guid.ToString() : null,
                 str => !string.IsNullOrEmpty(str) ? Guid.Parse(str) : Guid.Empty);
+        }
 
-        if ((propType.IsClass | propType.IsInterface) && propType != typeof(string))
-            return new ConversionAccessor<string, object>(objectProp,
+        // Complex reference types -> JSON
+        if ((propType.IsClass || propType.IsInterface) && propType != typeof(string))
+        {
+            return new ConversionAccessor<string, object>(
+                objectProp,
                 o => JsonConvert.SerializeObject(o, Property.PropertyType, JsonSettings.Minimal),
-                s => JsonConvert.DeserializeObject(s, Property.PropertyType, JsonSettings.Minimal));
+                s =>
+                {
+                    if (string.IsNullOrWhiteSpace(s))
+                    {
+                        var effectiveType = Nullable.GetUnderlyingType(Property.PropertyType) ?? Property.PropertyType;
 
+                        if (!effectiveType.IsValueType)
+                            return null;
+
+                        return Activator.CreateInstance(effectiveType);
+                    }
+
+                    return JsonConvert.DeserializeObject(s, Property.PropertyType, JsonSettings.Minimal);
+                });
+        }
+
+        // Normal string property
         return base.CreatePropertyAccessor(objectProp);
     }
 
     protected override object ToExpressionValue(object value)
     {
         var propType = Property.PropertyType;
+
+        // Guid -> string
         if (propType == typeof(Guid))
+        {
             return ((Guid)value).ToString();
+        }
 
-        if ((propType.IsClass | propType.IsInterface) && propType != typeof(string))
-            return JsonConvert.SerializeObject(value, Property.PropertyType, JsonSettings.Minimal);
+        // Complex reference types -> JSON
+        if ((propType.IsClass || propType.IsInterface) && propType != typeof(string))
+        {
+            return value == null ? null : JsonConvert.SerializeObject(value, Property.PropertyType, JsonSettings.Minimal);
+        }
 
+        // Normal string / primitive conversion
         return base.ToExpressionValue(value);
     }
 }

--- a/src/Moryx.Products.TestProducts/Importer/GenericJsonTestProductTypeImporter.cs
+++ b/src/Moryx.Products.TestProducts/Importer/GenericJsonTestProductTypeImporter.cs
@@ -1,0 +1,71 @@
+// Copyright (c) 2026 Phoenix Contact GmbH & Co. KG
+// Licensed under the Apache License, Version 2.0
+using Moryx.AbstractionLayer.Products;
+using Moryx.Modules;
+
+namespace Moryx.Products.TestProducts;
+
+[ExpectedConfig(typeof(GenericJsonTestProductTypeImporterConfig))]
+[ProductImporter(nameof(GenericJsonTestProductTypeImporter))]
+public class GenericJsonTestProductTypeImporter : ProductImporterBase<GenericJsonTestProductTypeImporterConfig, SpecializedJsonTestProductTypeParameters>
+{
+    protected override Task<ProductImporterResult> ImportAsync(ProductImportContext context, SpecializedJsonTestProductTypeParameters parameters,
+        CancellationToken cancellationToken)
+    {
+        var product = new GenericJsonTestProductType()
+        {
+            Name = parameters.Name,
+            Identity = new ProductIdentity(parameters.Identifier, parameters.Revision),
+
+            //Text1 = "T1",
+            Text2 = "T2",
+            Text3 = "T3",
+            Text4 = "T4",
+            Text5 = "T5",
+            Text6 = "T6",
+            Text7 = "T7",
+            Text8 = "T8",
+            Text9 = "T9",
+            Text10 = "T10",
+
+            Integer1 = 1,
+            Integer2 = 2,
+            Integer3 = 3,
+            Integer4 = 4,
+            Integer5 = 5,
+            Integer6 = 6,
+            Integer7 = 7,
+            Integer8 = 8,
+            Integer9 = 9,
+            Integer10 = 10,
+
+            Float1 = 1.23f,
+            Float2 = 2.34f,
+            Float3 = 3.45f,
+            Float4 = 4.56f,
+            Float5 = 5.67f,
+            Float6 = 6.78f,
+            Float7 = 7.89f,
+            Float8 = 8.90f,
+            Float9 = 9.01f,
+            Float10 = 10.11f,
+
+            ComplexData1 = new ComplexData()
+        };
+
+        var result = new ProductImporterResult
+        {
+            ImportedTypes = [product]
+        };
+
+        return Task.FromResult(new ProductImporterResult
+        {
+            ImportedTypes =
+                [product]
+        });
+    }
+}
+
+public class SpecializedJsonTestProductTypeParameters : PrototypeParameters
+{
+}

--- a/src/Moryx.Products.TestProducts/Importer/GenericJsonTestProductTypeImporterConfig.cs
+++ b/src/Moryx.Products.TestProducts/Importer/GenericJsonTestProductTypeImporterConfig.cs
@@ -1,0 +1,19 @@
+// Copyright (c) 2026 Phoenix Contact GmbH & Co. KG
+// Licensed under the Apache License, Version 2.0
+
+using System.Runtime.Serialization;
+using Moryx.AbstractionLayer.Products;
+
+namespace Moryx.Products.TestProducts;
+
+/// <summary>
+/// Importer config for testing GenericJsonTestProductType
+/// </summary>
+[DataContract]
+public class GenericJsonTestProductTypeImporterConfig : ProductImporterConfig
+{
+    /// <summary>
+    /// Name of the component represented by this entry
+    /// </summary>
+    public override string PluginName => nameof(GenericJsonTestProductTypeImporter);
+}

--- a/src/Moryx.Products.TestProducts/Importer/TextColumnMapperTestProductTypeImporter.cs
+++ b/src/Moryx.Products.TestProducts/Importer/TextColumnMapperTestProductTypeImporter.cs
@@ -1,0 +1,35 @@
+// Copyright (c) 2026 Phoenix Contact GmbH & Co. KG
+// Licensed under the Apache License, Version 2.0
+
+using Moryx.AbstractionLayer.Products;
+
+namespace Moryx.Products.TestProducts;
+
+public class TextColumnMapperTestProductTypeImporter : ProductImporterBase<TextColumnMapperTestProductTypeImporterConfig, TextColumnMapperTestProductTypeParameters>
+{
+    protected override Task<ProductImporterResult> ImportAsync(ProductImportContext context, TextColumnMapperTestProductTypeParameters parameters, CancellationToken cancellationToken)
+    {
+        var product = new TextColumnMapperTestProductType
+        {
+            Name = parameters.Name,
+            Identity = new ProductIdentity(parameters.Identifier, parameters.Revision),
+
+            ComplexData1 = new ComplexData
+            {
+                PropertyName = "First",
+                Number = 123,
+                Weight = 1.23f
+            },
+        };
+
+        return Task.FromResult(new ProductImporterResult
+        {
+            ImportedTypes = [product]
+        });
+    }
+}
+
+public class TextColumnMapperTestProductTypeParameters
+    : PrototypeParameters
+{
+}

--- a/src/Moryx.Products.TestProducts/Importer/TextColumnMapperTestProductTypeImporterConfig.cs
+++ b/src/Moryx.Products.TestProducts/Importer/TextColumnMapperTestProductTypeImporterConfig.cs
@@ -1,0 +1,13 @@
+// Copyright (c) 2026 Phoenix Contact GmbH & Co. KG
+// Licensed under the Apache License, Version 2.0
+
+using System.Runtime.Serialization;
+using Moryx.AbstractionLayer.Products;
+
+namespace Moryx.Products.TestProducts;
+
+[DataContract]
+public class TextColumnMapperTestProductTypeImporterConfig : ProductImporterConfig
+{
+    public override string PluginName => nameof(TextColumnMapperTestProductTypeImporter);
+}

--- a/src/Moryx.Products.TestProducts/Moryx.Products.TestProducts.csproj
+++ b/src/Moryx.Products.TestProducts/Moryx.Products.TestProducts.csproj
@@ -1,0 +1,13 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Moryx.AbstractionLayer\Moryx.AbstractionLayer.csproj" />
+    <ProjectReference Include="..\Moryx.Products.Management\Moryx.Products.Management.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Moryx.Products.TestProducts/Moryx.Products.TestProducts.csproj.DotSettings
+++ b/src/Moryx.Products.TestProducts/Moryx.Products.TestProducts.csproj.DotSettings
@@ -1,0 +1,4 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=importer/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=productinstances/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=producttypes/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/src/Moryx.Products.TestProducts/ProductInstances/GenericJsonTestProductTypeInstance.cs
+++ b/src/Moryx.Products.TestProducts/ProductInstances/GenericJsonTestProductTypeInstance.cs
@@ -1,0 +1,10 @@
+// Copyright (c) 2026 Phoenix Contact GmbH & Co. KG
+// Licensed under the Apache License, Version 2.0
+
+using Moryx.AbstractionLayer.Products;
+
+namespace Moryx.Products.TestProducts;
+
+public class GenericJsonTestProductTypeInstance : ProductInstance<GenericJsonTestProductType>
+{
+}

--- a/src/Moryx.Products.TestProducts/ProductInstances/TextColumnMapperTestProductTypeInstance.cs
+++ b/src/Moryx.Products.TestProducts/ProductInstances/TextColumnMapperTestProductTypeInstance.cs
@@ -1,0 +1,10 @@
+// Copyright (c) 2026 Phoenix Contact GmbH & Co. KG
+// Licensed under the Apache License, Version 2.0
+
+using Moryx.AbstractionLayer.Products;
+
+namespace Moryx.Products.TestProducts;
+
+public class TextColumnMapperTestProductTypeInstance : ProductInstance<TextColumnMapperTestProductType>
+{
+}

--- a/src/Moryx.Products.TestProducts/ProductTypes/ComplexData.cs
+++ b/src/Moryx.Products.TestProducts/ProductTypes/ComplexData.cs
@@ -1,0 +1,21 @@
+// Copyright (c) 2026 Phoenix Contact GmbH & Co. KG
+// Licensed under the Apache License, Version 2.0
+
+namespace Moryx.Products.TestProducts;
+
+/// <summary>
+/// To test complex data in text columns
+/// </summary>
+public class ComplexData
+{
+    // ToDo: Property name "Name" is reserved and is covered by Parent class property so it can not be used here
+
+    public string Content { get; set; }
+
+    public string PropertyName { get; set; }
+
+    public int Number { get; set; }
+
+    public float Weight { get; set; }
+}
+

--- a/src/Moryx.Products.TestProducts/ProductTypes/GenericJsonTestProductType.cs
+++ b/src/Moryx.Products.TestProducts/ProductTypes/GenericJsonTestProductType.cs
@@ -1,0 +1,144 @@
+// Copyright (c) 2026 Phoenix Contact GmbH & Co. KG
+// Licensed under the Apache License, Version 2.0
+
+using System.ComponentModel;
+using Moryx.AbstractionLayer.Products;
+
+namespace Moryx.Products.TestProducts;
+
+/// <summary>
+/// Product type used for integration tests of JSON column mappings.
+/// </summary>
+[DisplayName("Generic Json Test type")]
+public class GenericJsonTestProductType : ProductType
+{
+
+    protected override ProductInstance Instantiate()
+    {
+        return new GenericJsonTestProductTypeInstance();
+    }
+
+    [Description("Sample Int 1")]
+    // [DefaultValue(1)]
+    public int Integer1 { get; set; }
+
+    [Description("Sample Int 2")]
+    // [DefaultValue(2)]
+    public int Integer2 { get; set; }
+
+    [Description("Sample Int 3")]
+    // [DefaultValue(3)]
+    public int Integer3 { get; set; }
+
+    [Description("Sample Int 4")]
+    // [DefaultValue(4)]
+    public int Integer4 { get; set; }
+
+    [Description("Sample Int 5")]
+    // [DefaultValue(5)]
+    public int Integer5 { get; set; }
+
+    [Description("Sample Int 6")]
+    // [DefaultValue(6)]
+    public int Integer6 { get; set; }
+
+    [Description("Sample Int 7")]
+    // [DefaultValue(7)]
+    public int Integer7 { get; set; }
+
+    [Description("Sample Int 8")]
+    // [DefaultValue(8)]
+    public int Integer8 { get; set; }
+
+    [Description("Sample Int 9")]
+    // [DefaultValue(9)]
+    public int Integer9 { get; set; }
+
+    [Description("Sample Int 10")]
+    // [DefaultValue(10)]
+    public int Integer10 { get; set; }
+
+    [Description("Sample float 1")]
+    // [DefaultValue(1.1)]
+    public double Float1 { get; set; }
+
+    [Description("Sample float 2")]
+    // [DefaultValue(2.1)]
+    public float Float2 { get; set; }
+
+    [Description("Sample float 3")]
+    // [DefaultValue(3.1)]
+    public float Float3 { get; set; }
+
+    [Description("Sample float 4")]
+    // [DefaultValue(4.1)]
+    public float Float4 { get; set; }
+
+    [Description("Sample float 5")]
+    // [DefaultValue(5.1)]
+    public float Float5 { get; set; }
+
+    [Description("Sample float 6")]
+    // [DefaultValue(6.1)]
+    public float Float6 { get; set; }
+
+    [Description("Sample float 7")]
+    // [DefaultValue(7.1)]
+    public float Float7 { get; set; }
+
+    [Description("Sample float 8")]
+    // [DefaultValue(8.1)]
+    public float Float8 { get; set; }
+
+    [Description("Sample float 9")]
+    // [DefaultValue(9.1)]
+    public double Float9 { get; set; }
+
+    [Description("Sample float 10")]
+    // [DefaultValue(10.1)]
+    public float Float10 { get; set; }
+
+    //[Description("Sample Text 1")]
+    //// [DefaultValue("Text 1")]
+    //public string Text1 { get; set; }
+
+    [Description("Sample Text 2")]
+    // [DefaultValue("Text 2")]
+    public string Text2 { get; set; }
+
+    [Description("Sample Text 3")]
+    // [DefaultValue("Text 3")]
+    public string Text3 { get; set; }
+
+    [Description("Sample Text 4")]
+    // [DefaultValue("Text 4")]
+    public string Text4 { get; set; }
+
+    [Description("Sample Text 5")]
+    // [DefaultValue("Text 5")]
+    public string Text5 { get; set; }
+
+    [Description("Sample Text 6")]
+    // [DefaultValue("Text 6")]
+    public string Text6 { get; set; }
+
+    [Description("Sample Text 7")]
+    // [DefaultValue("Text 7")]
+    public string Text7 { get; set; }
+
+    [Description("Sample Text 8")]
+    // [DefaultValue("Text 8")]
+    public string Text8 { get; set; }
+
+    [Description("Sample Text 9")]
+    // [DefaultValue("Text 9")]
+    public string Text9 { get; set; }
+
+    [Description("Sample Text 10")]
+    // [DefaultValue("Text 10")]
+    public string Text10 { get; set; }
+
+    [Description("Complex data for a text column")]
+    public ComplexData ComplexData1 { get; set; }
+
+}

--- a/src/Moryx.Products.TestProducts/ProductTypes/TestProdData.cs
+++ b/src/Moryx.Products.TestProducts/ProductTypes/TestProdData.cs
@@ -1,0 +1,15 @@
+// Copyright (c) 2026 Phoenix Contact GmbH & Co. KG
+// Licensed under the Apache License, Version 2.0
+
+namespace Moryx.Products.TestProducts;
+
+/// <summary>
+/// another Test for complex data in products
+/// try to add after a product is already stored in database
+/// </summary>
+public class TestProdData
+{
+    public int TotalAmount { get; set; }
+
+    public string WorkerName { get; set; }
+}

--- a/src/Moryx.Products.TestProducts/ProductTypes/TextColumnMapperTestProductType.cs
+++ b/src/Moryx.Products.TestProducts/ProductTypes/TextColumnMapperTestProductType.cs
@@ -1,0 +1,30 @@
+// Copyright (c) 2026 Phoenix Contact GmbH & Co. KG
+// Licensed under the Apache License, Version 2.0
+
+using System.ComponentModel;
+using Moryx.AbstractionLayer.Products;
+namespace Moryx.Products.TestProducts;
+
+/// <summary>
+/// Product type used for integration tests of property-to-column mappings.
+/// </summary>
+[DisplayName("TextColumnMapper Test Type")]
+public class TextColumnMapperTestProductType : ProductType
+{
+    public int Integer1 { get; set; }
+
+    public int Integer2 { get; set; }
+
+    public double Float1 { get; set; }
+
+    public string MyText1 { get; set; }
+
+    public ComplexData ComplexData1 { get; set; }
+    
+    public TestProdData ProdDataAdded { get; set; }
+
+    protected override ProductInstance Instantiate()
+    {
+        return new TextColumnMapperTestProductTypeInstance();
+    }
+}

--- a/src/Moryx/Tools/PropertyAccessor.cs
+++ b/src/Moryx/Tools/PropertyAccessor.cs
@@ -23,14 +23,22 @@ internal abstract class PropertyAccessor<TConcrete, TProperty>
         Property = property;
 
         if (property.CanRead)
+        {
             PropertyGetter = (Func<TConcrete, TProperty>)Delegate.CreateDelegate(typeof(Func<TConcrete, TProperty>), property.GetMethod);
+        }
         else
+        {
             PropertyGetter = EmptyGetter;
+        }
 
         if (property.CanWrite)
+        {
             PropertySetter = (Action<TConcrete, TProperty>)Delegate.CreateDelegate(typeof(Action<TConcrete, TProperty>), property.SetMethod);
+        }
         else
+        {
             PropertySetter = EmptySetter;
+        }
     }
 
     private static TProperty EmptyGetter(TConcrete instance) => default(TProperty);
@@ -136,15 +144,29 @@ internal class ConversionAccessor<TConcrete, TBase, TProperty, TValue> : Propert
     public TValue ReadProperty(TBase instance)
     {
         var value = (object)PropertyGetter((TConcrete)instance);
-        return (TValue)(value is TValue ? value : Convert.ChangeType(value, typeof(TValue)));
+        TValue response;
+        if (value is TValue value1)
+        {
+            response = value1;
+        }
+        else
+        {
+            response = (TValue)Convert.ChangeType(value, typeof(TValue));
+        }
+
+        return response;
     }
 
     public void WriteProperty(TBase instance, TValue value)
     {
-        // Check if the value can be casted or needs conversion
+        // Check if the value can be cast or needs conversion
         if (value is TProperty)
+        {
             PropertySetter((TConcrete)instance, (TProperty)(object)value);
+        }
         else
+        {
             PropertySetter((TConcrete)instance, (TProperty)Convert.ChangeType(value, typeof(TProperty)));
+        }
     }
 }

--- a/src/StartProject.Asp/StartProject.Asp.csproj
+++ b/src/StartProject.Asp/StartProject.Asp.csproj
@@ -65,6 +65,8 @@
     <ProjectReference Include="..\Moryx.ControlSystem.Simulator\Moryx.ControlSystem.Simulator.csproj" />
     <ProjectReference Include="..\Moryx.Workplans.Editing\Moryx.Workplans.Editing.csproj" />
     <ProjectReference Include="..\Moryx.Workplans.Web\Moryx.Workplans.Web.csproj" />
+
+    <ProjectReference Include="..\Moryx.Products.TestProducts\Moryx.Products.TestProducts.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Tests/Moryx.Products.IntegrationTests/Moryx.Products.IntegrationTests.csproj
+++ b/src/Tests/Moryx.Products.IntegrationTests/Moryx.Products.IntegrationTests.csproj
@@ -17,6 +17,7 @@
 	<ProjectReference Include="..\..\Moryx.Model.InMemory\Moryx.Model.InMemory.csproj" />
     <ProjectReference Include="..\..\Moryx.AbstractionLayer.TestTools\Moryx.AbstractionLayer.TestTools.csproj" />
     <ProjectReference Include="..\..\Moryx.Products.Samples\Moryx.Products.Samples.csproj" />
+    <ProjectReference Include="..\..\Moryx.Products.TestProducts\Moryx.Products.TestProducts.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Tests/Moryx.Products.IntegrationTests/ProductStorageTests.cs
+++ b/src/Tests/Moryx.Products.IntegrationTests/ProductStorageTests.cs
@@ -6,21 +6,22 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Moryx.AbstractionLayer.Products;
-using Moryx.AbstractionLayer.Recipes;
-using Moryx.Products.Management;
-using Moryx.Products.Management.NullStrategies;
-using Moryx.Products.Samples;
-using Moryx.Products.Samples.Recipe;
-using Moryx.Tools;
-using Moryx.Workplans;
 using Moq;
 using Moryx.AbstractionLayer.Identity;
+using Moryx.AbstractionLayer.Products;
+using Moryx.AbstractionLayer.Recipes;
 using Moryx.AbstractionLayer.TestTools;
 using Moryx.AbstractionLayer.Workplans;
 using Moryx.Model.Repositories;
+using Moryx.Products.Management;
 using Moryx.Products.Management.Model;
+using Moryx.Products.Management.NullStrategies;
+using Moryx.Products.Samples;
+using Moryx.Products.Samples.Recipe;
+using Moryx.Products.TestProducts;
 using Moryx.Serialization;
+using Moryx.Tools;
+using Moryx.Workplans;
 using NUnit.Framework;
 
 namespace Moryx.Products.IntegrationTests;
@@ -42,7 +43,7 @@ public class ProductStorageTests
         // Enable test mode
         ReflectionTool.TestMode = true;
         // This call is necessary for NUnit to load the type
-        var someType = new WatchType();
+        _ = new WatchType();
     }
 
     [SetUp]
@@ -134,7 +135,38 @@ public class ProductStorageTests
                     TargetType = typeof(WatchPackageType).FullName,
                     JsonColumn = nameof(IGenericColumns.Text8),
                     PropertyConfigs = []
-                }
+                },
+
+                new GenericTypeConfiguration
+                {
+                    TargetType = typeof(GenericJsonTestProductType).FullName,
+                    JsonColumn = nameof(IGenericColumns.Text8),
+                    PropertyConfigs = []
+                },
+
+                new GenericTypeConfiguration
+                {
+                    TargetType = typeof(TextColumnMapperTestProductType).FullName,
+
+                    JsonColumn = nameof(IGenericColumns.Text8),
+
+                    PropertyConfigs =
+                    [
+                        new PropertyMapperConfig
+                        {
+                            PropertyName = nameof(TextColumnMapperTestProductType.Integer1),
+                            Column = nameof(IGenericColumns.Integer1),
+                            PluginName = nameof(IntegerColumnMapper)
+                        },
+
+                        new PropertyMapperConfig
+                        {
+                            PropertyName = nameof(TextColumnMapperTestProductType.MyText1),
+                            Column = nameof(IGenericColumns.Text1),
+                            PluginName = nameof(TextColumnMapper)
+                        }
+                    ]
+                },
             ],
             InstanceStrategies =
             [
@@ -867,14 +899,20 @@ public class ProductStorageTests
         // Act
         bool result;
         if (stillUsed)
+        {
             result = await productMgr.DeleteType(watch.WatchFace.Product.Id);
+        }
         else
+        {
             result = await productMgr.DeleteType(watch.Id);
+        }
 
         // Assert
         Assert.That(!result, Is.EqualTo(stillUsed));
         if (stillUsed)
+        {
             return;
+        }
 
         var matches = await productMgr.LoadTypes(new ProductQuery
         {
@@ -950,6 +988,169 @@ public class ProductStorageTests
         Assert.That(byType4.Count, Is.GreaterThanOrEqualTo(1));
         Assert.That(byType5.Count, Is.GreaterThanOrEqualTo(1));
         Assert.That(byType6.Count, Is.GreaterThanOrEqualTo(1));
+    }
+
+    [Test(Description = "Additional properties that exceed the configured generic columns must be stored in the JsonColumn and restored correctly.")]
+    public async Task SaveAndLoadGenericJsonType()
+    {
+        // Arrange
+        var product = new GenericJsonTestProductType
+        {
+            Name = "JsonTest",
+            Identity = new ProductIdentity("900001", 1),
+
+            Integer9 = 99,
+            Integer10 = 100,
+
+            Float9 = 9.9,
+            Float10 = 10.1f,
+
+            Text8 = "Text8Value",
+            Text9 = "Text9Value",
+            Text10 = "Text10Value"
+        };
+
+        // Act
+        var id = await _storage.SaveTypeAsync(product);
+        var loaded = (GenericJsonTestProductType)await _storage.LoadTypeAsync(id);
+
+        // Assert
+        Assert.That(loaded.Integer9, Is.EqualTo(product.Integer9));
+        Assert.That(loaded.Integer10, Is.EqualTo(product.Integer10));
+
+        Assert.That(loaded.Float9, Is.EqualTo(product.Float9));
+        Assert.That(loaded.Float10, Is.EqualTo(product.Float10));
+
+        Assert.That(loaded.Text8, Is.EqualTo(product.Text8));
+        Assert.That(loaded.Text9, Is.EqualTo(product.Text9));
+        Assert.That(loaded.Text10, Is.EqualTo(product.Text10));
+    }
+
+    [Test(Description = "Complex properties mapped through TextColumnMapper must be serialized and restored correctly.")]
+    public async Task SaveAndLoadComplexProperty()
+    {
+        // Arrange
+        var product = new TextColumnMapperTestProductType
+        {
+            Name = "ComplexDataTest",
+            Identity = new ProductIdentity("900002", 1),
+
+            Integer1 = 42,
+            Float1 = 123.456,
+            MyText1 = "RootText",
+
+            ComplexData1 = new ComplexData
+            {
+                Content = "Content1",
+                PropertyName = "Property1",
+                Number = 11,
+                Weight = 12.5f
+            },
+
+            ProdDataAdded = new TestProdData
+            {
+                TotalAmount = 12,
+                WorkerName = "Worker1"
+            }
+        };
+
+        // Act
+        var id = await _storage.SaveTypeAsync(product);
+        var loaded = (TextColumnMapperTestProductType)await _storage.LoadTypeAsync(id);
+
+        // Assert
+        Assert.That(loaded.ComplexData1, Is.Not.Null);
+        Assert.That(loaded.ComplexData1.Content, Is.EqualTo(product.ComplexData1.Content));
+        Assert.That(loaded.ComplexData1.PropertyName, Is.EqualTo(product.ComplexData1.PropertyName));
+        Assert.That(loaded.ComplexData1.Number, Is.EqualTo(product.ComplexData1.Number));
+        Assert.That(loaded.ComplexData1.Weight, Is.EqualTo(product.ComplexData1.Weight));
+    }
+
+    [Test(Description = "Loading products with null complex properties must not throw an ArgumentNullException.")]
+    public async Task SaveAndLoadTypeWithNullComplexProperty()
+    {
+        // Arrange
+        var product = new TextColumnMapperTestProductType
+        {
+            Name = "NullComplex",
+            Identity = new ProductIdentity("900003", 1),
+
+            ComplexData1 = null,
+            ProdDataAdded = null
+        };
+
+        var id = await _storage.SaveTypeAsync(product);
+
+        // Act
+        var loaded = (TextColumnMapperTestProductType)await _storage.LoadTypeAsync(id);
+
+        // Assert
+        Assert.That(loaded.ComplexData1, Is.Null);
+        Assert.That(loaded.ProdDataAdded, Is.Null);
+    }
+
+    /// <summary>
+    /// Should be obsolete in Moryx 12 because the double use of TEXT8-Column should be eliminated
+    /// </summary>
+    /// <returns></returns>
+    [Test(Description = "If Text8 column contains plain text no exception should be thrown")]
+    public async Task LoadTypeWithPlainTextInJsonColumn()
+    {
+        // Arrange
+        var product = new GenericJsonTestProductType
+        {
+            Name = "Legacy",
+            Identity = new ProductIdentity("900004", 1),
+
+            Text8 = "H"
+        };
+
+        var id = await _storage.SaveTypeAsync(product);
+
+        // Manipulation like older systems:
+        // Text8 just contains Plain Text
+
+        // Act / Assert
+        Assert.DoesNotThrowAsync(async () =>
+        {
+            await _storage.LoadTypeAsync(id);
+        });
+    }
+
+    /// <summary>
+    /// Should be obsolete in Moryx 12 because the double use of TEXT8-Column should be eliminated
+    /// </summary>
+    /// <returns></returns>
+    [Test(Description = "Loading a type with an empty JSON object in the JsonColumn must not fail. This reproduces the documented customer workaround using '{}'.")]
+    public async Task LoadTypeWithEmptyJsonObject()
+    {
+        // Arrange
+        var product = new TextColumnMapperTestProductType
+        {
+            Name = "EmptyJson",
+            Identity = new ProductIdentity("900004", 1)
+        };
+
+        var id = await _storage.SaveTypeAsync(product);
+
+        // simulate legacy database content
+        using (var uow = _factory.Create())
+        {
+            var repo = uow.GetRepository<IProductTypeRepository>();
+
+            var entity = repo.GetByKey(id);
+
+            entity.CurrentVersion.Text8 = "{}";
+
+            await uow.SaveChangesAsync();
+        }
+
+        // Act
+        var loaded = (TextColumnMapperTestProductType)
+            await _storage.LoadTypeAsync(id);
+
+        // Assert
+        Assert.That(loaded, Is.Not.Null);
     }
 
     [Test(Description = "LoadTypesAsync(ProductQuery) returns fully populated product types if full loading is requested.")]


### PR DESCRIPTION
## Summary

This MR fixes several issues in the generic product persistence layer.

### GenericEntityMapper
- reserve JsonColumn exclusively for JSON content
- prevent JsonColumn from being used as a regular mapped property
- store unmapped properties in the JSON fallback column
- write default/unset values as explicit null entries in JSON

### AutoConfigurator
- exclude JsonColumn from automatically generated property mappings
- exclude JsonColumn from selectable generic columns

### TextColumnMapper
- handle null and empty text values when deserializing complex JSON-backed properties
- prevent ArgumentNullException for newly introduced optional complex properties stored in text columns

~~### FloatColumnMapper~~
~~round floating point values before persistence~~
~~avoid floating-point representation artifacts in stored values~~

### Samples
- added dedicated sample product types for reproducing and validating JSON fallback and text-column JSON behavior

### Tests
- Save and load generic json type
- Save and load complex property
- Save and load type with complex property is null
- Load type with plain text in json column
- Load typ with empty json object

## Notes

The ShellNavigator / Microsoft.Build startup warning is already present on the base dev branch and is unrelated to the changes in this MR.