### PR TITLE
Fix enable scrolling on Operators/management page

### DIFF
--- a/src/Moryx.Operators.Web/app/src/app/operators-management/operators-management.scss
+++ b/src/Moryx.Operators.Web/app/src/app/operators-management/operators-management.scss
@@ -14,6 +14,8 @@
 
 .management-container {
   position: relative;
+  display: flex;
+  flex-direction: column;
   width: 100%;
   height: 100%;
   background-color: var(--mat-sys-background);
@@ -26,6 +28,8 @@
 
 .main-content {
   width: 100%;
+  flex: 1;
+  min-height: 0;
   overflow-y: auto;
   padding: 8px;
   row-gap: 8px;


### PR DESCRIPTION
## Summary

This PR fixes the Operators/management page not being scrollable. The operator list was clipped and unreachable below the fold.

### `operators-management.scss`
- make `.management-container` a flex column instead of an unconstrained block container
- give `.main-content` a bounded height via `flex: 1; min-height: 0` so its existing `overflow-y: auto` can actually take effect
- toolbar now stays fixed while the operator list scrolls underneath, matching the pattern already used in `operator-details.scss`

## Root cause
The launcher shell wraps every module in `::slotted([slot="app"]) { height: 100%; overflow: hidden; }` (`Moryx.Launcher/app/src/app/app.scss`). Modules are expected to manage their own internal scroll region within that fixed height. `.management-container` wasn't a flex layout, so `.main-content` never had a bounded height.

## Test plan
- [x] Isolated HTML reproduction of old vs. new CSS side by side.
- [x] Manual check in the running app at `/Operators/management`.