### PR TITLE
Give the vertical-module-nav a bit more space

### DIFF
--- a/src/Moryx.Launcher/app/src/app/layouts/full-layout/full-layout.html
+++ b/src/Moryx.Launcher/app/src/app/layouts/full-layout/full-layout.html
@@ -25,7 +25,7 @@
   </mat-toolbar>
 
   <mat-sidenav-container autosize>
-    <mat-sidenav mode="side" opened style="width: fit-content">
+    <mat-sidenav mode="side" opened>
       <app-vertical-module-nav [collapsed]="navCollapsed()"></app-vertical-module-nav>
     </mat-sidenav>
 

--- a/src/Moryx.Launcher/app/src/app/layouts/full-layout/full-layout.scss
+++ b/src/Moryx.Launcher/app/src/app/layouts/full-layout/full-layout.scss
@@ -12,6 +12,7 @@
 }
 
 mat-sidenav {
+  width: fit-content;
   overflow: visible;
   border-right: 1px solid var(--mat-sys-outline-variant);
   filter: drop-shadow(1px 0 2px color-mix(in srgb, var(--mat-sys-shadow) 6%, transparent));

--- a/src/Moryx.Launcher/app/src/app/navigation/vertical-module-nav/vertical-module-nav.scss
+++ b/src/Moryx.Launcher/app/src/app/navigation/vertical-module-nav/vertical-module-nav.scss
@@ -2,7 +2,7 @@
 
 :host {
   display: block;
-  width: 180px;
+  width: 220px;
   height: 100%;
 }
 


### PR DESCRIPTION
A lot of our module names were cutted in different languages. Giving the vertical nav a bit more horizontal space solves it for all modules. Used 220px based on YouTube navigation.

Before: 

<img width="728" height="563" alt="Screenshot 2026-08-04 at 14 29 22" src="https://github.com/user-attachments/assets/5dd221a0-eaaa-4730-99eb-1f630a401b72" />


After: 

<img width="602" height="555" alt="Screenshot 2026-08-04 at 14 28 56" src="https://github.com/user-attachments/assets/32570035-4400-4b6e-8534-60c4ad25b72c" />
