### PR TITLE
Small fixes to CommandCenter

### DIFF
--- a/src/Moryx.CommandCenter.Web/app/src/common/container/App.tsx
+++ b/src/Moryx.CommandCenter.Web/app/src/common/container/App.tsx
@@ -5,6 +5,7 @@
 
 import Container from "@mui/material/Container";
 import * as React from "react";
+import { createPortal } from "react-dom";
 import { connect } from "react-redux";
 import { Navigate, Route, Routes } from "react-router";
 import { ToastContainer } from "react-toastify";
@@ -86,7 +87,7 @@ function App(props: AppPropModel & AppDispatchPropModel) {
   return (
     <div>
       <div>
-        <ToastContainer />
+        {createPortal(<ToastContainer />, document.body)}
 
         <Container id="body">
           <Routes>

--- a/src/Moryx.CommandCenter.Web/app/src/modules/redux/ModulesState.ts
+++ b/src/Moryx.CommandCenter.Web/app/src/modules/redux/ModulesState.ts
@@ -25,46 +25,35 @@ export const initialModulesState: ModulesState = {
   RestClient: new ModulesRestClient(BASE_URL),
 };
 
+function updateModule(state: ModulesState, moduleName: string, update: Partial<ServerModuleModel>): ModulesState {
+  return {
+    ...state,
+    Modules: state.Modules.map((module) =>
+      module.name === moduleName ? { ...module, ...update } : module
+    ),
+  };
+}
+
 export function getModulesReducer(state: ModulesState = initialModulesState, action: ActionType<{}>): ModulesState {
   switch (action.type) {
     case UPDATE_MODULES: {
       return { ...state, Modules: action.payload as ServerModuleModel[] };
     }
     case UPDATE_HEALTHSTATE: {
-      const localPayload = action.payload as {  moduleName: string, healthState: ModuleServerModuleState };
-
-      return {
-        ...state,
-        Modules: state.Modules.map(
-          (module, i) => module.name === localPayload.moduleName ? {...module, HealthState: localPayload.healthState} : module),
-      };
+      const { moduleName, healthState } = action.payload as { moduleName: string; healthState: ModuleServerModuleState };
+      return updateModule(state, moduleName, { healthState });
     }
     case UPDATE_NOTIFICATIONS: {
-      const localPayload = action.payload as {  moduleName: string, notifications: NotificationModel[] };
-
-      return {
-        ...state,
-        Modules: state.Modules.map(
-          (module, i) => module.name === localPayload.moduleName ? {...module, Notifications: localPayload.notifications} : module),
-      };
+      const { moduleName, notifications } = action.payload as { moduleName: string; notifications: NotificationModel[] };
+      return updateModule(state, moduleName, { notifications });
     }
     case UPDATE_START_BEHAVIOUR: {
-      const localPayload = action.payload as { moduleName: string, startBehaviour: ModuleStartBehaviour };
-
-      return {
-        ...state,
-        Modules: state.Modules.map(
-          (module, i) => module.name === localPayload.moduleName ? {...module, StartBehaviour: localPayload.startBehaviour} : module),
-      };
+      const { moduleName, startBehaviour } = action.payload as { moduleName: string; startBehaviour: ModuleStartBehaviour };
+      return updateModule(state, moduleName, { startBehaviour });
     }
     case UPDATE_FAILURE_BEHAVIOUR: {
-      const localPayload = action.payload as { moduleName: string, failureBehaviour: FailureBehaviour };
-
-      return {
-        ...state,
-        Modules: state.Modules.map(
-          (module, i) => module.name === localPayload.moduleName ? {...module, FailureBehaviour: localPayload.failureBehaviour} : module),
-      };
+      const { moduleName, failureBehaviour } = action.payload as { moduleName: string; failureBehaviour: FailureBehaviour };
+      return updateModule(state, moduleName, { failureBehaviour });
     }
   }
   return state;

--- a/src/Moryx.CommandCenter.Web/app/src/modules/redux/ModulesState.ts
+++ b/src/Moryx.CommandCenter.Web/app/src/modules/redux/ModulesState.ts
@@ -45,7 +45,10 @@ export function getModulesReducer(state: ModulesState = initialModulesState, act
     }
     case UPDATE_NOTIFICATIONS: {
       const { moduleName, notifications } = action.payload as { moduleName: string; notifications: NotificationModel[] };
-      return updateModule(state, moduleName, { notifications });
+      const sorted = notifications.sort((a, b) =>
+        new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime()
+      );
+      return updateModule(state, moduleName, { notifications: sorted });
     }
     case UPDATE_START_BEHAVIOUR: {
       const { moduleName, startBehaviour } = action.payload as { moduleName: string; startBehaviour: ModuleStartBehaviour };


### PR DESCRIPTION
- [Fixed toast-notifications behind toolbar](https://github.com/PHOENIXCONTACT/MORYX-Framework/commit/56a7c4a5e92bb475e0bc15629f171c896fd571ee)
  - A portal renders the component into a different DOM (document.body) than its parent, escaping any stacking contexts that would otherwise trap it
- [Sort module notifications by time descending](https://github.com/PHOENIXCONTACT/MORYX-Framework/commit/942547c2e44c25cd0ac750a33294b61d435ea222)

close #1135

@1nf0rmagician merge on approval