### PR TITLE
increase visual instruction result `button` on big screens

### DIFF
--- a/src/Moryx.VisualInstructions.Web/app/src/app/components/worker-instructions/worker-instructions.html
+++ b/src/Moryx.VisualInstructions.Web/app/src/app/components/worker-instructions/worker-instructions.html
@@ -54,7 +54,7 @@
         <div class="result-actions">
           @if(displayedInstruction()?.type === InstructionType.Execute){
             @for (result of displayedInstruction()?.results; track result) {
-              <button  mat-stroked-button
+              <button  mat-flat-button
                 type="button" (click)="onSelectResult(result)">
                 {{ result.displayValue }}
               </button>

--- a/src/Moryx.VisualInstructions.Web/app/src/app/components/worker-instructions/worker-instructions.scss
+++ b/src/Moryx.VisualInstructions.Web/app/src/app/components/worker-instructions/worker-instructions.scss
@@ -86,7 +86,7 @@
   margin-top: -16px;
 }
 
-.mat-mdc-outlined-button {
+.mat-mdc-unelevated-button {
   text-transform: uppercase;
   font-size: xx-large;
   height: 80px;
@@ -166,7 +166,7 @@
   @media (width >=2560px) {
     gap: 30px;
     margin-right: 10px;
-    .mat-mdc-outlined-button {
+    .mat-mdc-unelevated-button {
       min-height: 150px;
       margin-bottom: 80px;
     }

--- a/src/Moryx.VisualInstructions.Web/app/src/app/components/worker-instructions/worker-instructions.scss
+++ b/src/Moryx.VisualInstructions.Web/app/src/app/components/worker-instructions/worker-instructions.scss
@@ -161,4 +161,14 @@
   display: flex;
   align-items: flex-end;
   justify-content: end;
+
+  // only on very big screen (4k)  make the result button bigger
+  @media (width >=2560px) {
+    gap: 30px;
+    margin-right: 10px;
+    .mat-mdc-outlined-button {
+      min-height: 150px;
+      margin-bottom: 80px;
+    }
+  }
 }


### PR DESCRIPTION
Increase the size of result buttons in the Visual instruction view on big screens


<img width="1446" height="872" alt="increase button in visual instructuinbs" src="https://github.com/user-attachments/assets/afe4f1d1-3075-4af5-ab17-be65ef0ae585" />
