### PR TITLE
Clear search query when spotlight-search is closed

### DIFF
--- a/src/Moryx.Launcher/app/src/app/services/search.service.ts
+++ b/src/Moryx.Launcher/app/src/app/services/search.service.ts
@@ -14,8 +14,8 @@ export class SearchService {
   private callback: SearchRequestCallback | null = null;
 
   /** Whether the spotlight search overlay is currently open. */
-  private readonly _isOpen = signal(false);
-  readonly isOpen = this._isOpen.asReadonly();
+  private readonly _isSpotlightOpen = signal(false);
+  readonly isSpotlightOpen = this._isSpotlightOpen.asReadonly();
 
   /** Whether a module has registered a search provider. */
   private readonly _hasProvider = signal(false);
@@ -43,12 +43,12 @@ export class SearchService {
   /** Opens the spotlight search overlay. */
   open(): void {
     this.clearSuggestions();
-    this._isOpen.set(true);
+    this._isSpotlightOpen.set(true);
   }
 
   /** Closes the spotlight search overlay and clears suggestions. */
   close(): void {
-    this._isOpen.set(false);
+    this._isSpotlightOpen.set(false);
     this.clearSuggestions();
   }
 

--- a/src/Moryx.Launcher/app/src/app/spotlight-search/spotlight-search.ts
+++ b/src/Moryx.Launcher/app/src/app/spotlight-search/spotlight-search.ts
@@ -103,6 +103,8 @@ export class SpotlightSearch {
   }
 
   protected close(): void {
+    this.query.set('');
+    this.searchService.search('', false);
     this.searchService.close();
   }
 

--- a/src/Moryx.Launcher/app/src/app/spotlight-search/spotlight-search.ts
+++ b/src/Moryx.Launcher/app/src/app/spotlight-search/spotlight-search.ts
@@ -3,7 +3,7 @@
  * Licensed under the Apache License, Version 2.0
 */
 
-import { Component, DestroyRef, effect, ElementRef, inject, signal, viewChild } from '@angular/core';
+import { afterNextRender, Component, DestroyRef, effect, ElementRef, inject, Injector, signal, viewChild } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { MatIconModule } from '@angular/material/icon';
 import { MatButtonModule } from '@angular/material/button';
@@ -27,13 +27,14 @@ export class SpotlightSearch {
   private searchService = inject(SearchService);
   private shortcutService = inject(ShortcutService);
   private destroyRef = inject(DestroyRef);
+  private injector = inject(Injector);
 
   protected readonly searchInput = viewChild<ElementRef<HTMLInputElement>>('searchInput');
   protected readonly resultsList = viewChild<ElementRef<HTMLUListElement>>('resultsList');
 
   protected TranslationConstants = TranslationConstants;
 
-  protected isOpen = this.searchService.isOpen;
+  protected isOpen = this.searchService.isSpotlightOpen;
   protected query = signal('');
   protected activeIndex = signal(0);
 
@@ -57,7 +58,12 @@ export class SpotlightSearch {
       if (this.isOpen()) {
         this.query.set('');
         this.activeIndex.set(0);
-        setTimeout(() => this.searchInput()?.nativeElement.focus(), 0);
+
+        // The input is inside @if(isOpen()), so it doesn't exist in the DOM yet.
+        // Wait for Angular to render the view before focusing.
+        afterNextRender(() => {
+          this.searchInput()?.nativeElement.focus()
+        }, { injector: this.injector });
       }
     });
   }

--- a/src/Moryx.Launcher/app/src/app/toolbar-search/toolbar-search.ts
+++ b/src/Moryx.Launcher/app/src/app/toolbar-search/toolbar-search.ts
@@ -3,7 +3,7 @@
  * Licensed under the Apache License, Version 2.0
 */
 
-import { Component, effect, ElementRef, inject, signal, viewChild } from '@angular/core';
+import { afterNextRender, Component, effect, ElementRef, inject, Injector, signal, viewChild } from '@angular/core';
 import { MatIconModule } from '@angular/material/icon';
 import { MatButtonModule } from '@angular/material/button';
 import { MatAutocompleteModule, MatAutocompleteSelectedEvent } from '@angular/material/autocomplete';
@@ -20,6 +20,7 @@ import { TranslationConstants } from '../translation-constants';
 })
 export class ToolbarSearch {
   private searchService = inject(SearchService);
+  private injector = inject(Injector);
 
   protected readonly searchInput = viewChild<ElementRef<HTMLInputElement>>('searchInput');
 
@@ -34,7 +35,7 @@ export class ToolbarSearch {
 
   constructor() {
     effect(() => {
-      if (this.searchService.isOpen() && this.expanded()) {
+      if (this.searchService.isSpotlightOpen() && this.expanded()) {
         this.collapse();
       }
     });
@@ -42,7 +43,12 @@ export class ToolbarSearch {
 
   protected expand(): void {
     this.expanded.set(true);
-    setTimeout(() => this.searchInput()?.nativeElement.focus(), 0);
+
+    // The expanded class makes the input visible via CSS transition.
+    // Wait for Angular to apply the class and re-render before focusing.
+    afterNextRender(() => {
+      this.searchInput()?.nativeElement.focus()
+    }, { injector: this.injector });
   }
 
   protected collapse(): void {

--- a/src/Moryx.Launcher/app/src/app/toolbar-search/toolbar-search.ts
+++ b/src/Moryx.Launcher/app/src/app/toolbar-search/toolbar-search.ts
@@ -3,7 +3,7 @@
  * Licensed under the Apache License, Version 2.0
 */
 
-import { Component, ElementRef, inject, signal, viewChild } from '@angular/core';
+import { Component, effect, ElementRef, inject, signal, viewChild } from '@angular/core';
 import { MatIconModule } from '@angular/material/icon';
 import { MatButtonModule } from '@angular/material/button';
 import { MatAutocompleteModule, MatAutocompleteSelectedEvent } from '@angular/material/autocomplete';
@@ -31,6 +31,14 @@ export class ToolbarSearch {
   protected suggestions = this.searchService.suggestions;
   protected hasProvider = this.searchService.hasProvider;
   protected disableSearchBox = this.searchService.disableSearchBox;
+
+  constructor() {
+    effect(() => {
+      if (this.searchService.isOpen() && this.expanded()) {
+        this.collapse();
+      }
+    });
+  }
 
   protected expand(): void {
     this.expanded.set(true);


### PR DESCRIPTION
- Clear search query when spotlight-search is closed
- Clear toolbar-query when spotlight gets opened
- Replaced setTimeout with afterNextRender

close #1421

@1nf0rmagician merge on approval