### PR TITLE
Changed the Regex of Identifier in ProductIdentity

### DIFF
--- a/src/Moryx.AbstractionLayer/Products/Import/PrototypeImportParameters.cs
+++ b/src/Moryx.AbstractionLayer/Products/Import/PrototypeImportParameters.cs
@@ -16,10 +16,8 @@ public class PrototypeParameters
     /// </summary>
     [DefaultValue("2901234")]
     [Description("Identifier of the new product"), Required]
-    //[StringLength(7, MinimumLength = 7), RegularExpression(@"\d+")]
-    [StringLength(35)]
-    [RegularExpression(@"^\d{7,12}(-[A-Za-z0-9]{1,20})?$")]
-    public string Identifier { get; set; }
+    [StringLength(7, MinimumLength = 7), RegularExpression(@"\d+")]
+    public virtual string Identifier { get; set; }
 
     /// <summary>
     /// Revision of the new product

--- a/src/Moryx.AbstractionLayer/Products/Import/PrototypeImportParameters.cs
+++ b/src/Moryx.AbstractionLayer/Products/Import/PrototypeImportParameters.cs
@@ -16,7 +16,9 @@ public class PrototypeParameters
     /// </summary>
     [DefaultValue("2901234")]
     [Description("Identifier of the new product"), Required]
-    [StringLength(7, MinimumLength = 7), RegularExpression(@"\d+")]
+    //[StringLength(7, MinimumLength = 7), RegularExpression(@"\d+")]
+    [StringLength(35)]
+    [RegularExpression(@"^\d{7,12}(-[A-Za-z0-9]{1,20})?$")]
     public string Identifier { get; set; }
 
     /// <summary>

--- a/src/Moryx.AbstractionLayer/Products/ProductIdentity.cs
+++ b/src/Moryx.AbstractionLayer/Products/ProductIdentity.cs
@@ -40,11 +40,24 @@ public class ProductIdentity : IIdentity
     /// <returns></returns>
     public static ProductIdentity Parse(string identityString)
     {
-        Regex rx = new Regex(@"(?<identifier>\w+)-(?<revision>\d+)");
-        if (!rx.IsMatch(identityString))
-            throw new FormatException("identityString should consist of <identity>-<revision> instead of " + identityString);
-        var groups = rx.Match(identityString).Groups;
-        return new ProductIdentity(groups["identifier"].Value, Convert.ToInt16(groups["revision"].Value, CultureInfo.InvariantCulture));
+        var separator = identityString.LastIndexOf('-');
+
+        if (separator < 1 || separator == identityString.Length - 1)
+        {
+            throw new FormatException(
+                $"identityString should consist of <identity>-<revision> instead of {identityString}");
+        }
+
+        var identifier = identityString[..separator];
+        var revisionPart = identityString[(separator + 1)..];
+
+        if (!short.TryParse(revisionPart, out var revision))
+        {
+            throw new FormatException(
+                $"identityString should consist of <identity>-<revision> instead of {identityString}");
+        }
+
+        return new ProductIdentity(identifier, revision);
     }
 
     /// <summary>

--- a/src/Moryx.AbstractionLayer/Products/ProductIdentity.cs
+++ b/src/Moryx.AbstractionLayer/Products/ProductIdentity.cs
@@ -10,7 +10,7 @@ namespace Moryx.AbstractionLayer.Products;
 /// <summary>
 /// Identity for products consisting of identifier and revision
 /// </summary>
-public class ProductIdentity : IIdentity
+public partial class ProductIdentity : IIdentity
 {
     /// <summary>
     /// Const value representing the latest revision of a product. This is intended for later changes of this constant.
@@ -34,30 +34,25 @@ public class ProductIdentity : IIdentity
     public static ProductIdentity AsLatestRevision(string identifier) => new(identifier, LatestRevision);
 
     /// <summary>
+    /// Pattern for building the identifier and revision
+    /// </summary>
+    /// <returns></returns>
+    [GeneratedRegex(@"^(?<identifier>.+)-(?<revision>\d+)$")]
+    private static partial Regex IdentityPattern();
+
+    /// <summary>
     /// Create a product identity from a string. Counterpart to ToString() method
     /// </summary>
     /// <param name="identityString">the ProductIdentity as string</param>
     /// <returns></returns>
     public static ProductIdentity Parse(string identityString)
     {
-        var separator = identityString.LastIndexOf('-');
+        var match = IdentityPattern().Match(identityString);
+        if (!match.Success || !short.TryParse(match.Groups["revision"].Value,
+                NumberStyles.None, CultureInfo.InvariantCulture, out var revision))
+            throw new FormatException($"identityString should consist of <identity>-<revision> instead of {identityString}");
 
-        if (separator < 1 || separator == identityString.Length - 1)
-        {
-            throw new FormatException(
-                $"identityString should consist of <identity>-<revision> instead of {identityString}");
-        }
-
-        var identifier = identityString[..separator];
-        var revisionPart = identityString[(separator + 1)..];
-
-        if (!short.TryParse(revisionPart, out var revision))
-        {
-            throw new FormatException(
-                $"identityString should consist of <identity>-<revision> instead of {identityString}");
-        }
-
-        return new ProductIdentity(identifier, revision);
+        return new ProductIdentity(match.Groups["identifier"].Value, revision);
     }
 
     /// <summary>

--- a/src/Moryx.Products.Web/package-lock.json
+++ b/src/Moryx.Products.Web/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "Moryx.Products.Web",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/src/Moryx.Products.Web/package-lock.json
+++ b/src/Moryx.Products.Web/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "Moryx.Products.Web",
-  "lockfileVersion": 3,
-  "requires": true,
-  "packages": {}
-}

--- a/src/Tests/Moryx.Products.IntegrationTests/ProductStorageTests.cs
+++ b/src/Tests/Moryx.Products.IntegrationTests/ProductStorageTests.cs
@@ -952,4 +952,48 @@ public class ProductStorageTests
         Assert.That(byType5.Count, Is.GreaterThanOrEqualTo(1));
         Assert.That(byType6.Count, Is.GreaterThanOrEqualTo(1));
     }
+
+    [TestCase("ABC-01", "ABC", 1)]
+    [TestCase("ABC-DEF-01", "ABC-DEF", 1)]
+    [TestCase("123-456-12", "123-456", 12)]
+    [TestCase("12345678-ABCD-42", "12345678-ABCD", 42)]
+    [TestCase("My-Custom-Identifier-7", "My-Custom-Identifier", 7)]
+    public void Parse_CustomIdentifiers_ReturnsExpectedIdentity(
+        string identityString,
+        string expectedIdentifier,
+        short expectedRevision)
+    {
+        // Act
+        var result = ProductIdentity.Parse(identityString);
+
+        // Assert
+        Assert.That(result.Identifier, Is.EqualTo(expectedIdentifier));
+        Assert.That(result.Revision, Is.EqualTo(expectedRevision));
+    }
+
+    [TestCase("")]
+    [TestCase("ABC")]
+    [TestCase("-1")]
+    [TestCase("ABC-")]
+    [TestCase("ABC-DEF")]
+    [TestCase("ABC-XYZ")]
+    public void Parse_InvalidIdentity_ThrowsFormatException(string identityString)
+    {
+        Assert.Throws<FormatException>(
+            () => ProductIdentity.Parse(identityString));
+    }
+
+    [Test]
+    public void TryParse_CustomIdentifier_ReturnsTrue()
+    {
+        var result = ProductIdentity.TryParse(
+            "12345678-ABCD-42",
+            out var identity);
+
+        Assert.That(result, Is.True);
+        Assert.That(identity, Is.Not.Null);
+        Assert.That(identity.Identifier, Is.EqualTo("12345678-ABCD"));
+        Assert.That(identity.Revision, Is.EqualTo(42));
+    }
+
 }


### PR DESCRIPTION
For his project, Sascha needs the ability to specify an alphanumeric identifier for a customer-specific item after the 7-digit item/material number. This identifier should be separated from the item number by a hyphen.
The change now allows for 
- a numeric item/material number with a minimum of 7 digits and a maximum of 12 digits
- optionally followed by a hyphen and one to twenty alphanumeric characters, excluding punctuation or special characters
The revision of the product type remains unaffected by this change