### PR TITLE
Fixed resource reference list on long type-names

### DIFF
--- a/src/Moryx.Resources.Web/app/src/app/components/details-view/resource-references/resource-references.html
+++ b/src/Moryx.Resources.Web/app/src/app/components/details-view/resource-references/resource-references.html
@@ -25,7 +25,7 @@
           </div>
         </mat-expansion-panel-header>
         @if (selectedReferenceType()?.isCollection) {
-          <table mat-table #table [dataSource]="selectedReference()?.targets ?? []">
+          <table mat-table #table class="reference-table" [dataSource]="selectedReference()?.targets ?? []">
             <!-- ID Column -->
             <ng-container matColumnDef="id">
               <th mat-header-cell *matHeaderCellDef>
@@ -45,7 +45,7 @@
               <th mat-header-cell *matHeaderCellDef>
                 {{ TranslationConstants.SHARED.TYPE | translate }}
               </th>
-              <td mat-cell *matCellDef="let element">{{ element.type }}</td>
+              <td mat-cell *matCellDef="let element">{{ element.type | wordBreak }}</td>
             </ng-container>
             <!-- Delete Symbol Column -->
             <ng-container matColumnDef="delete">

--- a/src/Moryx.Resources.Web/app/src/app/components/details-view/resource-references/resource-references.scss
+++ b/src/Moryx.Resources.Web/app/src/app/components/details-view/resource-references/resource-references.scss
@@ -1,5 +1,13 @@
 @use '../expansion-panel';
 
+.reference-table {
+  width: 100%;
+}
+
+.mat-column-type {
+  overflow-wrap: break-word;
+}
+
 .mat-column-delete {
   width: 32px;
   text-align: center;

--- a/src/Moryx.Resources.Web/app/src/app/components/details-view/resource-references/resource-references.ts
+++ b/src/Moryx.Resources.Web/app/src/app/components/details-view/resource-references/resource-references.ts
@@ -18,6 +18,7 @@ import { MatExpansionModule } from '@angular/material/expansion';
 
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatButtonModule } from '@angular/material/button';
+import { WordBreakPipe } from '@app/pipes/word-break.pipe';
 
 
 @Component({
@@ -33,7 +34,8 @@ import { MatButtonModule } from '@angular/material/button';
     MatSelectModule,
     MatTableModule,
     TranslatePipe,
-    MatButtonModule
+    MatButtonModule,
+    WordBreakPipe,
 ]
 })
 export class ResourceReferences {

--- a/src/Moryx.Resources.Web/app/src/app/pipes/word-break.pipe.ts
+++ b/src/Moryx.Resources.Web/app/src/app/pipes/word-break.pipe.ts
@@ -1,0 +1,17 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+/**
+ * Inserts zero-width spaces after each occurrence of the separator (default: '.')
+ * to allow the browser to break long strings like type names at those positions.
+ */
+@Pipe({
+  name: 'wordBreak',
+})
+export class WordBreakPipe implements PipeTransform {
+  transform(value: string | undefined | null, separator = '.'): string {
+    if (!value) {
+      return '';
+    }
+    return value.replaceAll(separator, separator + '\u200B');
+  }
+}


### PR DESCRIPTION
Column cotent is now wrapped, introduced pipe for word-wrap on dots for type-names.


<img width="893" height="388" alt="Screenshot 2026-08-04 at 15 13 05" src="https://github.com/user-attachments/assets/21ffc6c3-6672-4aa7-b492-0cec787610e5" />


close #1385