### PR TITLE
Fixed margins in order-dialogs

### DIFF
--- a/src/Moryx.Orders.Web/app/src/app/components/dialog-context/dialog-context.scss
+++ b/src/Moryx.Orders.Web/app/src/app/components/dialog-context/dialog-context.scss
@@ -1,3 +1,7 @@
+:host {
+  display: block;
+}
+
 .dialog-context {
   display: grid;
   grid-template-columns: 1fr;

--- a/src/Moryx.Orders.Web/app/src/app/components/operator-selector/operator-selector.html
+++ b/src/Moryx.Orders.Web/app/src/app/components/operator-selector/operator-selector.html
@@ -1,5 +1,5 @@
 @if (providesOperatorSelection()) {
-  <mat-form-field class="outer-field" appearance="outline">
+  <mat-form-field class="outer-field" appearance="outline" subscriptSizing="dynamic">
     <mat-label>
       {{ TranslationConstants.OPERATOR_SELECTOR.OPERATOR_SELECTOR_LABEL | translate }}
     </mat-label>

--- a/src/Moryx.Orders.Web/app/src/app/components/operator-selector/operator-selector.scss
+++ b/src/Moryx.Orders.Web/app/src/app/components/operator-selector/operator-selector.scss
@@ -1,5 +1,9 @@
 @use '@angular/material' as mat;
 
+:host {
+  display: block;
+}
+
 .outer-field {
-    width: 100%;
+  width: 100%;
 }

--- a/src/Moryx.Orders.Web/app/src/app/dialogs/begin-dialog/begin-dialog.html
+++ b/src/Moryx.Orders.Web/app/src/app/dialogs/begin-dialog/begin-dialog.html
@@ -32,69 +32,41 @@
 
   <app-dialog-context class="full-width dialog-context" [operationModel]="operation.model"></app-dialog-context>
 
-  <mat-grid-list cols="3" rowHeight="50px">
-    <mat-grid-tile>
-      <div class="content-data-entry">
-        <span><b>{{
-            TranslationConstants.BEGIN_DIALOG.TOTAL_AMOUNT | translate
-          }}</b></span>
-        <div>{{ operation.model.totalAmount }}</div>
+  <div class="data-grid">
+    <div class="content-data-entry">
+      <span><b>{{ TranslationConstants.BEGIN_DIALOG.TOTAL_AMOUNT | translate }}</b></span>
+      <div>{{ operation.model.totalAmount }}</div>
+    </div>
+    <div class="content-data-entry">
+      <span><b>{{ TranslationConstants.BEGIN_DIALOG.OVERDELIVERY | translate }}</b></span>
+      <div [style.color]="overDeliveryReached() ? 'var(--mat-sys-error)' : 'var(--mat-sys-on-surface)'">
+        {{ operation.model.overDeliveryAmount }} ({{ operation.overDelivery }} %)
       </div>
-    </mat-grid-tile>
-    <mat-grid-tile>
-      <div class="content-data-entry">
-        <span><b>{{
-            TranslationConstants.BEGIN_DIALOG.OVERDELIVERY | translate
-          }}</b></span>
-        <div [style.color]="overDeliveryReached() ? 'var(--mat-sys-error)' : 'var(--mat-sys-on-surface)'">
-          {{ operation.model.overDeliveryAmount }} ({{ operation.overDelivery }}
-          %)
-        </div>
+    </div>
+    <div class="content-data-entry">
+      <span><b>{{ TranslationConstants.BEGIN_DIALOG.UNDERDELIVERY | translate }}</b></span>
+      <div [style.color]="underDeliveryReached() ? 'var(--mat-sys-error)' : 'var(--mat-sys-on-surface)'">
+        {{ operation.model.underDeliveryAmount }} ({{ operation.underDelivery }} %)
       </div>
-    </mat-grid-tile>
-    <mat-grid-tile>
-      <div class="content-data-entry">
-        <span><b>{{
-            TranslationConstants.BEGIN_DIALOG.UNDERDELIVERY | translate
-          }}</b></span>
-        <div [style.color]="underDeliveryReached() ? 'var(--mat-sys-error)' : 'var(--mat-sys-on-surface)'">
-          {{ operation.model.underDeliveryAmount }} ({{
-            operation.underDelivery
-          }}
-          %)
-        </div>
-      </div>
-    </mat-grid-tile>
-    <mat-grid-tile>
-      <div class="content-data-entry">
-        <span><b>{{
-            TranslationConstants.BEGIN_DIALOG.ESTIMATED | translate
-          }}</b></span>
-        <div>{{ currentPartialAmount }}</div>
-      </div>
-    </mat-grid-tile>
-    <mat-grid-tile>
-      <div class="content-data-entry">
-        <span><b>{{
-            TranslationConstants.BEGIN_DIALOG.SUCCESS | translate
-          }}</b></span>
-        <div>{{ successCount }}</div>
-      </div>
-    </mat-grid-tile>
-    <mat-grid-tile>
-      <div class="content-data-entry">
-        <span><b>{{
-            TranslationConstants.BEGIN_DIALOG.SCRAP | translate
-          }}</b></span>
-        <div>{{ scrapCount }}</div>
-      </div>
-    </mat-grid-tile>
-    <mat-grid-tile colspan="3">
+    </div>
+    <div class="content-data-entry">
+      <span><b>{{ TranslationConstants.BEGIN_DIALOG.ESTIMATED | translate }}</b></span>
+      <div>{{ currentPartialAmount }}</div>
+    </div>
+    <div class="content-data-entry">
+      <span><b>{{ TranslationConstants.BEGIN_DIALOG.SUCCESS | translate }}</b></span>
+      <div>{{ successCount }}</div>
+    </div>
+    <div class="content-data-entry">
+      <span><b>{{ TranslationConstants.BEGIN_DIALOG.SCRAP | translate }}</b></span>
+      <div>{{ scrapCount }}</div>
+    </div>
+    <div class="progress-bar-entry">
       <app-multi-progress-bar [totalAmount]="estimatedTotal()" [successCount]="successCount" [scrapCount]="scrapCount"
                               [activeCount]="partialCount()" [activeLabel]="TranslationConstants.OPERATIONS.PARTIAL"
                               variant="forecast"/>
-    </mat-grid-tile>
-  </mat-grid-list>
+    </div>
+  </div>
   <mat-form-field appearance="outline">
     <mat-label>{{
         TranslationConstants.BEGIN_DIALOG.PARTIAL_AMOUNT | translate
@@ -129,7 +101,8 @@
   </mat-form-field>
 
   <app-operator-selector class="full-width top-spaced" [isEnabled]="canBegin"
-    [(selectedOperatorId)]="selectedOperatorId" (creatingOperatorFailed)="creatingOperatorFailed.set($event)"/>
+                         [(selectedOperatorId)]="selectedOperatorId"
+                         (creatingOperatorFailed)="creatingOperatorFailed.set($event)"/>
 </mat-dialog-content>
 
 <div mat-dialog-actions align="end">

--- a/src/Moryx.Orders.Web/app/src/app/dialogs/begin-dialog/begin-dialog.scss
+++ b/src/Moryx.Orders.Web/app/src/app/dialogs/begin-dialog/begin-dialog.scss
@@ -1,57 +1,73 @@
 @use "../dialog-styles.scss";
 
+.data-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 4px 0;
+  margin-top: 8px;
+}
+
 .content-data-entry {
-    position: absolute;
-    left: 0px;
-    font-size: 16px;
+  font-size: 16px;
+}
+
+.progress-bar-entry {
+  grid-column: 1 / -1;
+  display: flex;
+  align-items: center;
+  padding: 8px 0;
+  margin-bottom: 8px;
 }
 
 .content-calculation-button {
-   margin: 1px 4px;
+  margin: 1px 4px;
 }
 
 .restrictions {
-    margin-bottom: 12px;
-    display: flex;
-    flex-direction: column;
-    gap: 4px;
-    width: 100%;
+  margin-bottom: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  width: 100%;
 }
 
 mat-form-field {
-    width: 100%;
+  width: 100%;
 }
 
 .min-amount-button {
-    border-radius: 100%;
+  border-radius: 100%;
 }
+
 ::ng-deep .mat-mdc-form-field-infix {
-    width: 128px !important;
+  width: 128px !important;
 }
+
 ::ng-deep .mat-mdc-form-field-icon-prefix {
-    padding: 4px !important;
-    .mdc-button {
-        padding: 4px;
-    }
+  padding: 4px !important;
+
+  .mdc-button {
+    padding: 4px;
+  }
 }
 
 mat-card {
-    width: 100%;
+  width: 100%;
 }
 
 .error-restriction {
-    background-color: var(--mat-sys-error);
-    color: var(--mat-sys-on-error);
+  background-color: var(--mat-sys-error);
+  color: var(--mat-sys-on-error);
 }
 
 .warning-restriction {
-    background-color: var(--mat-sys-tertiary);
-    color: var(--mat-sys-on-tertiary);
+  background-color: var(--mat-sys-tertiary);
+  color: var(--mat-sys-on-tertiary);
 }
 
 .info-restriction {
-    background-color: var(--mat-sys-primary);
-    color: var(--mat-sys-on-primary);
+  background-color: var(--mat-sys-primary);
+  color: var(--mat-sys-on-primary);
 }
 
 /* Hide the spinner for number inputs in all browsers */

--- a/src/Moryx.Orders.Web/app/src/app/dialogs/begin-dialog/begin-dialog.ts
+++ b/src/Moryx.Orders.Web/app/src/app/dialogs/begin-dialog/begin-dialog.ts
@@ -19,7 +19,6 @@ import { OperatorsService } from '@app/services/operators.service';
 import { CommonModule } from '@angular/common';
 import { MatCardModule } from '@angular/material/card';
 import { MatListModule } from '@angular/material/list';
-import { MatGridListModule } from '@angular/material/grid-list';
 import { MatInputModule } from '@angular/material/input';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatButtonModule } from '@angular/material/button';
@@ -39,7 +38,6 @@ import { DialogContext } from "@app/components/dialog-context/dialog-context";
     MatDialogModule,
     CommonModule,
     TranslatePipe,
-    MatGridListModule,
     MatFormFieldModule,
     ReactiveFormsModule,
     FormsModule,

--- a/src/Moryx.Orders.Web/app/src/app/dialogs/create-dialog/create-dialog.html
+++ b/src/Moryx.Orders.Web/app/src/app/dialogs/create-dialog/create-dialog.html
@@ -3,7 +3,7 @@
 </h2>
 <mat-dialog-content>
   <h3>{{ TranslationConstants.CREATE_DIALOG.ORDER_DETAILS | translate }}</h3>
-  <mat-form-field appearance="outline" class="full-width">
+  <mat-form-field appearance="outline" class="full-width" subscriptSizing="dynamic">
     <mat-label>{{
       TranslationConstants.CREATE_DIALOG.ORDER_NUMBER | translate
     }}</mat-label>
@@ -19,7 +19,7 @@
     {{ TranslationConstants.CREATE_DIALOG.OPERATION_DETAILS | translate }}
   </h3>
   <!-- Operation Number -->
-  <mat-form-field appearance="outline" class="full-width">
+  <mat-form-field appearance="outline" class="full-width" subscriptSizing="dynamic">
     <mat-label>{{
       TranslationConstants.CREATE_DIALOG.OPERATION_NUMBER | translate
     }}</mat-label>
@@ -41,25 +41,25 @@
       </mat-error>
     }
   </mat-form-field>
-  
+
   <!-- Product Selection -->
-  <mat-form-field appearance="outline" class="full-width top-spaced">
+  <mat-form-field appearance="outline" class="full-width top-spaced" subscriptSizing="dynamic">
     <mat-label>{{ TranslationConstants.CREATE_DIALOG.PRODUCT | translate }}</mat-label>
-    <input 
+    <input
       #productInput
-      type="text" 
-      matInput 
-      [formControl]="productFormControl" 
+      type="text"
+      matInput
+      [formControl]="productFormControl"
       [matAutocomplete]="productAutoComplete"
       (input)="filterProduct()"
       (focus)="filterProduct()"
       (focusout)="filterProduct()">
     @if (selectedProduct()) {
-      <button 
-        matSuffix 
-        matIconButton 
-        aria-label="Clear" 
-        class="suffix-icon" 
+      <button
+        matSuffix
+        matIconButton
+        aria-label="Clear"
+        class="suffix-icon"
         (click)="selectedProduct.set(undefined)">
         <mat-icon>close</mat-icon>
       </button>
@@ -75,23 +75,23 @@
   </mat-form-field>
 
   <!-- Recipe Selection -->
-  <mat-form-field appearance="outline" class="full-width top-spaced">
+  <mat-form-field appearance="outline" class="full-width top-spaced" subscriptSizing="dynamic">
     <mat-label>{{ TranslationConstants.CREATE_DIALOG.RECIPE | translate }}</mat-label>
-    <input 
+    <input
       #recipeInput
-      type="text" 
-      matInput 
-      [formControl]="recipeFormControl" 
+      type="text"
+      matInput
+      [formControl]="recipeFormControl"
       [matAutocomplete]="recipeAutoComplete"
       (input)="filterRecipe()"
       (focus)="filterRecipe()"
       (focusout)="filterRecipe()">
     @if (selectedRecipe()) {
-      <button 
-        matSuffix 
+      <button
+        matSuffix
         matIconButton
-        aria-label="Clear" 
-        class="suffix-icon" 
+        aria-label="Clear"
+        class="suffix-icon"
         (click)="selectedRecipe.set(undefined)">
         <mat-icon>close</mat-icon>
       </button>
@@ -103,14 +103,14 @@
     </mat-autocomplete>
   </mat-form-field>
 
-  <mat-form-field appearance="outline" class="full-width top-spaced">
+  <mat-form-field appearance="outline" class="full-width top-spaced" subscriptSizing="dynamic">
     <mat-label>{{ TranslationConstants.CREATE_DIALOG.AMOUNT | translate }}</mat-label>
     <input type="number" matInput [(ngModel)]="amount" [disabled]="isLoading()"/>
   </mat-form-field>
 
   @if(operations().length > 0) {
     <h3 class="top-spaced">
-      {{ TranslationConstants.CREATE_DIALOG.ADDED_OPERATIONS | translate }} 
+      {{ TranslationConstants.CREATE_DIALOG.ADDED_OPERATIONS | translate }}
       ({{ operations().length }})
     </h3>
     <mat-list class="create-dialog-operation-list-container">

--- a/src/Moryx.Orders.Web/app/src/app/dialogs/dialog-styles.scss
+++ b/src/Moryx.Orders.Web/app/src/app/dialogs/dialog-styles.scss
@@ -3,7 +3,7 @@
 }
 
 .top-spaced {
-  margin-top: 8px;
+  margin-top: 12px;
 }
 
 .suffix-icon {
@@ -19,11 +19,11 @@
 }
 
 .dialog-container {
-    width: 100%;
+  width: 100%;
 }
 
 .dialog-context {
-    margin-bottom: 16px;
+  margin-bottom: 8px;
 }
 
 

--- a/src/Moryx.Orders.Web/app/src/app/dialogs/report-dialog/report-dialog.html
+++ b/src/Moryx.Orders.Web/app/src/app/dialogs/report-dialog/report-dialog.html
@@ -44,7 +44,7 @@
       </mat-form-field>
     </div>
 
-    <mat-form-field appearance="outline" class="full-width top-spaced">
+    <mat-form-field appearance="outline" class="full-width top-spaced" subscriptSizing="dynamic">
       <mat-label>{{ TranslationConstants.REPORT_DIALOG.COMMENT | translate }}</mat-label>
       <textarea matInput [(ngModel)]="comment" [disabled]="isLoading()"></textarea>
     </mat-form-field>

--- a/src/Moryx.Orders.Web/app/src/app/dialogs/report-dialog/report-dialog.scss
+++ b/src/Moryx.Orders.Web/app/src/app/dialogs/report-dialog/report-dialog.scss
@@ -3,6 +3,7 @@
 .report-dialog-amounts-row {
   display: flex;
   width: 100%;
+  margin-top: 8px;
   margin-bottom: 16px;
 }
 
@@ -17,11 +18,11 @@
 }
 
 .radio-group {
-  margin-bottom: 8px;
+  display: block;
 }
 
-.mat-radio-button ~ .mat-radio-button {
-  margin-left: 16px;
+mat-radio-button ~ mat-radio-button {
+  margin-left: 8px;
 }
 
 .report-dialog-form-row {


### PR DESCRIPTION
- changed subscriptSizing="dynamic" in form fields to behave like the entry editor
- changed spacing to 12 to match entry-editor. The entry editor uses 8px like shown here https://github.com/PHOENIXCONTACT/MORYX-Framework/pull/1360#issuecomment-5066201201 but this is only the half of the truth - each form field additionally takes 2px margin which are 10px then. Material design guideline says it should be a multiple of 4 - remove the margin of 2 and use 12 for from field lists should be done in a separate PR
- Fixed showing scrollbar when there is no restriction
- Fixed margin between radio-elements in report dialog

<img width="601" height="568" alt="Screenshot 2026-08-07 at 12 30 56" src="https://github.com/user-attachments/assets/85a59655-75b0-459a-a4f0-b9534d5e3bab" />

<img width="588" height="595" alt="Screenshot 2026-08-07 at 12 31 30" src="https://github.com/user-attachments/assets/4c9142da-20b0-4358-add7-540ab7f21e89" />

<img width="582" height="519" alt="Screenshot 2026-08-07 at 12 05 44" src="https://github.com/user-attachments/assets/566781e6-5cee-46b7-b621-503a48ab721b" />

<img width="583" height="691" alt="Screenshot 2026-08-07 at 12 32 01" src="https://github.com/user-attachments/assets/694e3b61-b2df-4041-b551-41417480de41" />


