### PR TITLE
Add an `IActivity.Abort` method allowing activities to define their abort results

### DIFF
--- a/src/Moryx.AbstractionLayer/Activities/Activity.cs
+++ b/src/Moryx.AbstractionLayer/Activities/Activity.cs
@@ -65,6 +65,12 @@ public abstract class Activity : IActivity
     }
 
     /// <inheritdoc />
+    public ActivityResult Abort()
+    {
+        return Result = CreateAbortionResult();
+    }
+
+    /// <inheritdoc />
     public ActivityResult Complete(long resultNumber)
     {
         return Result = CreateResult(resultNumber);
@@ -80,6 +86,11 @@ public abstract class Activity : IActivity
     /// Create a typed result object for this result number
     /// </summary>
     protected abstract ActivityResult CreateResult(long resultNumber);
+
+    /// <summary>
+    /// Create a typed result object when aborting the activity; The default behaviour sets a technical failure result.
+    /// </summary>
+    protected virtual ActivityResult CreateAbortionResult() => CreateFailureResult();
 
     /// <summary>
     /// Create a typed result object for a technical failure.

--- a/src/Moryx.AbstractionLayer/Activities/IActivity.cs
+++ b/src/Moryx.AbstractionLayer/Activities/IActivity.cs
@@ -52,6 +52,11 @@ public interface IActivity : IDisposable
     ActivityResult Result { get; }
 
     /// <summary>
+    /// Create and sets a typed result object when aborting.
+    /// </summary>
+    ActivityResult Abort();
+
+    /// <summary>
     /// Creates and sets a typed result object for this result number
     /// </summary>
     ActivityResult Complete(long resultNumber);


### PR DESCRIPTION
Currently an activity only supports to `Complete` with a given result number (for which you need to know the possible results of the activity type and hence the activity type) and to `Fail`. While the fact that `ICell.ProcessAborting` exists is a detail of a different namespace and should not lead implementation directly, this function would allow for more generic and activity independent cell implementations. And since aborting an activity and having activity specific result creation has semantic meaning, this extension is proposed.

Example:
```csharp
void ICell.ProcessAborting(Activity affectedActivity)
{
    var result = affectedActivity.Abort();
    PublishActivityCompleted(_currentActivityStart.CreateResult());
}
```