### PR TITLE
Add meaningful exception for invalid strategy configurations

### DIFF
--- a/src/Moryx.Products.Management/Implementation/Storage/StrategyBase.cs
+++ b/src/Moryx.Products.Management/Implementation/Storage/StrategyBase.cs
@@ -24,7 +24,17 @@ public class StrategyBase<TConfig, TConfigBase> : IAsyncConfiguredInitializable<
     /// </summary>
     public virtual Task InitializeAsync(TConfigBase config, CancellationToken cancellationToken = default)
     {
-        Config = (TConfig)config;
+        if (config is not TConfig typedConfig)
+        {
+            throw new InvalidOperationException(
+                $"Configuration mismatch for plugin '{config.PluginName}' " +
+                $"and target type '{config.TargetType}'. " +
+                $"Expected configuration type '{typeof(TConfig).Name}', " +
+                $"but received '{config.GetType().Name}'. " +
+                $"Please recreate the strategy configuration in the ControlCenter.");
+        }
+
+        Config = typedConfig;
         return Task.CompletedTask;
     }
 }

--- a/src/Tests/Moryx.Products.IntegrationTests/ProductStorageTests.cs
+++ b/src/Tests/Moryx.Products.IntegrationTests/ProductStorageTests.cs
@@ -22,6 +22,9 @@ using Moryx.Model.Repositories;
 using Moryx.Products.Management.Model;
 using Moryx.Serialization;
 using NUnit.Framework;
+// ReSharper disable PossibleNullReferenceException
+// ReSharper disable StringLiteralTypo
+// ReSharper disable CommentTypo
 
 namespace Moryx.Products.IntegrationTests;
 
@@ -66,178 +69,178 @@ public class ProductStorageTests
         _storage = new ProductStorage
         {
             Factory = _factory,
-            StrategyFactory = strategyFactory.Object
-        };
-        _storage.Config = new ModuleConfig
-        {
-            TypeStrategies =
-            [
-                new ProductTypeConfiguration
-                {
-                    TargetType = typeof(WatchType).FullName,
-                    PluginName = nameof(WatchStrategy)
-                },
+            StrategyFactory = strategyFactory.Object,
+            Config = new ModuleConfig
+            {
+                TypeStrategies =
+                [
+                    new ProductTypeConfiguration
+                    {
+                        TargetType = typeof(WatchType).FullName,
+                        PluginName = nameof(WatchStrategy)
+                    },
 
-                new GenericTypeConfiguration
-                {
-                    TargetType = typeof(WatchFaceType).FullName,
-                    PropertyConfigs =
-                    [
-                        new PropertyMapperConfig
-                        {
-                            PropertyName = nameof(WatchFaceType.Brand),
-                            Column = nameof(IGenericColumns.Text1),
-                            PluginName = nameof(TextColumnMapper)
-                        },
+                    new GenericTypeConfiguration
+                    {
+                        TargetType = typeof(WatchFaceType).FullName,
+                        PropertyConfigs =
+                        [
+                            new PropertyMapperConfig
+                            {
+                                PropertyName = nameof(WatchFaceType.Brand),
+                                Column = nameof(IGenericColumns.Text1),
+                                PluginName = nameof(TextColumnMapper)
+                            },
 
-                        new PropertyMapperConfig
-                        {
-                            PropertyName = nameof(WatchFaceType.IsDigital),
-                            Column = nameof(IGenericColumns.Integer1),
-                            PluginName = nameof(IntegerColumnMapper)
-                        },
+                            new PropertyMapperConfig
+                            {
+                                PropertyName = nameof(WatchFaceType.IsDigital),
+                                Column = nameof(IGenericColumns.Integer1),
+                                PluginName = nameof(IntegerColumnMapper)
+                            },
 
-                        new PropertyMapperConfig
-                        {
-                            PropertyName = nameof(WatchFaceType.Color),
-                            Column = string.Empty,
-                            PluginName = nameof(NullPropertyMapper)
-                        }
-                    ],
-                    JsonColumn = nameof(IGenericColumns.Text8)
-                },
+                            new PropertyMapperConfig
+                            {
+                                PropertyName = nameof(WatchFaceType.Color),
+                                Column = string.Empty,
+                                PluginName = nameof(NullPropertyMapper)
+                            }
+                        ],
+                        JsonColumn = nameof(IGenericColumns.Text8)
+                    },
 
-                new GenericTypeConfiguration
-                {
-                    TargetType = typeof(DisplayWatchFaceType).FullName,
-                    PropertyConfigs =
-                    [
-                        new PropertyMapperConfig
-                        {
-                            PropertyName = nameof(DisplayWatchFaceType.Resolution),
-                            Column = nameof(IGenericColumns.Integer1),
-                            PluginName = nameof(IntegerColumnMapper)
-                        }
-                    ],
-                    JsonColumn = nameof(IGenericColumns.Text8)
-                },
+                    new GenericTypeConfiguration
+                    {
+                        TargetType = typeof(DisplayWatchFaceType).FullName,
+                        PropertyConfigs =
+                        [
+                            new PropertyMapperConfig
+                            {
+                                PropertyName = nameof(DisplayWatchFaceType.Resolution),
+                                Column = nameof(IGenericColumns.Integer1),
+                                PluginName = nameof(IntegerColumnMapper)
+                            }
+                        ],
+                        JsonColumn = nameof(IGenericColumns.Text8)
+                    },
 
-                new GenericTypeConfiguration
-                {
-                    TargetType = typeof(NeedleType).FullName,
-                    PropertyConfigs = [],
-                    JsonColumn = nameof(IGenericColumns.Text8)
-                },
+                    new GenericTypeConfiguration
+                    {
+                        TargetType = typeof(NeedleType).FullName,
+                        PropertyConfigs = [],
+                        JsonColumn = nameof(IGenericColumns.Text8)
+                    },
 
-                new GenericTypeConfiguration
-                {
-                    TargetType = typeof(WatchPackageType).FullName,
-                    JsonColumn = nameof(IGenericColumns.Text8),
-                    PropertyConfigs = []
-                }
-            ],
-            InstanceStrategies =
-            [
-                new GenericInstanceConfiguration
-                {
-                    TargetType = typeof(WatchInstance).FullName,
-                    JsonColumn = nameof(IGenericColumns.Text8),
-                    PropertyConfigs =
-                    [
-                        new PropertyMapperConfig
-                        {
-                            PropertyName = nameof(WatchInstance.DeliveryDate),
-                            Column = nameof(IGenericColumns.Integer1),
-                            PluginName = nameof(IntegerColumnMapper)
-                        },
+                    new GenericTypeConfiguration
+                    {
+                        TargetType = typeof(WatchPackageType).FullName,
+                        JsonColumn = nameof(IGenericColumns.Text8),
+                        PropertyConfigs = []
+                    }
+                ],
+                InstanceStrategies =
+                [
+                    new GenericInstanceConfiguration
+                    {
+                        TargetType = typeof(WatchInstance).FullName,
+                        JsonColumn = nameof(IGenericColumns.Text8),
+                        PropertyConfigs =
+                        [
+                            new PropertyMapperConfig
+                            {
+                                PropertyName = nameof(WatchInstance.DeliveryDate),
+                                Column = nameof(IGenericColumns.Integer1),
+                                PluginName = nameof(IntegerColumnMapper)
+                            },
 
-                        new PropertyMapperConfig
-                        {
-                            PropertyName = nameof(WatchInstance.TimeSet),
-                            Column = nameof(IGenericColumns.Integer2),
-                            PluginName = nameof(IntegerColumnMapper)
-                        },
+                            new PropertyMapperConfig
+                            {
+                                PropertyName = nameof(WatchInstance.TimeSet),
+                                Column = nameof(IGenericColumns.Integer2),
+                                PluginName = nameof(IntegerColumnMapper)
+                            },
 
-                        new PropertyMapperConfig
-                        {
-                            PropertyName = nameof(WatchInstance.Identity),
-                            Column = nameof(IGenericColumns.Text1),
-                            PluginName = nameof(TextColumnMapper)
-                        }
-                    ]
-                },
+                            new PropertyMapperConfig
+                            {
+                                PropertyName = nameof(WatchInstance.Identity),
+                                Column = nameof(IGenericColumns.Text1),
+                                PluginName = nameof(TextColumnMapper)
+                            }
+                        ]
+                    },
 
-                new GenericInstanceConfiguration
-                {
-                    TargetType = typeof(WatchFaceInstance).FullName,
-                    PropertyConfigs =
-                    [
-                        new PropertyMapperConfig
-                        {
-                            PropertyName = nameof(WatchFaceInstance.Identifier),
-                            Column = nameof(IGenericColumns.Text1),
-                            PluginName = nameof(TextColumnMapper)
-                        },
+                    new GenericInstanceConfiguration
+                    {
+                        TargetType = typeof(WatchFaceInstance).FullName,
+                        PropertyConfigs =
+                        [
+                            new PropertyMapperConfig
+                            {
+                                PropertyName = nameof(WatchFaceInstance.Identifier),
+                                Column = nameof(IGenericColumns.Text1),
+                                PluginName = nameof(TextColumnMapper)
+                            },
 
-                        new PropertyMapperConfig
-                        {
-                            PropertyName = nameof(WatchFaceInstance.Identity),
-                            Column = nameof(IGenericColumns.Text2),
-                            PluginName = nameof(TextColumnMapper)
-                        }
-                    ],
-                    JsonColumn = nameof(IGenericColumns.Text8)
-                },
+                            new PropertyMapperConfig
+                            {
+                                PropertyName = nameof(WatchFaceInstance.Identity),
+                                Column = nameof(IGenericColumns.Text2),
+                                PluginName = nameof(TextColumnMapper)
+                            }
+                        ],
+                        JsonColumn = nameof(IGenericColumns.Text8)
+                    },
 
-                new ProductInstanceConfiguration()
-                {
-                    TargetType = typeof(NeedleInstance).FullName,
-                    PluginName = nameof(SkipInstancesStrategy)
-                }
+                    new ProductInstanceConfiguration()
+                    {
+                        TargetType = typeof(NeedleInstance).FullName,
+                        PluginName = nameof(SkipInstancesStrategy)
+                    }
 
-            ],
-            LinkStrategies =
-            [
-                new ProductLinkConfiguration()
-                {
-                    TargetType = typeof(WatchType).FullName,
-                    PartName = nameof(WatchType.WatchFace),
-                    PluginName = nameof(SimpleLinkStrategy)
-                },
+                ],
+                LinkStrategies =
+                [
+                    new ProductLinkConfiguration()
+                    {
+                        TargetType = typeof(WatchType).FullName,
+                        PartName = nameof(WatchType.WatchFace),
+                        PluginName = nameof(SimpleLinkStrategy)
+                    },
 
-                new GenericLinkConfiguration
-                {
-                    TargetType = typeof(WatchType).FullName,
-                    PartName = nameof(WatchType.Needles),
-                    JsonColumn = nameof(IGenericColumns.Text8),
-                    PropertyConfigs =
-                    [
-                        new PropertyMapperConfig
-                        {
-                            PropertyName = nameof(NeedlePartLink.Role),
-                            PluginName = nameof(IntegerColumnMapper),
-                            Column = nameof(IGenericColumns.Integer1)
-                        }
-                    ]
-                },
+                    new GenericLinkConfiguration
+                    {
+                        TargetType = typeof(WatchType).FullName,
+                        PartName = nameof(WatchType.Needles),
+                        JsonColumn = nameof(IGenericColumns.Text8),
+                        PropertyConfigs =
+                        [
+                            new PropertyMapperConfig
+                            {
+                                PropertyName = nameof(NeedlePartLink.Role),
+                                PluginName = nameof(IntegerColumnMapper),
+                                Column = nameof(IGenericColumns.Integer1)
+                            }
+                        ]
+                    },
 
-                new ProductLinkConfiguration()
-                {
-                    TargetType = typeof(WatchPackageType).FullName,
-                    PartName = nameof(WatchPackageType.PossibleWatches),
-                    PluginName = nameof(SimpleLinkStrategy)
-                }
+                    new ProductLinkConfiguration()
+                    {
+                        TargetType = typeof(WatchPackageType).FullName,
+                        PartName = nameof(WatchPackageType.PossibleWatches),
+                        PluginName = nameof(SimpleLinkStrategy)
+                    }
 
-            ],
-            RecipeStrategies =
-            [
-                new GenericRecipeConfiguration
-                {
-                    TargetType = typeof(WatchProductRecipe).FullName,
-                    JsonColumn = nameof(IGenericColumns.Text8),
-                    PropertyConfigs = []
-                }
-            ]
+                ],
+                RecipeStrategies =
+                [
+                    new GenericRecipeConfiguration
+                    {
+                        TargetType = typeof(WatchProductRecipe).FullName,
+                        JsonColumn = nameof(IGenericColumns.Text8),
+                        PropertyConfigs = []
+                    }
+                ]
+            }
         };
 
         await _storage.StartAsync();
@@ -951,5 +954,23 @@ public class ProductStorageTests
         Assert.That(byType4.Count, Is.GreaterThanOrEqualTo(1));
         Assert.That(byType5.Count, Is.GreaterThanOrEqualTo(1));
         Assert.That(byType6.Count, Is.GreaterThanOrEqualTo(1));
+    }
+
+    [Test]
+    public void Initialize_WithWrongConfigType_ThrowsMeaningfulException()
+    {
+        var strategy = new GenericInstanceStrategy();
+
+        var config = new ProductInstanceConfiguration
+        {
+            PluginName = nameof(GenericInstanceStrategy),
+            TargetType = "TestType"
+        };
+
+        var ex = Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await strategy.InitializeAsync(config));
+
+        Assert.That(ex.Message,
+            Does.Contain(nameof(GenericInstanceConfiguration)));
     }
 }


### PR DESCRIPTION
## Problem
Changing a strategy in the CommandCenter may leave an incompatible configuration type in the ModuleConfig.

Currently this results in an InvalidCastException during startup, which does not provide enough information to identify the root cause.

## Solution

Replace the InvalidCastException with a descriptive InvalidOperationException.

The new exception includes:
- plugin name
- target type
- expected configuration type
- actual configuration type
- guidance to recreate the configuration

## Validation

Added a test covering initialization with an incompatible configuration type.