### PR TITLE
Removed click and tooltip from dialog-context and wrap always

### DIFF
--- a/src/Moryx.Orders.Web/app/src/app/components/dialog-context/dialog-context.html
+++ b/src/Moryx.Orders.Web/app/src/app/components/dialog-context/dialog-context.html
@@ -3,23 +3,12 @@
 <div class="dialog-context">
   <p class="dialog-context-item">
     <span class="info-label">{{ TranslationConstants.DIALOG_CONTEXT.ORDER | translate }}</span>
-
-    @let orderValue = model.order + ' - ' + model.number;
-
-    <span class="info-value" [class.expanded]="orderExpanded()" [matTooltip]="orderValue" matTooltipPosition="below"
-      (click)="toggleOrderExpansion()">
-      {{ orderValue }}
-    </span>
+    <span class="info-value">{{ model.order + ' - ' + model.number }}</span>
   </p>
   <p class="dialog-context-item">
     <span class="info-label">{{ TranslationConstants.DIALOG_CONTEXT.PRODUCT | translate }}</span>
-
-    @let productValue = model.productIdentifier + '-' + (model.productRevision | number:'2.0') + ' ' +
-      model.productName;
-
-    <span class="info-value" [class.expanded]="productExpanded()" [matTooltip]="productValue" matTooltipPosition="below"
-      (click)="toggleProductExpansion()">
-      {{productValue}}
+    <span class="info-value">
+      {{ model.productIdentifier + '-' + (model.productRevision | number:'2.0') + ' ' + model.productName }}
     </span>
   </p>
 </div>

--- a/src/Moryx.Orders.Web/app/src/app/components/dialog-context/dialog-context.scss
+++ b/src/Moryx.Orders.Web/app/src/app/components/dialog-context/dialog-context.scss
@@ -7,7 +7,7 @@
 .dialog-context-item {
   margin: 0;
   display: flex;
-  align-items: center;
+  align-items: flex-start;
 
   padding: 10px 12px;
   background: var(--mat-sys-surface-container-low);
@@ -31,15 +31,6 @@
   font-size: 14px;
   font-weight: 500;
   color: var(--mat-sys-on-surface);
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  word-break: break-word;
   flex: 1 1 auto;
-  cursor: pointer;
-
-  &.expanded {
-    white-space: normal;
-    word-break: break-word;
-    text-overflow: unset;
-  }
 }

--- a/src/Moryx.Orders.Web/app/src/app/components/dialog-context/dialog-context.ts
+++ b/src/Moryx.Orders.Web/app/src/app/components/dialog-context/dialog-context.ts
@@ -3,12 +3,11 @@
  * Licensed under the Apache License, Version 2.0
 */
 
-import { Component, ChangeDetectionStrategy, input, signal } from "@angular/core";
+import { Component, ChangeDetectionStrategy, input } from "@angular/core";
 import { TranslationConstants } from "@app/extensions/translation-constants.extensions";
 import { OperationModel } from "@app/api/models";
 import { TranslatePipe } from "@ngx-translate/core";
-import { CommonModule } from "@angular/common";
-import { MatTooltip } from "@angular/material/tooltip";
+import { DecimalPipe } from "@angular/common";
 
 @Component({
   selector: "app-dialog-context",
@@ -17,21 +16,10 @@ import { MatTooltip } from "@angular/material/tooltip";
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
     TranslatePipe,
-    CommonModule,
-    MatTooltip
+    DecimalPipe
   ]
 })
 export class DialogContext {
   protected TranslationConstants = TranslationConstants;
   operationModel = input.required<OperationModel>();
-  orderExpanded = signal(false);
-  productExpanded = signal(false);
-
-  toggleOrderExpansion(): void {
-    this.orderExpanded.update(v => !v);
-  }
-
-  toggleProductExpansion(): void {
-    this.productExpanded.update(v => !v);
-  }
 }

--- a/src/Moryx.Orders.Web/app/src/app/dialogs/dialog-styles.scss
+++ b/src/Moryx.Orders.Web/app/src/app/dialogs/dialog-styles.scss
@@ -19,9 +19,7 @@
 }
 
 .dialog-container {
-    display: flex;
     width: 100%;
-    flex-direction: column;
 }
 
 .dialog-context {


### PR DESCRIPTION
 - Touch devices have no hover state, so tooltips are effectively inaccessible                                                                                                                                     
  - The dialog context is the primary identifying information; truncating it defeats its purpose                                                                                                                   
  - Word-wrap keeps the content always visible without requiring extra interaction   

Additionally I fixed an overflow issue introduced during refactorings.

Wrap always:

<img width="611" height="213" alt="Screenshot 2026-08-05 at 09 49 01" src="https://github.com/user-attachments/assets/cb29bda0-09f1-457c-8b3d-28acd87d785f" />

Fixed overflow issue: 

<img width="618" height="547" alt="Screenshot 2026-08-05 at 09 53 08" src="https://github.com/user-attachments/assets/57e72aa4-1c8e-444b-95bd-2ec7d777b4dc" />
