### PR TITLE
Update cell on ResourceChanged

### DIFF
--- a/docs/articles/module-resources/resource-object-graph.md
+++ b/docs/articles/module-resources/resource-object-graph.md
@@ -84,3 +84,25 @@ public class DynamicTree : Resource
 ```
 
 The `Shrink`-method shows the two alternatives for destroying resource instances. The caller can specify whether to remove the object by ﬂagging it as deleted or actually deleting the entry from the database. The call with a single argument is a shortcut for the second one with permanent = false. In both cases the object is removed from the resource graph and all references it occurs in to allow proper garbage collection.
+
+### Notify without saving
+
+In some cases a resource property changes frequently at runtime but does not need to be persisted — for example, a counter or a current temperature. For these transient changes, `RaiseResourceChanged(false)` raises the `ResourceChanged` event on the `IResourceManagement` facade without triggering a database persistence.
+An optional property name is captured automatically when called from a property setter via `[CallerMemberName]`.
+
+```cs
+public class MonitoredCell : Resource
+{
+    private int _partCount;
+
+    public int PartCount
+    {
+        get => _partCount;
+        set
+        {
+            _partCount = value;
+            RaiseResourceChanged(save: false); // PropertyName = "PartCount"
+        }
+    }
+}
+```

--- a/src/Moryx.AbstractionLayer/Resources/Resource.cs
+++ b/src/Moryx.AbstractionLayer/Resources/Resource.cs
@@ -1,6 +1,7 @@
 // Copyright (c) 2026 Phoenix Contact GmbH & Co. KG
 // Licensed under the Apache License, Version 2.0
 
+using System.Runtime.CompilerServices;
 using System.Runtime.Serialization;
 using Microsoft.Extensions.Logging;
 using Moryx.AbstractionLayer.Capabilities;
@@ -138,10 +139,27 @@ public abstract class Resource : ILoggingComponent, IResource, IAsyncInitializab
     /// Inform the resource management, that this instance was modified
     /// and trigger saving the current state to storage
     /// </summary>
-    protected void RaiseResourceChanged()
+    protected void RaiseResourceChanged() => RaiseResourceChanged(true);
+
+    /// <summary>
+    /// Inform the resource management, that this instance was modified
+    /// </summary>
+    /// <param name="save">If true, the change is persisted to storage.</param>
+    /// <param name="propertyName">Name of the property that changed.</param>
+    protected void RaiseResourceChanged(bool save, [CallerMemberName] string propertyName = null)
     {
-        // This is only null during boot, when the resource manager populates the object
-        Changed?.Invoke(this, EventArgs.Empty);
+        if (save)
+        {
+            Changed?.Invoke(this, EventArgs.Empty);
+        }
+        else
+        {
+            Notified?.Invoke(this, new ResourceChangedEventArgs
+            {
+                Save = save,
+                PropertyName = propertyName
+            });
+        }
     }
 
     /// <summary>
@@ -169,9 +187,16 @@ public abstract class Resource : ILoggingComponent, IResource, IAsyncInitializab
     /// </summary>
     public event EventHandler<ICapabilities> CapabilitiesChanged;
 
+    // TODO: In next major, merge Changed and Notified into a single event using ResourceChangedEventArgs
     /// <summary>
     /// Event raised when the resource was modified and the changes should be
     /// written to the data storage
     /// </summary>
     public event EventHandler Changed;
+
+    /// <summary>
+    /// Event raised when the resource wants to notify listeners of a change
+    /// without triggering persistence
+    /// </summary>
+    public event EventHandler<ResourceChangedEventArgs> Notified;
 }

--- a/src/Moryx.AbstractionLayer/Resources/ResourceChangedEventArgs.cs
+++ b/src/Moryx.AbstractionLayer/Resources/ResourceChangedEventArgs.cs
@@ -1,0 +1,20 @@
+// Copyright (c) 2026 Phoenix Contact GmbH & Co. KG
+// Licensed under the Apache License, Version 2.0
+
+namespace Moryx.AbstractionLayer.Resources;
+
+/// <summary>
+/// Event args for <see cref="Resource.Changed"/>
+/// </summary>
+public class ResourceChangedEventArgs : EventArgs
+{
+    /// <summary>
+    /// If true, the resource will be saved to storage.
+    /// </summary>
+    public bool Save { get; init; }
+
+    /// <summary>
+    /// Name of the property that changed, or null if not specified
+    /// </summary>
+    public string PropertyName { get; init; }
+}

--- a/src/Moryx.FactoryMonitor.Endpoints/Extensions/FactoryMonitorHelper.cs
+++ b/src/Moryx.FactoryMonitor.Endpoints/Extensions/FactoryMonitorHelper.cs
@@ -62,22 +62,18 @@ internal static class FactoryMonitorHelper
         broadcast(Cell_State_Event_Type_Key, cellStateChangedModel);
     }
 
-    public static void ResourceUpdated(IResourceManagement resourceManager,
-        Func<IEnumerable<IMachineLocation>, Dictionary<IMachineLocation, ICell>> mapCellsTo,
+    public static void ResourceUpdated(IResource changedResource,
+        Dictionary<IMachineLocation, ICell> locationToCellMappings,
         Converter.Converter converter,
+        IResourceManagement resourceManager,
         Action<string, object> broadcast)
     {
-        var locations = resourceManager.GetResources<IMachineLocation>();
-        // ToDo: Added and removed resources not reflected
-        var locationToCellMappings = mapCellsTo(locations);
+        var mapping = locationToCellMappings.FirstOrDefault(l2c => l2c.Value.Id == changedResource.Id);
+        if (mapping.Key is null)
+            return;
 
-        foreach (var l2cMapping in locationToCellMappings)
-        {
-            var cell = l2cMapping.Value;
-            var location = l2cMapping.Key;
-            var resourceChangedModel = cell.GetResourceChangedModel(converter, resourceManager, location);
-            broadcast(Recource_Event_Type_Key, resourceChangedModel);
-        }
+        var resourceChangedModel = mapping.Value.GetResourceChangedModel(converter, resourceManager, mapping.Key);
+        broadcast(Recource_Event_Type_Key, resourceChangedModel);
     }
 
     public static List<TransportRouteModel> CreateRoutes(IReadOnlyList<IMachineLocation> locations)

--- a/src/Moryx.FactoryMonitor.Endpoints/Extensions/FactoryMonitorHelper.cs
+++ b/src/Moryx.FactoryMonitor.Endpoints/Extensions/FactoryMonitorHelper.cs
@@ -62,6 +62,7 @@ internal static class FactoryMonitorHelper
         broadcast(Cell_State_Event_Type_Key, cellStateChangedModel);
     }
 
+    // ToDo: Added and removed resources not reflected
     public static void ResourceUpdated(IResource changedResource,
         Dictionary<IMachineLocation, ICell> locationToCellMappings,
         Converter.Converter converter,
@@ -74,6 +75,24 @@ internal static class FactoryMonitorHelper
 
         var resourceChangedModel = mapping.Value.GetResourceChangedModel(converter, resourceManager, mapping.Key);
         broadcast(Recource_Event_Type_Key, resourceChangedModel);
+    }
+
+    public static void ResourceUpdated(IResourceManagement resourceManager,
+        Func<IEnumerable<IMachineLocation>, Dictionary<IMachineLocation, ICell>> mapCellsTo,
+        Converter.Converter converter,
+        Action<string, object> broadcast)
+    {
+        var locations = resourceManager.GetResources<IMachineLocation>();
+        // ToDo: Added and removed resources not reflected
+        var locationToCellMappings = mapCellsTo(locations);
+
+        foreach (var l2cMapping in locationToCellMappings)
+        {
+            var cell = l2cMapping.Value;
+            var location = l2cMapping.Key;
+            var resourceChangedModel = cell.GetResourceChangedModel(converter, resourceManager, location);
+            broadcast(Recource_Event_Type_Key, resourceChangedModel);
+        }
     }
 
     public static List<TransportRouteModel> CreateRoutes(IReadOnlyList<IMachineLocation> locations)

--- a/src/Moryx.FactoryMonitor.Endpoints/FactoryMonitorController.cs
+++ b/src/Moryx.FactoryMonitor.Endpoints/FactoryMonitorController.cs
@@ -8,7 +8,6 @@ using System.Runtime.CompilerServices;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Threading.Channels;
-using System.Timers;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
@@ -24,7 +23,6 @@ using Moryx.FactoryMonitor.Endpoints.Extensions;
 using Moryx.FactoryMonitor.Endpoints.Models;
 using Moryx.FactoryMonitor.Endpoints.Properties;
 using Moryx.Orders;
-using Timer = System.Timers.Timer;
 
 namespace Moryx.FactoryMonitor.Endpoints;
 
@@ -51,7 +49,6 @@ public class FactoryMonitorController : ControllerBase
     };
 
     private Dictionary<IMachineLocation, ICell> _locationToCellMappings;
-    private Timer _resourceChangedTimer;
     private readonly ILogger<FactoryMonitorController> _logger;
 
     public FactoryMonitorController(IResourceManagement resourceManager, IProcessControl processControl, IOrderManagement orderManagement, ILogger<FactoryMonitorController> logger = null)
@@ -246,8 +243,8 @@ public class FactoryMonitorController : ControllerBase
         var converter = new Converter.Converter(_serialization, _logger);
 
         // Define event handlers using helper methods
-        var resourceEventHandler = new ElapsedEventHandler((_, _) =>
-            FactoryMonitorHelper.ResourceUpdated(_resourceManager, l => MapCellsTo(l), converter, Broadcast));
+        var resourceChangedEventHandler = new EventHandler<IResource>((_, resource) =>
+            FactoryMonitorHelper.ResourceUpdated(resource, _locationToCellMappings, converter, _resourceManager, Broadcast));
 
         var capabilitiesEventHandler = new EventHandler<ICapabilities>((sender, _) =>
             FactoryMonitorHelper.PublishCellUpdate((sender as ICell)?.GetCellStateChangedModel(), Broadcast));
@@ -263,12 +260,6 @@ public class FactoryMonitorController : ControllerBase
             FactoryMonitorHelper.ActivityUpdated(eventArgs, [.. _locationToCellMappings.Values],
                 TryGetOrders(), Broadcast));
 
-        // Setup timer
-        _resourceChangedTimer = new();
-        _resourceChangedTimer.Interval = 5000;
-        _resourceChangedTimer.AutoReset = true;
-        _resourceChangedTimer.Enabled = true;
-
         try
         {
             var result = TypedResults.ServerSentEvents(Subscribe(cancellationToken));
@@ -279,10 +270,10 @@ public class FactoryMonitorController : ControllerBase
                 l2cMapping.Value.CapabilitiesChanged += capabilitiesEventHandler;
             }
 
+            _resourceManager.ResourceChanged += resourceChangedEventHandler;
             _orderManager.OperationStarted += orderStartedEventHandler;
             _orderManager.OperationUpdated += orderEventHandler;
             _processControl.ActivityUpdated += activityEventHandler;
-            _resourceChangedTimer.Elapsed += resourceEventHandler;
 
             await result.ExecuteAsync(HttpContext);
         }
@@ -298,11 +289,10 @@ public class FactoryMonitorController : ControllerBase
                 l2cMapping.Value.CapabilitiesChanged -= capabilitiesEventHandler;
             }
 
+            _resourceManager.ResourceChanged -= resourceChangedEventHandler;
             _orderManager.OperationStarted -= orderStartedEventHandler;
             _orderManager.OperationUpdated -= orderEventHandler;
             _processControl.ActivityUpdated -= activityEventHandler;
-            _resourceChangedTimer.Elapsed -= resourceEventHandler;
-            _resourceChangedTimer?.Dispose();
         }
 
         return;

--- a/src/Moryx.FactoryMonitor.Endpoints/FactoryMonitorController.cs
+++ b/src/Moryx.FactoryMonitor.Endpoints/FactoryMonitorController.cs
@@ -8,6 +8,7 @@ using System.Runtime.CompilerServices;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Threading.Channels;
+using System.Timers;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
@@ -23,6 +24,7 @@ using Moryx.FactoryMonitor.Endpoints.Extensions;
 using Moryx.FactoryMonitor.Endpoints.Models;
 using Moryx.FactoryMonitor.Endpoints.Properties;
 using Moryx.Orders;
+using Timer = System.Timers.Timer;
 
 namespace Moryx.FactoryMonitor.Endpoints;
 
@@ -49,6 +51,7 @@ public class FactoryMonitorController : ControllerBase
     };
 
     private Dictionary<IMachineLocation, ICell> _locationToCellMappings;
+    private Timer _resourceChangedTimer;
     private readonly ILogger<FactoryMonitorController> _logger;
 
     public FactoryMonitorController(IResourceManagement resourceManager, IProcessControl processControl, IOrderManagement orderManagement, ILogger<FactoryMonitorController> logger = null)
@@ -246,6 +249,9 @@ public class FactoryMonitorController : ControllerBase
         var resourceChangedEventHandler = new EventHandler<IResource>((_, resource) =>
             FactoryMonitorHelper.ResourceUpdated(resource, _locationToCellMappings, converter, _resourceManager, Broadcast));
 
+        var resourceTimerEventHandler = new ElapsedEventHandler((_, _) =>
+            FactoryMonitorHelper.ResourceUpdated(_resourceManager, l => MapCellsTo(l), converter, Broadcast));
+
         var capabilitiesEventHandler = new EventHandler<ICapabilities>((sender, _) =>
             FactoryMonitorHelper.PublishCellUpdate((sender as ICell)?.GetCellStateChangedModel(), Broadcast));
 
@@ -260,6 +266,12 @@ public class FactoryMonitorController : ControllerBase
             FactoryMonitorHelper.ActivityUpdated(eventArgs, [.. _locationToCellMappings.Values],
                 TryGetOrders(), Broadcast));
 
+        // TODO: Remove timer in next major when resources use RaiseResourceChanged
+        _resourceChangedTimer = new();
+        _resourceChangedTimer.Interval = 5000;
+        _resourceChangedTimer.AutoReset = true;
+        _resourceChangedTimer.Enabled = true;
+
         try
         {
             var result = TypedResults.ServerSentEvents(Subscribe(cancellationToken));
@@ -271,6 +283,7 @@ public class FactoryMonitorController : ControllerBase
             }
 
             _resourceManager.ResourceChanged += resourceChangedEventHandler;
+            _resourceChangedTimer.Elapsed += resourceTimerEventHandler;
             _orderManager.OperationStarted += orderStartedEventHandler;
             _orderManager.OperationUpdated += orderEventHandler;
             _processControl.ActivityUpdated += activityEventHandler;
@@ -290,9 +303,11 @@ public class FactoryMonitorController : ControllerBase
             }
 
             _resourceManager.ResourceChanged -= resourceChangedEventHandler;
+            _resourceChangedTimer.Elapsed -= resourceTimerEventHandler;
             _orderManager.OperationStarted -= orderStartedEventHandler;
             _orderManager.OperationUpdated -= orderEventHandler;
             _processControl.ActivityUpdated -= activityEventHandler;
+            _resourceChangedTimer?.Dispose();
         }
 
         return;

--- a/src/Moryx.FactoryMonitor.Web/app/src/app/components/cell-details/cell-details.ts
+++ b/src/Moryx.FactoryMonitor.Web/app/src/app/components/cell-details/cell-details.ts
@@ -3,7 +3,7 @@
  * Licensed under the Apache License, Version 2.0
 */
 
-import { Component, inject, ChangeDetectionStrategy } from '@angular/core';
+import { Component, inject, computed, ChangeDetectionStrategy } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 import { CellImageDialog } from '@app/dialogs/cell-image-dialog/cell-image-dialog';
 import { CellStoreService } from '@app/services/cell-store.service';
@@ -34,8 +34,16 @@ export class CellDetails {
   private matDialog = inject(MatDialog);
   private cellStoreService = inject(CellStoreService);
 
-  protected cellDetails = this.cellStoreService.cellSelected;
   protected TranslationConstants = TranslationConstants;
+
+  protected cellDetails = computed(() => {
+    const selected = this.cellStoreService.cellSelected();
+    const updated = this.cellStoreService.cellUpdated();
+    if (selected && updated && selected.id === updated.id) {
+      return updated;
+    }
+    return selected;
+  });
 
   protected openCellImageDialog() {
     this.matDialog.open(CellImageDialog, {

--- a/src/Moryx.Resources.Management/Resources/ResourceManager.cs
+++ b/src/Moryx.Resources.Management/Resources/ResourceManager.cs
@@ -260,6 +260,7 @@ internal class ResourceManager : IResourceManager
     private void RegisterEvents(Resource instance)
     {
         instance.Changed += OnResourceChanged;
+        instance.Notified += OnResourceNotified;
         instance.CapabilitiesChanged += RaiseCapabilitiesChanged;
 
         foreach (var autoSaveCollection in ResourceReferenceTools.GetAutoSaveCollections(instance))
@@ -272,6 +273,7 @@ internal class ResourceManager : IResourceManager
     private void UnregisterEvents(Resource instance)
     {
         instance.Changed -= OnResourceChanged;
+        instance.Notified -= OnResourceNotified;
         instance.CapabilitiesChanged -= RaiseCapabilitiesChanged;
 
         foreach (var autoSaveCollection in ResourceReferenceTools.GetAutoSaveCollections(instance))
@@ -285,6 +287,14 @@ internal class ResourceManager : IResourceManager
     private void OnResourceChanged(object sender, EventArgs eventArgs)
     {
         _ = Task.Run(() => SaveAsync((Resource)sender));
+    }
+
+    /// <summary>
+    /// Event handler when a resource notifies of a change without requiring persistence
+    /// </summary>
+    private void OnResourceNotified(object sender, ResourceChangedEventArgs eventArgs)
+    {
+        _ = Task.Run(() => RaiseResourceChanged((IResource)sender));
     }
 
     /// <summary>


### PR DESCRIPTION
based on #1437

There a hardcoded 5 seconds timer in FactoryMonitor server instead of pushing changes directly by ResourceChanged event. This PR added ResourceChanged-event in addition to hardcoded timer.

I also introduced an option to RaiseResourceChanged that the persistence should not be triggered. Its a separate event on Resource which must be merged on future with Changed.

Open Question: Is the timer removal an behavior change we cannot introduce in 10.x? Resources which do not raise the event were updated before. With listening on ResourceChanged it is necessary that RaiseResourceChanged is raised in the resources. 
- Option A: We enforce the use of RaiseResourceChanged, then 1175971369b94bffb785e37abc24260b4bebf358 can be reverted
- Option B: Keep the timer for compatibiity and revert 1175971369b94bffb785e37abc24260b4bebf358 in `future`