### PR TITLE
Fix dark-mode issues in visual instructions and notifications

### DIFF
--- a/src/Moryx.Launcher/app/src/app/notifications-bar/notifications-bar.scss
+++ b/src/Moryx.Launcher/app/src/app/notifications-bar/notifications-bar.scss
@@ -8,7 +8,7 @@
   --color-Fatal: #{$fatal};
 
   --severity-background-color: var(--color-Success);
-  --severity-foreground-color: var(--mat-sys-on-error);
+  --severity-foreground-color: white;
 }
 
 .outerborder {

--- a/src/Moryx.Notifications.Web/app/src/app/components/notification-details/notification-details.scss
+++ b/src/Moryx.Notifications.Web/app/src/app/components/notification-details/notification-details.scss
@@ -25,7 +25,7 @@
   align-items: center;
   border-top-left-radius: 4px;
   border-top-right-radius: 4px;
-  color: var(--mat-sys-surface-container-lowest);
+  color: white;
 }
 
 .notification-content {
@@ -49,4 +49,5 @@
 
 .mat-mdc-card-subtitle{
   margin-bottom: 10px;
+  color: white;
 }

--- a/src/Moryx.VisualInstructions.Web/app/src/app/components/worker-instructions/worker-instructions.scss
+++ b/src/Moryx.VisualInstructions.Web/app/src/app/components/worker-instructions/worker-instructions.scss
@@ -49,7 +49,7 @@
 .card-content {
   font: 200 45px/36px Roboto, sans-serif !important;
   margin-bottom: 20px !important;
-  color: #0000008a;
+  color: var(--mat-sys-on-surface);
   line-height: 50px !important;
 }
 


### PR DESCRIPTION
### **Fixed visual instructions text-issues described in #1296**

Removed hardcoded color value

<img width="1439" height="486" alt="Screenshot 2026-08-10 at 13 06 08" src="https://github.com/user-attachments/assets/83d89e2e-2a90-48e3-8ee5-b10c46f3c689" />
<img width="1429" height="522" alt="Screenshot 2026-08-10 at 13 06 18" src="https://github.com/user-attachments/assets/7ed3bb77-e1a7-4981-b9ec-52613f75a133" />


### **Fixed notifications color issues**

Using variable in notification bar was causing the text to be light red in dark-mode. Hardcoded to white until there is maybe a dark mode style for notifications (From my point of view unnecessary at the moment because it looks great).

<img width="1220" height="664" alt="Screenshot 2026-08-10 at 13 05 54" src="https://github.com/user-attachments/assets/fe2995d0-9f79-4106-a74c-8b6af45e234c" />
<img width="1153" height="645" alt="Screenshot 2026-08-10 at 13 05 45" src="https://github.com/user-attachments/assets/11cb314f-3c53-44aa-b7d6-97d68eb5e449" />


