### PR TITLE
Expand to selected tree-node and restore tree state on reload

### DIFF
--- a/src/Moryx.Products.Web/app/src/app/components/product-tree/product-tree.ts
+++ b/src/Moryx.Products.Web/app/src/app/components/product-tree/product-tree.ts
@@ -3,7 +3,7 @@
  * Licensed under the Apache License, Version 2.0
 */
 
-import { Component, inject, viewChild, input, output, effect, ChangeDetectionStrategy } from '@angular/core';
+import { Component, inject, viewChild, input, output, effect, untracked, ChangeDetectionStrategy } from '@angular/core';
 import { MatTree, MatTreeModule } from '@angular/material/tree';
 import { MatIconModule } from '@angular/material/icon';
 import { ProductModel } from '@api/models';
@@ -22,6 +22,7 @@ import { MatIconButton } from '@angular/material/button';
 export class ProductTree {
   private sessionService = inject(SessionService);
   private editProductsService = inject(EditProductsService);
+  private expandedNames = new Set<string>();
 
   // Inputs
   readonly treeData = input.required<ProductNode[]>();
@@ -38,15 +39,34 @@ export class ProductTree {
   protected hasChild = (_: number, node: ProductNode) => !!node.children?.length;
 
   constructor() {
-    // Re-expand saved nodes whenever treeData or tree instance changes
+    // Restore expanded tree state from session when tree data is loaded
     effect(() => {
       const data = this.treeData();
       const tree = this.tree();
       if (!tree) {
         return;
       }
-      const names = this.sessionService.getExpandedNodeNames();
-      this.expandSavedNodes(data, names);
+
+      untracked(() => {
+        for (const name of this.sessionService.getExpandedNodeNames()) {
+          this.expandedNames.add(name);
+        }
+        this.expandToSelected();
+        this.applyExpandedState(data);
+        this.storeState();
+      });
+    });
+
+    // Expand parent nodes to make the selected product visible in the tree
+    effect(() => {
+      const selectedId = this.selected()?.id;
+      if (selectedId) {
+        untracked(() => {
+          this.expandToSelected();
+          this.applyExpandedState(this.treeData());
+          this.storeState();
+        });
+      }
     });
   }
 
@@ -59,20 +79,56 @@ export class ProductTree {
   }
 
   protected onExpandOrCollapseNode(node: ProductNode) {
-    this.sessionService.saveProductTreeExpansion(node, this.tree()!.isExpanded(node));
+    if (this.expandedNames.has(node.name)) {
+      this.expandedNames.delete(node.name);
+    } else {
+      this.expandedNames.add(node.name);
+    }
+    this.storeState();
   }
 
   protected createProductIdentity(identifier: string | undefined | null, revision: number | undefined): string {
     return this.editProductsService.createProductIdentity(identifier, revision);
   }
 
-  private expandSavedNodes(nodes: ProductNode[], expandedNames: string[]) {
+  private storeState() {
+    this.sessionService.storeProductTreeExpansion([...this.expandedNames]);
+  }
+
+  private expandToSelected() {
+    const data = this.treeData();
+    const selectedId = this.selected()?.id;
+    if (!data.length || !selectedId) {
+      return;
+    }
+    for (const name of this.getAncestorNames(selectedId, data)) {
+      this.expandedNames.add(name);
+    }
+  }
+
+  private getAncestorNames(targetId: number, nodes: ProductNode[]): string[] {
     for (const node of nodes) {
-      if (expandedNames.includes(node.name)) {
+      if (node.id === targetId) {
+        return [];
+      }
+      if (node.children) {
+        const path = this.getAncestorNames(targetId, node.children);
+        if (path !== undefined) {
+          path.push(node.name);
+          return path;
+        }
+      }
+    }
+    return undefined!;
+  }
+
+  private applyExpandedState(nodes: ProductNode[]) {
+    for (const node of nodes) {
+      if (this.expandedNames.has(node.name)) {
         this.tree()!.expand(node);
       }
       if (node.children) {
-        this.expandSavedNodes(node.children, expandedNames);
+        this.applyExpandedState(node.children);
       }
     }
   }

--- a/src/Moryx.Products.Web/app/src/app/services/session.service.ts
+++ b/src/Moryx.Products.Web/app/src/app/services/session.service.ts
@@ -5,7 +5,6 @@
 
 import { Injectable } from '@angular/core';
 import { ProductModel } from '../api/models';
-import { ProductNode } from '../app';
 
 @Injectable({
   providedIn: 'root'
@@ -43,27 +42,8 @@ export class SessionService {
     sessionStorage.setItem(this.PRODUCT_TREE_HIERARCHY, hierarchic ? true.toString() : false.toString());
   }
 
-  saveProductTreeExpansion(node: ProductNode, expanded: boolean) {
-    let expandedNodesString = "";
-    const expandedNodes = sessionStorage.getItem(this.PRODUCT_TREE);
-    const expandedNodesArray = expandedNodes ? expandedNodes.split(',') : [];
-    const nodeName = node.name;
-
-    if (expanded && !expandedNodesArray.includes(nodeName)) {
-      expandedNodesString = expandedNodes ? expandedNodes + ',' + nodeName : nodeName;
-    }
-    else if (!expanded && expandedNodesArray.includes(nodeName)) {
-      const index = expandedNodesArray.indexOf(nodeName, 0);
-      if (index > -1) {
-        expandedNodesArray.splice(index, 1);
-        for (const id of expandedNodesArray) {
-          expandedNodesString += id + ',';
-        }
-        expandedNodesString = expandedNodesString.slice(0, -1);
-      }
-    }
-
-    sessionStorage.setItem(this.PRODUCT_TREE, expandedNodesString);
+  storeProductTreeExpansion(expandedNames: string[]) {
+    sessionStorage.setItem(this.PRODUCT_TREE, expandedNames.join(','));
   }
 
   getExpandedNodeNames(): string[] {

--- a/src/Moryx.Resources.Web/app/src/app/components/resource-tree/resource-tree.html
+++ b/src/Moryx.Resources.Web/app/src/app/components/resource-tree/resource-tree.html
@@ -27,7 +27,7 @@
       matTreeNodeToggle
       type="button"
       [attr.aria-label]="'Toggle ' + node.name"
-      (click)="onExpandOrCollapseNode()">
+      (click)="onExpandOrCollapseNode(node)">
       <mat-icon class="mat-icon-rtl-mirror">
         {{ treeNode.isExpanded ? "expand_more" : "chevron_right" }}
       </mat-icon>

--- a/src/Moryx.Resources.Web/app/src/app/components/resource-tree/resource-tree.ts
+++ b/src/Moryx.Resources.Web/app/src/app/components/resource-tree/resource-tree.ts
@@ -18,11 +18,11 @@ import { getHierarchieLineFor } from '@app/models/TypeTree';
   templateUrl: './resource-tree.html',
   styleUrls: ['./resource-tree.scss'],
   changeDetection: ChangeDetectionStrategy.Eager,
-  host: { '(window:beforeunload)': 'saveState()' },
   imports: [MatTreeModule, MatIconModule, MatButtonModule, TranslatePipe]
 })
 export class ResourceTree {
   private sessionService = inject(SessionService);
+  private expandedIds = new Set<number>();
 
   readonly resources = input.required<ResourceModel[]>();
   readonly selected = input<ResourceModel | undefined>(undefined);
@@ -41,6 +41,7 @@ export class ResourceTree {
   protected TranslationConstants = TranslationConstants;
 
   constructor() {
+    // Restore expanded tree state from session when resources are loaded
     effect(() => {
       const data = this.resources();
       const tree = this.tree();
@@ -48,24 +49,28 @@ export class ResourceTree {
         return;
       }
 
-      const expandedIds = this.sessionService.getExpandedIds();
-      if (expandedIds.length > 0) {
-        this.restoreExpandedNodes(data, expandedIds);
-      } else {
+      untracked(() => {
+        const sessionIds = this.sessionService.getExpandedIds();
+        for (const id of sessionIds) {
+          this.expandedIds.add(id);
+        }
+        this.expandToSelected();
+        this.applyExpandedState(data);
+        this.storeState();
+      });
+    });
+
+    // Expand ancestor nodes to make the selected resource visible in the tree
+    effect(() => {
+      const selectedId = this.selected()?.id;
+      if (selectedId) {
         untracked(() => {
-          const selectedId = this.selected()?.id;
-          if (selectedId) {
-            const toExpand = getHierarchieLineFor(selectedId, data);
-            this.expandNodesById(data, toExpand);
-            this.sessionService.storeTreeState(this.getExpandedIds());
-          }
+          this.expandToSelected();
+          this.applyExpandedState(this.resources());
+          this.storeState();
         });
       }
     });
-  }
-
-  protected saveState() {
-    this.sessionService.storeTreeState(this.getExpandedIds());
   }
 
   protected onNodeClick(id: number) {
@@ -76,40 +81,37 @@ export class ResourceTree {
     this.nodeContextMenu.emit({ event, id });
   }
 
-  protected onExpandOrCollapseNode() {
-    this.sessionService.storeTreeState(this.getExpandedIds());
+  protected onExpandOrCollapseNode(node: ResourceModel) {
+    if (this.expandedIds.has(node.id!)) {
+      this.expandedIds.delete(node.id!);
+    } else {
+      this.expandedIds.add(node.id!);
+    }
+    this.storeState();
   }
 
-  private getExpandedIds(): number[] {
-    const ids: number[] = [];
-    this.collectExpandedIds(this.resources(), ids);
-    return ids;
+  private storeState() {
+    this.sessionService.storeTreeState([...this.expandedIds]);
   }
 
-  private collectExpandedIds(nodes: ResourceModel[], ids: number[]) {
-    for (const node of nodes) {
-      if (this.tree()!.isExpanded(node)) {
-        ids.push(node.id!);
-      }
-      this.collectExpandedIds(this.childrenAccessor(node), ids);
+  private expandToSelected() {
+    const data = this.resources();
+    const selectedId = this.selected()?.id;
+    if (!data.length || !selectedId) {
+      return;
+    }
+    const toExpand = getHierarchieLineFor(selectedId, data);
+    for (const id of toExpand) {
+      this.expandedIds.add(id);
     }
   }
 
-  private restoreExpandedNodes(nodes: ResourceModel[], expandedIds: number[]) {
+  private applyExpandedState(nodes: ResourceModel[]) {
     for (const node of nodes) {
-      if (expandedIds.includes(node.id!)) {
+      if (this.expandedIds.has(node.id!)) {
         this.tree()!.expand(node);
       }
-      this.restoreExpandedNodes(this.childrenAccessor(node), expandedIds);
-    }
-  }
-
-  private expandNodesById(nodes: ResourceModel[], ids: (number | undefined)[]) {
-    for (const node of nodes) {
-      if (ids.includes(node.id)) {
-        this.tree()!.expand(node);
-      }
-      this.expandNodesById(this.childrenAccessor(node), ids);
+      this.applyExpandedState(this.childrenAccessor(node));
     }
   }
 }

--- a/src/Moryx.Resources.Web/app/src/app/components/resource-tree/resource-tree.ts
+++ b/src/Moryx.Resources.Web/app/src/app/components/resource-tree/resource-tree.ts
@@ -60,7 +60,7 @@ export class ResourceTree {
       });
     });
 
-    // Expand ancestor nodes to make the selected resource visible in the tree
+    // Expand nodes to make the selected resource visible in the tree
     effect(() => {
       const selectedId = this.selected()?.id;
       if (selectedId) {


### PR DESCRIPTION
**Resources**

Added a second effect to expand tree nodes when the selected resource changes (e.g. via search). Replaced beforeunload-based state persistence with a local id set that is stored to the session on every expand/collapse and selection change, because beforeunload was unreliable for  persisting state on browser refresh. Expanded ids are tracked independently rather than read from MatTree because the tree loses its expansion state when it receives new data source objects from the API.

**Products**

Applied the same tree expansion fix to the product tree. Added a second effect to expand parent nodes when the selected product changes, and replaced beforeunload-based persistence with a local expandedNames set. Simplified SessionService.saveProductTreeExpansion from per-node add/remove logic to a bulk store matching the resource tree pattern.

close #1422