### PR TITLE
Fixed notification header styling

### DIFF
--- a/src/Moryx.Notifications.Web/app/src/app/components/notification-details/notification-details.html
+++ b/src/Moryx.Notifications.Web/app/src/app/components/notification-details/notification-details.html
@@ -1,46 +1,29 @@
-@if (notification()) {
+@let currentNotification = notification();
+@if (currentNotification) {
   <div class="scaling">
     <mat-card class="notification-card">
-      <mat-card-header
-        class="notification-header"
-        [class]="'has-background-' + notification()?.severity"
-        >
+      <mat-card-header class="notification-header" [class]="'has-background-' + currentNotification.severity">
         <div mat-card-avatar class="notification-icon">
-          <mat-icon
-            [inline]="true"
-            role="complementary"
-            aria-label="Notification Severity Icon"
-            >
-            {{ getIcon(notification()!) }}
+          <mat-icon [inline]="true" role="complementary" aria-label="Notification Severity Icon">
+            {{ getIcon(currentNotification) }}
           </mat-icon>
         </div>
         <mat-card-title class="notification-title">
-          <markdown [data]="notification()?.title" [disableSanitizer]="true" />
+          <markdown [data]="currentNotification.title" [disableSanitizer]="true" [inline]="true" />
         </mat-card-title>
-        <mat-card-subtitle>{{
-          notification()?.created | date: "medium"
-        }}</mat-card-subtitle>
+        <mat-card-subtitle>{{ currentNotification.created | date: "medium" }}</mat-card-subtitle>
       </mat-card-header>
       <mat-card-content class="notification-content">
         <div class="content">
-          <markdown class="notification-message" [data]="notification()?.message" [disableSanitizer]="true" />
-          @if (notification()?.properties && isArrayNotEmpty(notification()?.properties?.subEntries)) {
-            <navigable-entry-editor
-              [entry]="notification()!.properties!"
-              [disabled]="true"
-              queryParam="properties"
-            ></navigable-entry-editor>
+          <markdown [data]="currentNotification.message" [disableSanitizer]="true" />
+          @if (currentNotification.properties && isArrayNotEmpty(currentNotification.properties.subEntries)) {
+            <navigable-entry-editor [entry]="currentNotification.properties" [disabled]="true" queryParam="properties" />
           }
         </div>
       </mat-card-content>
-      @if (notification()?.isAcknowledgable) {
+      @if (currentNotification.isAcknowledgable) {
         <mat-card-actions align="end">
-          <button
-            mat-button
-            color="primary"
-            type="button"
-            (click)="onAcknowledge(notification()!)"
-            >
+          <button mat-button color="primary" type="button" (click)="onAcknowledge(currentNotification)">
             {{ TranslationConstants.DETAILS.ACKNOWLEDGE | translate }}
           </button>
         </mat-card-actions>
@@ -48,10 +31,5 @@
     </mat-card>
   </div>
 } @else {
-  <img
-    src="{{ environment.assets + 'assets/moryx_transparent_colored.png' }}"
-    alt="Semi-transparent Moryx Banner"
-    width="80%"
-    />
+  <img src="{{ environment.assets + 'assets/moryx_transparent_colored.png' }}" alt="Semi-transparent Moryx Banner" width="80%" />
 }
-

--- a/src/Moryx.Notifications.Web/app/src/app/components/notification-details/notification-details.scss
+++ b/src/Moryx.Notifications.Web/app/src/app/components/notification-details/notification-details.scss
@@ -22,6 +22,7 @@
 }
 
 .notification-header {
+  align-items: center;
   border-top-left-radius: 4px;
   border-top-right-radius: 4px;
   color: var(--mat-sys-surface-container-lowest);
@@ -41,11 +42,6 @@
 .navigation-bar{
   margin: 0;
 }
-
-.notification-message{
-  font-size: 20px;
-  line-height: 1.4;
-} 
 
 .notification-title{
   font-size: 30px;


### PR DESCRIPTION
Using markdown in the header introduced a `<p>` in the header but there is an option to make it inline. Arranged icon to title and date. I also removed the custom font-size and line-height. I don't know why markdown is in the title but to keep the behavior ...

Before:

<img width="1375" height="551" alt="Screenshot 2026-08-04 at 13 58 50" src="https://github.com/user-attachments/assets/ddac228b-3942-44ea-a500-48bd6d31ef90" />


After:

<img width="1082" height="369" alt="Screenshot 2026-08-04 at 13 53 12" src="https://github.com/user-attachments/assets/6089e0d2-b003-47ee-ae78-7483ab0871c6" />


close #1386