### PR TITLE
Fixed restriction list styling and typography and improved dialog-context

### DIFF
--- a/src/Moryx.Orders.Web/app/src/app/components/dialog-context/dialog-context.html
+++ b/src/Moryx.Orders.Web/app/src/app/components/dialog-context/dialog-context.html
@@ -6,7 +6,8 @@
 
     @let orderValue = model.order + ' - ' + model.number;
 
-    <span class="info-value" [matTooltip]="orderValue" matTooltipPosition="below">
+    <span class="info-value" [class.expanded]="orderExpanded()" [matTooltip]="orderValue" matTooltipPosition="below"
+      (click)="toggleOrderExpansion()">
       {{ orderValue }}
     </span>
   </p>
@@ -16,7 +17,8 @@
     @let productValue = model.productIdentifier + '-' + (model.productRevision | number:'2.0') + ' ' +
       model.productName;
 
-    <span class="info-value" [matTooltip]="productValue" matTooltipPosition="below">
+    <span class="info-value" [class.expanded]="productExpanded()" [matTooltip]="productValue" matTooltipPosition="below"
+      (click)="toggleProductExpansion()">
       {{productValue}}
     </span>
   </p>

--- a/src/Moryx.Orders.Web/app/src/app/components/dialog-context/dialog-context.scss
+++ b/src/Moryx.Orders.Web/app/src/app/components/dialog-context/dialog-context.scss
@@ -35,4 +35,11 @@
   text-overflow: ellipsis;
   white-space: nowrap;
   flex: 1 1 auto;
+  cursor: pointer;
+
+  &.expanded {
+    white-space: normal;
+    word-break: break-word;
+    text-overflow: unset;
+  }
 }

--- a/src/Moryx.Orders.Web/app/src/app/components/dialog-context/dialog-context.ts
+++ b/src/Moryx.Orders.Web/app/src/app/components/dialog-context/dialog-context.ts
@@ -3,7 +3,7 @@
  * Licensed under the Apache License, Version 2.0
 */
 
-import { Component, ChangeDetectionStrategy, input } from "@angular/core";
+import { Component, ChangeDetectionStrategy, input, signal } from "@angular/core";
 import { TranslationConstants } from "@app/extensions/translation-constants.extensions";
 import { OperationModel } from "@app/api/models";
 import { TranslatePipe } from "@ngx-translate/core";
@@ -24,4 +24,14 @@ import { MatTooltip } from "@angular/material/tooltip";
 export class DialogContext {
   protected TranslationConstants = TranslationConstants;
   operationModel = input.required<OperationModel>();
+  orderExpanded = signal(false);
+  productExpanded = signal(false);
+
+  toggleOrderExpansion(): void {
+    this.orderExpanded.update(v => !v);
+  }
+
+  toggleProductExpansion(): void {
+    this.productExpanded.update(v => !v);
+  }
 }

--- a/src/Moryx.Orders.Web/app/src/app/dialogs/report-dialog/report-dialog.html
+++ b/src/Moryx.Orders.Web/app/src/app/dialogs/report-dialog/report-dialog.html
@@ -20,56 +20,62 @@
     </div>
   </div>
 
-  <div class="report-dialog-form-row">
-    <mat-form-field appearance="outline" class="interrupt-dialog-report-success-count">
-      <mat-label>{{ TranslationConstants.REPORT_DIALOG.SUCCESS | translate }}</mat-label>
-      <input matInput [(ngModel)]="success" [disabled]="isLoading()"/>
-      <mat-hint align="start">
-        {{ TranslationConstants.REPORT_DIALOG.REPORTED | translate }}: {{ reportContext()?.reportedSuccess }}
-      </mat-hint>
-      <mat-hint align="end">
-        {{ TranslationConstants.REPORT_DIALOG.ESTIMATED | translate }}: {{ estimatedSuccess() }}
-      </mat-hint>
+  @if (reportContext(); as context) {
+    <div class="report-dialog-form-row">
+      <mat-form-field appearance="outline" class="interrupt-dialog-report-success-count">
+        <mat-label>{{ TranslationConstants.REPORT_DIALOG.SUCCESS | translate }}</mat-label>
+        <input matInput [(ngModel)]="success" [disabled]="isLoading()"/>
+        <mat-hint align="start">
+          {{ TranslationConstants.REPORT_DIALOG.REPORTED | translate }}: {{ context.reportedSuccess }}
+        </mat-hint>
+        <mat-hint align="end">
+          {{ TranslationConstants.REPORT_DIALOG.ESTIMATED | translate }}: {{ estimatedSuccess() }}
+        </mat-hint>
+      </mat-form-field>
+      <mat-form-field appearance="outline" class="interrupt-dialog-report-failure-count">
+        <mat-label>{{ TranslationConstants.REPORT_DIALOG.SCRAP | translate }}</mat-label>
+        <input matInput [(ngModel)]="scrap" [disabled]="isLoading()"/>
+        <mat-hint align="start">
+          {{ TranslationConstants.REPORT_DIALOG.REPORTED | translate }}: {{ context.reportedFailure }}
+        </mat-hint>
+        <mat-hint align="end">
+          {{ TranslationConstants.REPORT_DIALOG.ESTIMATED | translate }}: {{ estimatedFailure() }}
+        </mat-hint>
+      </mat-form-field>
+    </div>
+
+    <mat-form-field appearance="outline" class="full-width top-spaced">
+      <mat-label>{{ TranslationConstants.REPORT_DIALOG.COMMENT | translate }}</mat-label>
+      <textarea matInput [(ngModel)]="comment" [disabled]="isLoading()"></textarea>
     </mat-form-field>
-    <mat-form-field appearance="outline" class="interrupt-dialog-report-failure-count">
-      <mat-label>{{ TranslationConstants.REPORT_DIALOG.SCRAP | translate }}</mat-label>
-      <input matInput [(ngModel)]="scrap" [disabled]="isLoading()"/>
-      <mat-hint align="start">
-        {{ TranslationConstants.REPORT_DIALOG.REPORTED | translate }}: {{ reportContext()?.reportedFailure }}
-      </mat-hint>
-      <mat-hint align="end">
-        {{ TranslationConstants.REPORT_DIALOG.ESTIMATED | translate }}: {{ estimatedFailure() }}
-      </mat-hint>
-    </mat-form-field>
-  </div>
 
-  <mat-form-field appearance="outline" class="full-width top-spaced">
-    <mat-label>{{ TranslationConstants.REPORT_DIALOG.COMMENT | translate }}</mat-label>
-    <textarea matInput [(ngModel)]="comment" [disabled]="isLoading()"></textarea>
-  </mat-form-field>
+    <app-operator-selector class="full-width top-spaced" [isEnabled]="canReport()"
+      [(selectedOperatorId)]="selectedOperatorId" (creatingOperatorFailed)="creatingOperatorFailed.set($event)"/>
 
-  <app-operator-selector class="full-width top-spaced" [isEnabled]="canReport()"
-    [(selectedOperatorId)]="selectedOperatorId" (creatingOperatorFailed)="creatingOperatorFailed.set($event)"/>
+    <h3 class="radio-group-header">{{ TranslationConstants.REPORT_DIALOG.CONFIRMATION | translate }}</h3>
+    <mat-radio-group class="radio-group" aria-label="Select an report option" [(ngModel)]="confirmationType">
+      <mat-radio-button [disabled]="!context.canPartial || isLoading()" value="partial">
+        {{ TranslationConstants.REPORT_DIALOG.PARTIAL | translate }}
+      </mat-radio-button>
+      <mat-radio-button [disabled]="!context.canFinal || isLoading()" value="final">
+        {{ TranslationConstants.REPORT_DIALOG.FINAL | translate }}
+      </mat-radio-button>
+    </mat-radio-group>
 
-  <h3 class="radio-group-header">{{ TranslationConstants.REPORT_DIALOG.CONFIRMATION | translate }}</h3>
-  <mat-radio-group class="radio-group" aria-label="Select an report option" [(ngModel)]="confirmationType">
-    <mat-radio-button [disabled]="!reportContext()?.canPartial || isLoading()" value="partial">
-      {{ TranslationConstants.REPORT_DIALOG.PARTIAL | translate }}
-    </mat-radio-button>
-    <mat-radio-button [disabled]="!reportContext()?.canFinal || isLoading()" value="final">
-      {{ TranslationConstants.REPORT_DIALOG.FINAL | translate }}
-    </mat-radio-button>
-  </mat-radio-group>
-
-  @for (restriction of reportContext()?.restrictions; track restriction) {
-    <mat-list>
-      <mat-list-item>
-        <mat-icon matListItemIcon>
-          {{ restriction.severity === 'Error' ? 'error' : restriction.severity === 'Warning' ? 'warning' : 'info' }}
-        </mat-icon>
-        <div matListItemTitle>{{ restriction.text }}</div>
-      </mat-list-item>
-    </mat-list>
+    @if (context.restrictions?.length) {
+      <mat-list class="restriction-list">
+        @for (restriction of context.restrictions; track restriction) {
+          <mat-list-item>
+            <mat-icon matListItemIcon>
+              {{ restriction.severity === 'Error' ? 'error' : restriction.severity === 'Warning' ? 'warning' : 'info' }}
+            </mat-icon>
+            <div matListItemTitle class="restriction-text">
+              {{ restriction.text }}
+            </div>
+          </mat-list-item>
+        }
+      </mat-list>
+    }
   }
 </mat-dialog-content>
 

--- a/src/Moryx.Orders.Web/app/src/app/dialogs/report-dialog/report-dialog.scss
+++ b/src/Moryx.Orders.Web/app/src/app/dialogs/report-dialog/report-dialog.scss
@@ -1,43 +1,53 @@
 @use '../dialog-styles.scss';
 
 .report-dialog-amounts-row {
-    display: flex;
-    width: 100%;
-    margin-bottom: 16px;
+  display: flex;
+  width: 100%;
+  margin-bottom: 16px;
 }
 
 .amounts-data-entry {
-    flex: 1;
-    font-size: 16px;
+  flex: 1;
+  font-size: 16px;
 }
 
 .radio-group-header {
-    margin-top: 8px;
-    margin-bottom: 8px;
+  margin-top: 8px;
+  margin-bottom: 8px;
 }
 
 .radio-group {
-    margin-bottom: 8px;
+  margin-bottom: 8px;
 }
 
 .mat-radio-button ~ .mat-radio-button {
-    margin-left: 16px;
+  margin-left: 16px;
 }
 
 .report-dialog-form-row {
-    display: flex;
+  display: flex;
 }
 
 .interrupt-dialog-report-success-count {
-    width: 100%;
-    margin-right: 4px;
+  width: 100%;
+  margin-right: 4px;
 }
 
 .interrupt-dialog-report-failure-count {
-    width: 100%;
-    margin-left: 4px;
+  width: 100%;
+  margin-left: 4px;
 }
 
 .interrupt-dialog-title {
-    margin-left: -5px;
+  margin-left: -5px;
+}
+
+.restriction-list mat-icon {
+  margin-left: 0;
+}
+
+.restriction-text {
+  white-space: normal;
+  word-break: break-word;
+  font-size: inherit;
 }


### PR DESCRIPTION
Fixed restriction list styling and typography

<img width="625" height="238" alt="Screenshot 2026-08-04 at 15 55 41" src="https://github.com/user-attachments/assets/6c104e4d-0cd4-4b93-b407-49c4c9cfa94c" />

Support click on dialog-context items to expand them (switch ellipses)

<img width="563" height="182" alt="Screenshot 2026-08-04 at 16 09 23" src="https://github.com/user-attachments/assets/65f160ad-0c69-4a6a-b7e4-2682a3a2808d" />

close #1387