### PR TITLE
Adds controller actions to interact with the order integration

### DIFF
--- a/MORYX-Framework.slnx
+++ b/MORYX-Framework.slnx
@@ -119,6 +119,7 @@
   </Folder>
     <Folder Name="/Tests/IntegrationTests/">
       <Project Path="src/Tests/Moryx.Communication.Sockets.IntegrationTests/Moryx.Communication.Sockets.IntegrationTests.csproj" />
+      <Project Path="src/Tests/Moryx.Material.Integrations.Orders.Integrator.Tests/Moryx.Material.Integrations.Orders.Integrator.Tests.csproj" />
       <Project Path="src/Tests/Moryx.Material.IntegrationTests/Moryx.Material.IntegrationTests.csproj" />
       <Project Path="src/Tests/Moryx.Operators.Management.Integration.Tests/Moryx.Operators.Management.Integration.Tests.csproj" />
       <Project Path="src/Tests/Moryx.Products.IntegrationTests/Moryx.Products.IntegrationTests.csproj" />

--- a/src/Moryx.Material.Endpoints/MaterialManagementController.cs
+++ b/src/Moryx.Material.Endpoints/MaterialManagementController.cs
@@ -13,6 +13,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Moryx.Material.Endpoints.Model;
 using Moryx.Material.Facade;
+using Moryx.Material.Integrations.Orders;
 using Moryx.Tools;
 
 namespace Moryx.Material.Endpoints;
@@ -25,22 +26,25 @@ namespace Moryx.Material.Endpoints;
 [ApiController]
 [Route("api/moryx/materials/")]
 [Produces("application/json")]
-public class MaterialManagementController(IMaterialManagement materialManagement, ILogger<MaterialManagementController> logger) : ControllerBase
+public class MaterialManagementController(IMaterialManagement materialManagement, IOrderIntegration? orderIntegration, ILogger<MaterialManagementController> logger) : ControllerBase
 {
     private readonly IMaterialManagement _materialManagement = materialManagement ?? throw new ArgumentNullException(nameof(materialManagement));
+    private readonly IOrderIntegration _orderIntegration = orderIntegration;
+
     private static readonly JsonSerializerOptions _serializerOptions = new()
     {
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
         Converters = { new JsonStringEnumConverter() }
     };
 
+    #region Material Containers
     #region GET
 
     [HttpGet("containers")]
-    [ProducesResponseType(typeof(MaterialContainerModel), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(MaterialContainerModel[]), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     [Authorize(Policy = MaterialPermissions.CanRead)]
-    public ActionResult<MaterialContainerModel[]> GetAll()
+    public ActionResult<MaterialContainerModel[]> GetContainers()
     {
         var containers = _materialManagement.GetContainers();
         return Ok(containers.ToModels());
@@ -91,7 +95,7 @@ public class MaterialManagementController(IMaterialManagement materialManagement
     [ProducesResponseType(typeof(string), StatusCodes.Status404NotFound)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     [Authorize(Policy = MaterialPermissions.CanDelete)]
-    public async Task<ActionResult<MaterialContainerModel>> Deregister(long id, CancellationToken cancellationToken)
+    public async Task<ActionResult> Deregister(long id, CancellationToken cancellationToken)
     {
         if (id <= 0)
         {
@@ -168,5 +172,26 @@ public class MaterialManagementController(IMaterialManagement materialManagement
         void Broadcast(IMaterialContainer container) => _containerStreamSubscribers.Values.ForEach(channel =>
             channel.Writer.TryWrite(JsonSerializer.Serialize(container.ToModel(), _serializerOptions)));
     }
+    #endregion
+    #endregion
+
+    #region Order References
+    #region GET
+
+    [HttpGet("integrations/orders/available")]
+    [ProducesResponseType(typeof(bool), StatusCodes.Status200OK)]
+    [Authorize(Policy = MaterialPermissions.CanRead)]
+    public ActionResult<bool> HasOrderIntegration() => Ok(_orderIntegration is null);
+
+    [HttpGet("integrations/orders")]
+    [ProducesResponseType(typeof(OrderReferenceModel[]), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    [Authorize(Policy = MaterialPermissions.CanRead)]
+    public ActionResult<OrderReference[]> GetOrderReferences()
+    {
+        var references = _orderIntegration.GetOrderReferences();
+        return Ok(references.ToModels());
+    }
+    #endregion
     #endregion
 }

--- a/src/Moryx.Material.Endpoints/MaterialManagementController.cs
+++ b/src/Moryx.Material.Endpoints/MaterialManagementController.cs
@@ -47,7 +47,7 @@ public class MaterialManagementController(IMaterialManagement materialManagement
     }
 
     [HttpGet("containers/types")]
-    [ProducesResponseType(typeof(MaterialContainerTypeModel), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(MaterialContainerTypeModel[]), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     [Authorize(Policy = MaterialPermissions.CanRead)]
     public ActionResult<MaterialContainerTypeModel[]> GetTypes()
@@ -86,26 +86,26 @@ public class MaterialManagementController(IMaterialManagement materialManagement
 
     #region Delete
     [HttpDelete("containers/{id}")]
-    [ProducesResponseType(typeof(MaterialContainerModel), StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(typeof(string), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(typeof(string), StatusCodes.Status404NotFound)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     [Authorize(Policy = MaterialPermissions.CanDelete)]
-    public async Task<ActionResult<MaterialContainerModel>> Deregister(long containerId, CancellationToken cancellationToken)
+    public async Task<ActionResult<MaterialContainerModel>> Deregister(long id, CancellationToken cancellationToken)
     {
-        if (containerId <= 0)
+        if (id <= 0)
         {
             return BadRequest("Container Id must be a positive number");
         }
 
         try
         {
-            await _materialManagement.DeregisterContainerAsync(containerId, cancellationToken);
+            await _materialManagement.DeregisterContainerAsync(id, cancellationToken);
             return NoContent();
         }
         catch (KeyNotFoundException)
         {
-            return NotFound($"Container with id '{containerId}' could not be found.");
+            return NotFound($"Container with id '{id}' could not be found.");
         }
     }
     #endregion

--- a/src/Moryx.Material.Endpoints/MaterialManagementController.cs
+++ b/src/Moryx.Material.Endpoints/MaterialManagementController.cs
@@ -1,4 +1,4 @@
-// Copyright (channel) 2026 Phoenix Contact GmbH & Co. KG
+// Copyright (c) 2026 Phoenix Contact GmbH & Co. KG
 // Licensed under the Apache License, Version 2.0
 
 using System.Collections.Concurrent;
@@ -28,8 +28,6 @@ namespace Moryx.Material.Endpoints;
 public class MaterialManagementController(IMaterialManagement materialManagement, ILogger<MaterialManagementController> logger) : ControllerBase
 {
     private readonly IMaterialManagement _materialManagement = materialManagement ?? throw new ArgumentNullException(nameof(materialManagement));
-    private readonly ILogger<MaterialManagementController> _logger = logger ?? throw new ArgumentNullException(nameof(materialManagement));
-
     private static readonly JsonSerializerOptions _serializerOptions = new()
     {
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
@@ -67,7 +65,7 @@ public class MaterialManagementController(IMaterialManagement materialManagement
     [ProducesResponseType(typeof(string), StatusCodes.Status404NotFound)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     [Authorize(Policy = MaterialPermissions.CanUpdate)]
-    public async Task<ActionResult<MaterialContainerModel>> PreAdviceAsync(PreAdvideModel preAdvice)
+    public async Task<ActionResult<MaterialContainerModel>> PreAdviceAsync(PreAdvideModel preAdvice, CancellationToken cancellationToken)
     {
         if (preAdvice.ContainerId <= 0)
         {
@@ -76,12 +74,38 @@ public class MaterialManagementController(IMaterialManagement materialManagement
 
         try
         {
-            var updatedContainer = await _materialManagement.PreAdviceMaterialAsync(preAdvice.ToBusiness());
+            var updatedContainer = await _materialManagement.PreAdviceMaterialAsync(preAdvice.ToBusiness(), cancellationToken);
             return Ok(updatedContainer.ToModel());
         }
         catch (KeyNotFoundException)
         {
-            return NotFound($"Container {preAdvice.ContainerId} could not be found.");
+            return NotFound($"Container id '{preAdvice.ContainerId}' could not be found.");
+        }
+    }
+    #endregion
+
+    #region Delete
+    [HttpDelete("containers/{id}")]
+    [ProducesResponseType(typeof(MaterialContainerModel), StatusCodes.Status204NoContent)]
+    [ProducesResponseType(typeof(string), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(string), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    [Authorize(Policy = MaterialPermissions.CanDelete)]
+    public async Task<ActionResult<MaterialContainerModel>> Deregister(long containerId, CancellationToken cancellationToken)
+    {
+        if (containerId <= 0)
+        {
+            return BadRequest("Container Id must be a positive number");
+        }
+
+        try
+        {
+            await _materialManagement.DeregisterContainerAsync(containerId, cancellationToken);
+            return NoContent();
+        }
+        catch (KeyNotFoundException)
+        {
+            return NotFound($"Container with id '{containerId}' could not be found.");
         }
     }
     #endregion

--- a/src/Moryx.Material.Endpoints/Model/MaterialManagementConverter.cs
+++ b/src/Moryx.Material.Endpoints/Model/MaterialManagementConverter.cs
@@ -8,7 +8,7 @@ using Moryx.Tools;
 
 namespace Moryx.Material.Endpoints.Model;
 
-internal static class Converter
+internal static class MaterialManagementConverter
 {
     #region ToModel
     public static MaterialContainerTypeModel ToModel(this Type type) => new()

--- a/src/Moryx.Material.Endpoints/Model/OrderIntegrationConverter.cs
+++ b/src/Moryx.Material.Endpoints/Model/OrderIntegrationConverter.cs
@@ -1,0 +1,31 @@
+// Copyright (c) 2026 Phoenix Contact GmbH & Co. KG
+// Licensed under the Apache License, Version 2.0
+
+using Moryx.Material.Integrations.Orders;
+using Moryx.Tools;
+
+namespace Moryx.Material.Endpoints.Model;
+
+internal static class OrderIntegrationConverter
+{
+    #region ToModel
+
+    public static OrderReferenceModel[] ToModels(this IReadOnlyList<OrderReference> references)
+    {
+        return references.Select(r =>
+        {
+            var status = r.Status;
+            return new OrderReferenceModel()
+            {
+                OrderNumber = r.OrderNumber,
+                OperationNumber = r.OperationNumber,
+                StatusKey = status is null ? -1 : (int)status,
+                StatusDisplayName = status?.GetDisplayName(),
+                ReferenceStateKey = (int)r.State,
+                ReferenceStateDisplayName = r.State.GetDisplayName(),
+            };
+        }).ToArray();
+    }
+
+    #endregion
+}

--- a/src/Moryx.Material.Endpoints/Model/OrderReferenceModel.cs
+++ b/src/Moryx.Material.Endpoints/Model/OrderReferenceModel.cs
@@ -1,0 +1,19 @@
+// Copyright (c) 2026 Phoenix Contact GmbH & Co. KG
+// Licensed under the Apache License, Version 2.0
+
+namespace Moryx.Material.Endpoints.Model;
+
+public class OrderReferenceModel
+{
+    public required int ReferenceStateKey { get; set; }
+
+    public required string ReferenceStateDisplayName { get; set; }
+
+    public required string OrderNumber { get; set; }
+
+    public string? OperationNumber { get; set; }
+
+    public int StatusKey { get; set; }
+
+    public string? StatusDisplayName { get; set; }
+}

--- a/src/Moryx.Material.Endpoints/Moryx.Material.Endpoints.csproj
+++ b/src/Moryx.Material.Endpoints/Moryx.Material.Endpoints.csproj
@@ -16,6 +16,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Moryx.AspNetCore\Moryx.AspNetCore.csproj" />
+    <ProjectReference Include="..\Moryx.Material.Integrations.Orders\Moryx.Material.Integrations.Orders.csproj" />
     <ProjectReference Include="..\Moryx.Material\Moryx.Material.csproj" />
     <ProjectReference Include="..\Moryx.Runtime\Moryx.Runtime.csproj" />
   </ItemGroup>
@@ -33,10 +34,6 @@
       <AutoGen>True</AutoGen>
       <DependentUpon>Strings.resx</DependentUpon>
     </Compile>
-  </ItemGroup>
-
-  <ItemGroup>
-    <None Update="C:\Repositories\00 Products\MORYX-Framework\.build\\moryx-logo.png" Link="Model\moryx-logo.png" />
   </ItemGroup>
 
 </Project>

--- a/src/Moryx.Material.Integrations.Orders.Integrator/Components/IOrderReferencesPool.cs
+++ b/src/Moryx.Material.Integrations.Orders.Integrator/Components/IOrderReferencesPool.cs
@@ -17,4 +17,6 @@ internal interface IOrderReferencesPool : IAsyncPlugin
     InternalOrderReference? Get(OrderReference? reference);
 
     InternalOrderReference? GetOrCreate(string orderNumber, string? operationNumber);
+
+    IReadOnlyList<OrderReference> GetAll();
 }

--- a/src/Moryx.Material.Integrations.Orders.Integrator/Components/OrderReferencesPool.cs
+++ b/src/Moryx.Material.Integrations.Orders.Integrator/Components/OrderReferencesPool.cs
@@ -75,6 +75,7 @@ internal class OrderReferencesPool : IOrderReferencesPool
     #endregion
 
     #region IOrderReferencesPool
+
     public InternalOrderReference? Get(OrderReference? reference)
     {
         if (reference is null)
@@ -98,6 +99,8 @@ internal class OrderReferencesPool : IOrderReferencesPool
             State = ReferenceState.Unavailable
         });
     }
-    #endregion
 
+    public IReadOnlyList<OrderReference> GetAll() => [.. _operationReferences.Values];
+
+    #endregion
 }

--- a/src/Moryx.Material.Integrations.Orders.Integrator/Facade/OrderIntegrationFacade.cs
+++ b/src/Moryx.Material.Integrations.Orders.Integrator/Facade/OrderIntegrationFacade.cs
@@ -1,0 +1,16 @@
+// Copyright (c) 2026 Phoenix Contact GmbH & Co. KG
+// Licensed under the Apache License, Version 2.0
+
+using Moryx.Material.Integrations.Orders.Integrator.Components;
+using Moryx.Runtime.Modules;
+
+namespace Moryx.Material.Integrations.Orders.Integrator.Facade;
+
+internal class OrderIntegrationFacade : FacadeBase, IOrderIntegration
+{
+#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring as nullable.
+    public IOrderReferencesPool Pool { get; set; }
+#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring as nullable.
+
+    public IReadOnlyList<OrderReference> GetOrderReferences() => Pool.GetAll();
+}

--- a/src/Moryx.Material.Integrations.Orders.Integrator/ModuleController/ModuleController.cs
+++ b/src/Moryx.Material.Integrations.Orders.Integrator/ModuleController/ModuleController.cs
@@ -7,6 +7,7 @@ using Moryx.Configuration;
 using Moryx.Container;
 using Moryx.Material.Facade;
 using Moryx.Material.Integrations.Orders.Integrator.Components;
+using Moryx.Material.Integrations.Orders.Integrator.Facade;
 using Moryx.Material.Linking;
 using Moryx.Orders;
 using Moryx.Runtime.Modules;
@@ -20,7 +21,7 @@ namespace Moryx.Material.Integrations.Orders.Integrator;
 /// </summary>
 [Display(Name = "Material Mánagement - Order Integration", Description = "Wires order linking semantics into the material management module.")]
 public class ModuleController(IModuleContainerFactory containerFactory, IConfigManager configManager, ILoggerFactory loggerFactory)
-    : ServerModuleBase<ModuleConfig>(containerFactory, configManager, loggerFactory)
+    : ServerModuleBase<ModuleConfig>(containerFactory, configManager, loggerFactory), IFacadeContainer<IOrderIntegration>
 {
     /// <inheritdoc />
     public override string Name => "Material Mánagement - Order Integration";
@@ -46,8 +47,7 @@ public class ModuleController(IModuleContainerFactory containerFactory, IConfigM
     /// <inheritdoc />
     protected override Task OnInitializeAsync(CancellationToken cancellationToken)
     {
-        _ = Container
-            .SetInstance(OrderManagement)
+        Container.SetInstance(OrderManagement)
             .SetInstance(MaterialManagement);
 
         Container.LoadComponents<ILinkingHook>();
@@ -60,13 +60,19 @@ public class ModuleController(IModuleContainerFactory containerFactory, IConfigM
         await Container.Resolve<ILinkingHookManager>().StartAsync(cancellationToken);
         await Container.Resolve<IOrderReferencesPool>().StartAsync(cancellationToken);
         await Container.Resolve<IOrderContainerManager>().StartAsync(cancellationToken);
+        ActivateFacade(_facade);
     }
 
     /// <inheritdoc />
     protected override async Task OnStopAsync(CancellationToken cancellationToken)
     {
+        DeactivateFacade(_facade);
         await Container.Resolve<IOrderContainerManager>().StopAsync(cancellationToken);
         await Container.Resolve<IOrderReferencesPool>().StopAsync(cancellationToken);
         await Container.Resolve<ILinkingHookManager>().StopAsync(cancellationToken);
     }
+
+    private readonly OrderIntegrationFacade _facade = new();
+
+    IOrderIntegration IFacadeContainer<IOrderIntegration>.Facade => _facade;
 }

--- a/src/Moryx.Material.Integrations.Orders/IOrderIntegration.cs
+++ b/src/Moryx.Material.Integrations.Orders/IOrderIntegration.cs
@@ -1,0 +1,9 @@
+// Copyright (c) 2026 Phoenix Contact GmbH & Co. KG
+// Licensed under the Apache License, Version 2.0
+
+namespace Moryx.Material.Integrations.Orders;
+
+public interface IOrderIntegration
+{
+    IReadOnlyList<OrderReference> GetOrderReferences();
+}

--- a/src/Moryx.Material.Management/Components/InMemoryLineageEventStorage.cs
+++ b/src/Moryx.Material.Management/Components/InMemoryLineageEventStorage.cs
@@ -12,14 +12,14 @@ namespace Moryx.Material.Management.Components;
 [Component(LifeCycle.Singleton, typeof(ILineageEventStorage))]
 internal class InMemoryLineageEventStorage : ILineageEventStorage
 {
-    private readonly List<ILineageEvent> _events = new();
+    private readonly List<ILineageEvent> _events = [];
     private readonly Lock _lock = new();
 
-    public IContainerPool Pool { get; set; }
+    public required IContainerPool Pool { get; set; }
 
     public Task StartAsync(CancellationToken cancellationToken)
     {
-        Pool.StateChanged += OnContainerStateChanged;
+        // TODO: Read when lineage storage is correctly implemented Pool.StateChanged += OnContainerStateChanged;
         return Task.CompletedTask;
     }
 

--- a/src/Moryx.Material.Management/Components/MaterialFlowHandler.cs
+++ b/src/Moryx.Material.Management/Components/MaterialFlowHandler.cs
@@ -1,6 +1,7 @@
 // Copyright (c) 2026 Phoenix Contact GmbH & Co. KG
 // Licensed under the Apache License, Version 2.0
 
+using Microsoft.Extensions.Logging;
 using Moryx.AbstractionLayer.Resources;
 using Moryx.Container;
 using Moryx.Logging;
@@ -11,15 +12,24 @@ namespace Moryx.Material.Management.Components;
 [Component(LifeCycle.Singleton, typeof(IMaterialFlowHandler))]
 internal class MaterialFlowHandler : IMaterialFlowHandler, ILoggingComponent
 {
+    #region Dependencies
+#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring as nullable.
     public IModuleLogger Logger { get; set; }
 
     public IContainerPool Pool { get; set; }
 
     public IResourceManagement ResourceManagement { get; set; }
+#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring as nullable.
+    #endregion
+
+    #region Lifecycle
 
     public void Start() { }
     public void Stop() { }
 
+    #endregion
+
+    #region IMaterialFlowHandler
     public async Task<IMaterialContainer> RequestMaterialAsync(MaterialRequest request, Type targetContainerType)
     {
         request.Id ??= Guid.NewGuid().ToString();
@@ -77,17 +87,33 @@ internal class MaterialFlowHandler : IMaterialFlowHandler, ILoggingComponent
         throw new NotImplementedException();
     }
 
-    public Task<IMaterialContainer> PreAdviceMaterialAsync(IMaterialContainer container, PreAdviceDepartureReason departureReason)
+    public static Task<IMaterialContainer> PreAdviceMaterialAsync(IMaterialContainer container, PreAdviceDepartureReason departureReason, CancellationToken cancellationToken)
     {
         var outbound = new OutboundStateInformation { DepartureReason = departureReason };
+        cancellationToken.ThrowIfCancellationRequested();
         container.TransitionTo(outbound);
         return Task.FromResult(container);
     }
 
-    public Task DeregisterContainerAsync(IMaterialContainer container, CancellationToken cancellationToken = default)
+    public async Task DeregisterContainerAsync(IMaterialContainer container, CancellationToken cancellationToken = default)
+    {
+        var deregistration = new DeregisteredStateInformation();
+        cancellationToken.ThrowIfCancellationRequested();
+        container.TransitionTo(deregistration);
+        var isDeleted = await ResourceManagement.DeleteAsync(container.Id, CancellationToken.None);
+        if (!isDeleted)
+        {
+            Logger.LogWarning("Material container {id}-{name} was deregisted, but failed to be deleted from the underlying {resources}",
+                container.Id, container.Name, nameof(IResourceManagement));
+        }
+    }
+
+    public Task<IMaterialContainer> PreAdviceMaterialAsync(IMaterialContainer container, PreAdviceDepartureReason reason)
     {
         throw new NotImplementedException();
     }
 
     public event EventHandler<StateChangedEventArgs>? StateChanged;
+
+    #endregion
 }

--- a/src/Moryx.Material.Management/Facade/MaterialManagementFacade.cs
+++ b/src/Moryx.Material.Management/Facade/MaterialManagementFacade.cs
@@ -14,6 +14,8 @@ namespace Moryx.Material.Management;
 
 internal class MaterialManagementFacade : FacadeBase, IMaterialManagement
 {
+
+#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring as nullable.
     public IContainerPool Pool { get; set; }
 
     public IMaterialFlowHandler MaterialFlowHandler { get; set; }
@@ -25,6 +27,7 @@ internal class MaterialManagementFacade : FacadeBase, IMaterialManagement
     public IResourceManagement ResourceManagement { get; set; }
 
     public IResourceTypeTree ResourceTypes { get; set; }
+#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring as nullable.
 
     public override void Activate()
     {
@@ -122,10 +125,7 @@ internal class MaterialManagementFacade : FacadeBase, IMaterialManagement
     public async Task<IMaterialContainer> AnnounceMaterialAsync(MaterialAnnouncement announcement, CancellationToken cancellationToken = default)
     {
         ValidateHealthState();
-        if (announcement == null)
-        {
-            throw new ArgumentNullException(nameof(announcement));
-        }
+        ArgumentNullException.ThrowIfNull(announcement);
 
         announcement.Id ??= Guid.NewGuid().ToString();
 
@@ -188,10 +188,7 @@ internal class MaterialManagementFacade : FacadeBase, IMaterialManagement
     public async Task RegisterContainerAsync(IMaterialContainer container, CancellationToken cancellationToken = default)
     {
         ValidateHealthState();
-        if (container == null)
-        {
-            throw new ArgumentNullException(nameof(container));
-        }
+        ArgumentNullException.ThrowIfNull(container);
 
         // If a matching virtual container exists (Requested or Inbound), apply identity to it instead
         var match = Matcher.TryMatchRegistration(container);
@@ -222,7 +219,6 @@ internal class MaterialManagementFacade : FacadeBase, IMaterialManagement
         }, cancellationToken);
     }
 
-    // TODO: Should this method take the container object in the pre advice?
     public async Task<IMaterialContainer> PreAdviceMaterialAsync(MaterialPreAdvice preAdvice, CancellationToken cancellationToken = default)
     {
         ValidateHealthState();
@@ -264,16 +260,14 @@ internal class MaterialManagementFacade : FacadeBase, IMaterialManagement
 
     #region Delete
 
-    public async Task DeregisterContainerAsync(IMaterialContainer container, CancellationToken cancellationToken = default)
+    public async Task DeregisterContainerAsync(long id, CancellationToken cancellationToken = default)
     {
         ValidateHealthState();
-        if (container == null)
-        {
-            throw new ArgumentNullException(nameof(container));
-        }
+        var container = Pool.Get(id) ??
+            throw new KeyNotFoundException($"Could not find an {nameof(IMaterialContainer)} with {nameof(IPersistentObject.Id)} '{id}'");
 
         var finalQuantity = container.Quantity;
-        //await MaterialFlowHandler.TransitionAsync(container, new DeregisteredStateInformation(), cancellationToken);
+        await MaterialFlowHandler.DeregisterContainerAsync(container, cancellationToken);
         await LineageStorage.RecordAsync(new DeregisterLineageEvent
         {
             ContainerId = container.Id,
@@ -314,5 +308,5 @@ internal class MaterialManagementFacade : FacadeBase, IMaterialManagement
     #endregion
 
     private static StateInformation? GetStateInformation(IMaterialContainer container) =>
-        (container as MaterialContainer)?.StateInformation;
+    (container as MaterialContainer)?.StateInformation;
 }

--- a/src/Moryx.Material.Management/Facade/MaterialManagementFacade.cs
+++ b/src/Moryx.Material.Management/Facade/MaterialManagementFacade.cs
@@ -270,7 +270,7 @@ internal class MaterialManagementFacade : FacadeBase, IMaterialManagement
         await MaterialFlowHandler.DeregisterContainerAsync(container, cancellationToken);
         await LineageStorage.RecordAsync(new DeregisterLineageEvent
         {
-            ContainerId = container.Id,
+            ContainerId = id,
             FinalQuantity = finalQuantity
         }, cancellationToken);
     }

--- a/src/Moryx.Material/Facade/IMaterialManagement.cs
+++ b/src/Moryx.Material/Facade/IMaterialManagement.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0
 
 using Moryx.AbstractionLayer.Identity;
-using Moryx.AbstractionLayer.Resources;
 using Moryx.Material.Lineage;
 
 namespace Moryx.Material.Facade;
@@ -51,6 +50,7 @@ public interface IMaterialManagement
     /// Records a material request, creating a virtual container in <see cref="States.RequestedStateInformation"/>.
     /// </summary>
     /// <param name="request">Material request to record.</param>
+    /// <param name="targetContainerType"></param>
     /// <param name="cancellationToken">Token used to cancel the asynchronous operation.</param>
     /// <returns>The requested virtual container.</returns>
     Task<IMaterialContainer> RequestMaterialAsync(MaterialRequest request, Type targetContainerType, CancellationToken cancellationToken = default);
@@ -94,11 +94,11 @@ public interface IMaterialManagement
     Task<IMaterialContainer> PreAdviceMaterialAsync(MaterialPreAdvice preAdvice, CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Deregisters a container, transitioning it into <see cref="States.DeregisteredStateInformation"/>.
+    /// Deregisters a container using its <see cref="IPersistentObject.Id"/>, transitioning it into <see cref="States.DeregisteredStateInformation"/>.
     /// </summary>
-    /// <param name="container">Container to deregister.</param>
+    /// <param name="id">Id of the container to be deregistered</param>
     /// <param name="cancellationToken">Token used to cancel the asynchronous operation.</param>
-    Task DeregisterContainerAsync(IMaterialContainer container, CancellationToken cancellationToken = default);
+    Task DeregisterContainerAsync(long id, CancellationToken cancellationToken = default);
     #endregion
 
     // TODO: Decide whether we should map DELETE actions for container from resource facade to here

--- a/src/Moryx/Tools/Extensions/CustomAttributeProviderExtensions.cs
+++ b/src/Moryx/Tools/Extensions/CustomAttributeProviderExtensions.cs
@@ -68,7 +68,9 @@ public static class CustomAttributeProviderExtensions
             var name = attributeProvider.GetCustomAttribute<DisplayAttribute>(false)?.GetName();
 
             if (string.IsNullOrEmpty(name))
+            {
                 name = attributeProvider.GetCustomAttribute<DisplayNameAttribute>(false)?.DisplayName;
+            }
 
             return name;
         }
@@ -84,7 +86,9 @@ public static class CustomAttributeProviderExtensions
             var description = attributeProvider.GetCustomAttribute<DisplayAttribute>(false)?.GetDescription();
 
             if (string.IsNullOrEmpty(description))
+            {
                 description = attributeProvider.GetCustomAttribute<DescriptionAttribute>(false)?.Description;
+            }
 
             return description;
         }

--- a/src/Moryx/Tools/Extensions/EnumExtensions.cs
+++ b/src/Moryx/Tools/Extensions/EnumExtensions.cs
@@ -1,0 +1,96 @@
+// Copyright (c) 2026 Phoenix Contact GmbH & Co. KG
+// Licensed under the Apache License, Version 2.0
+
+using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
+using System.Globalization;
+using System.Reflection;
+
+namespace Moryx.Tools;
+
+/// <summary>
+/// Extensions for the <see cref="Enum"/>
+/// </summary>
+public static class EnumExtensions
+{
+    /// <param name="enumValue">Enum value decorated with the attribute</param>
+    extension(Enum enumValue)
+    {
+        /// <summary>
+        /// Returns the <see cref="FieldInfo"/> corresponding to the <paramref name="enumValue"/>, if it is not a Flag enum. 
+        /// Otherwise returns the <see cref="FieldInfo"/>s for each active Flag seperately.
+        /// </summary>
+        private FieldInfo[] GetFieldInfos()
+        {
+            var enumType = enumValue.GetType();
+
+            if (enumType.GetCustomAttribute<FlagsAttribute>() is null)
+            {
+                return [enumType.GetField(enumValue.ToString())];
+            }
+
+            var enumNumericValue = Convert.ToUInt64(enumValue, CultureInfo.InvariantCulture);
+            return Enum.GetValues(enumType).Cast<Enum>()
+                .Where(e => enumValue.HasFlag(e) && (Convert.ToUInt64(e, CultureInfo.InvariantCulture) != 0 || enumNumericValue == 0))
+                .Select(e => enumType.GetField(e.ToString())).ToArray();
+        }
+
+        /// <summary>
+        /// Returns the (first) custom attribute of type <typeparamref name="TAttribute"/> on this 
+        /// <paramref name="enumValue"/> or null if attribute was not found.
+        /// </summary>
+        /// <typeparam name="TAttribute">Type of the attribute</typeparam>
+        /// <param name="inherit">When true, look up the hierarchy chain for the inherited custom attribute. </param>
+        public TAttribute GetCustomAttribute<TAttribute>(bool inherit = true)
+            where TAttribute : Attribute
+        {
+            var field = GetFieldInfos(enumValue).FirstOrDefault();
+            return field?.GetCustomAttributes(typeof(TAttribute), inherit).FirstOrDefault() as TAttribute;
+        }
+
+        /// <summary>
+        /// Returns an array of attributes defined on this member or an empty array, if no attribute were found
+        /// </summary>
+        /// <typeparam name="TAttribute">Type of the attribute</typeparam>
+        /// <param name="inherit">When true, look up the hierarchy chain for the inherited custom attribute. </param>
+        public TAttribute[] GetCustomAttributes<TAttribute>(bool inherit = true)
+            where TAttribute : Attribute
+        {
+            var fields = GetFieldInfos(enumValue);
+            return fields.SelectMany(f => f.GetCustomAttributes(typeof(TAttribute), inherit)) as TAttribute[];
+        }
+
+        /// <summary>
+        /// Tries to get an attribute defining a display name on this <paramref name="enumValue"/>. If no attribute 
+        /// was found returns the type name. If multiple attributes were found, returns the first.
+        /// </summary>
+        public string GetDisplayName()
+        {
+            var name = enumValue.GetCustomAttribute<DisplayAttribute>(false)?.GetName();
+
+            if (string.IsNullOrEmpty(name))
+            {
+                name = enumValue.GetFieldInfos().FirstOrDefault().Name;
+            }
+
+            return name;
+        }
+
+        /// <summary>
+        /// Tries to get an attribute defining a description on this <paramref name="enumValue"/>. If no attribute was 
+        /// found, null will be the result.
+        /// The chain follows: <see cref="DisplayAttribute"/> and <see cref="DescriptionAttribute"/>
+        /// </summary>
+        public string GetDescription()
+        {
+            var description = enumValue.GetCustomAttribute<DisplayAttribute>(false)?.GetDescription();
+
+            if (string.IsNullOrEmpty(description))
+            {
+                description = enumValue.GetCustomAttribute<DescriptionAttribute>(false)?.Description;
+            }
+
+            return description;
+        }
+    }
+}

--- a/src/StartProject.Asp/StartProject.Asp.csproj
+++ b/src/StartProject.Asp/StartProject.Asp.csproj
@@ -23,6 +23,8 @@
     <ProjectReference Include="..\Moryx.ControlSystem.ProcessEngine\Moryx.ControlSystem.ProcessEngine.csproj" />
     <ProjectReference Include="..\Moryx.ControlSystem.Processes.Endpoints\Moryx.ControlSystem.Processes.Endpoints.csproj" />
     <ProjectReference Include="..\Moryx.ControlSystem.SetupProvider\Moryx.ControlSystem.SetupProvider.csproj" />
+    <ProjectReference Include="..\Moryx.Material.Endpoints\Moryx.Material.Endpoints.csproj" />
+    <ProjectReference Include="..\Moryx.Material.Management\Moryx.Material.Management.csproj" />
     <ProjectReference Include="..\Moryx.Material\Moryx.Material.csproj" />
     <ProjectReference Include="..\Moryx.Resources.Benchmarking\Moryx.Resources.Benchmarking.csproj" />
     <ProjectReference Include="..\Moryx.Resources.BenchmarkSetup\Moryx.Benchmarking.Setups.csproj" />

--- a/src/Tests/Moryx.Material.IntegrationTests/MaterialManagementFacadeTests.cs
+++ b/src/Tests/Moryx.Material.IntegrationTests/MaterialManagementFacadeTests.cs
@@ -4,7 +4,6 @@
 using Moq;
 using Moryx.AbstractionLayer.Identity;
 using Moryx.AbstractionLayer.Resources;
-using Moryx.Material.Lineage;
 using Moryx.Material.States;
 using NUnit.Framework;
 
@@ -133,9 +132,38 @@ internal sealed class MaterialManagementFacadeTests : TestBase
     }
 
     [Test]
-    public void DeregisterContainerAsync_WithContainer_DeregistersContainer()
+    public async Task DeregisterContainerAsync_WithExistingContainer_TransitionsContainerIntoDeregisteredState()
     {
-        Assert.Ignore("Test stub for IMaterialManagement.DeregisterContainerAsync(IMaterialContainer, CancellationToken).");
+        // Arrange
+        const long containerId = 42L;
+        var container = CreateAvailableDummyMaterialContainer(containerId);
+        _resourceManagementMock.Setup(r => r.DeleteAsync(containerId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+        _resourceManagementMock.Raise(m => m.ResourceAdded += It.IsAny<EventHandler<IResource>>(), this, container);
+        var expectedFinalQuantity = container.Quantity;
+
+        // Act
+        await _materialManagement.DeregisterContainerAsync(containerId);
+
+        // Assert
+        var deregisteredStateInformation = container.StateInformation as DeregisteredStateInformation;
+        Assert.Multiple(() =>
+        {
+            Assert.That(container.State, Is.EqualTo(StateClassification.Deregistered));
+            Assert.That(deregisteredStateInformation, Is.Not.Null);
+        });
+        _resourceManagementMock.Verify(r => r.DeleteAsync(containerId, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Test]
+    public void DeregisterContainerAsync_WithUnknownContainerId_ThrowsKeyNotFound()
+    {
+        // Arrange
+        const long unknownContainerId = 999L;
+
+        // Act & Assert
+        Assert.That(async () => await _materialManagement.DeregisterContainerAsync(unknownContainerId),
+            Throws.TypeOf<KeyNotFoundException>(), "Deregistering an unknown container id should throw KeyNotFoundException");
     }
 
     [Test]

--- a/src/Tests/Moryx.Material.Integrations.Orders.Integrator.Tests/OrderIntegrationTests.cs
+++ b/src/Tests/Moryx.Material.Integrations.Orders.Integrator.Tests/OrderIntegrationTests.cs
@@ -31,6 +31,7 @@ internal sealed class OrderIntegrationTests
     private Mock<IMaterialManagement> _materialManagement = null!;
     private Mock<IOrderManagement> _orderManagement = null!;
     private MoryxTestEnvironment _env = null!;
+    private IOrderIntegration _orderIntegration = null!; // ToDo: Remove null!
 
     [SetUp]
     public async Task SetUp()
@@ -39,20 +40,16 @@ internal sealed class OrderIntegrationTests
         _containers.Clear();
         _operations.Clear();
 
-        _materialManagement = MoryxTestEnvironment.CreateModuleMock<IMaterialManagement>();
-        _orderManagement = MoryxTestEnvironment.CreateModuleMock<IOrderManagement>();
         SetupMaterialManagementMock();
         SetupOrderManagementMock();
+        await SetupEnvironment();
 
-        var config = new IntegratorModuleConfig();
-        config.Initialize();
-        _env = new MoryxTestEnvironment(typeof(IntegratorModuleController), [_materialManagement, _orderManagement], config);
-
-        await _env.StartTestModuleAsync();
+        _orderIntegration = _env.GetTestModule<IOrderIntegration>();
     }
 
     private void SetupMaterialManagementMock()
     {
+        _materialManagement = MoryxTestEnvironment.CreateModuleMock<IMaterialManagement>();
         _materialManagement.Setup(m => m.GetContainers()).Returns([.. _containers]);
         _materialManagement.Setup(m => m.GetContainers(It.IsAny<Func<IMaterialContainer, bool>>()))
             .Returns((Func<IMaterialContainer, bool> filter) => [.. _containers.Where(filter)]);
@@ -60,11 +57,21 @@ internal sealed class OrderIntegrationTests
 
     private void SetupOrderManagementMock()
     {
+        _orderManagement = MoryxTestEnvironment.CreateModuleMock<IOrderManagement>();
         _orderManagement.Setup(m => m.GetOperations(It.IsAny<Func<Operation, bool>>()))
             .Returns((Func<Operation, bool> filter) => [.. _operations.Where(filter)]);
         _orderManagement.Setup(m => m.LoadOperationAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((string orderNumber, string operationNumber, CancellationToken _) =>
                 _operations.SingleOrDefault(o => o.Order.Number == orderNumber && o.Number == operationNumber));
+    }
+
+    private async Task SetupEnvironment()
+    {
+        var config = new IntegratorModuleConfig();
+        config.Initialize();
+        _env = new MoryxTestEnvironment(typeof(IntegratorModuleController), [_materialManagement, _orderManagement], config);
+
+        await _env.StartTestModuleAsync();
     }
 
     [TearDown]
@@ -77,7 +84,7 @@ internal sealed class OrderIntegrationTests
         var originalReference = new OrderReference(OrderNumber, OperationNumber);
         var container = await CreateAndAddContainer(originalReference);
         var operation = CreateAndAddOperation(OrderNumber, OperationNumber, OperationStateClassification.Ready);
-        
+
         // Act
         await RestartModuleAsync();
 
@@ -100,7 +107,7 @@ internal sealed class OrderIntegrationTests
         var originalReference = new OrderReference("UNKNOWN-ORDER", "9999");
         var container = await CreateAndAddContainer(originalReference);
         var operation = CreateAndAddOperation(OrderNumber, OperationNumber, OperationStateClassification.Ready);
-        
+
         // Act
         await RestartModuleAsync();
 
@@ -204,6 +211,25 @@ internal sealed class OrderIntegrationTests
         });
     }
 
+    [Test]
+    public async Task GetOrderReferences_WithRunningOperation_ReturnsReferences()
+    {
+        // Arrange
+        var operation = CreateAndAddOperation(OrderNumber, OperationNumber, OperationStateClassification.Ready);
+        RaiseOperationUpdatedToRunning(operation);
+
+        // Act
+        var references = _orderIntegration.GetOrderReferences();
+
+        // Assert
+        Assert.Multiple(() =>
+        {
+            Assert.That(references, Has.Count.EqualTo(1));
+            Assert.That(references.Single().OrderNumber, Is.EqualTo(OrderNumber));
+            Assert.That(references.Single().OperationNumber, Is.EqualTo(OperationNumber));
+        });
+    }
+
     private async Task RestartModuleAsync()
     {
         await _env.StopTestModuleAsync();
@@ -225,7 +251,7 @@ internal sealed class OrderIntegrationTests
         return container;
     }
 
-    private Operation CreateAndAddOperation(string orderNumber, string operationNumber, OperationStateClassification state)
+    private MockOperation CreateAndAddOperation(string orderNumber, string operationNumber, OperationStateClassification state)
     {
         var order = new MockOrder(orderNumber);
         var operation = new MockOperation(order, operationNumber, state);

--- a/src/Tests/Moryx.Tests/Extensions/CustomAttributeProviderExtensionTests.cs
+++ b/src/Tests/Moryx.Tests/Extensions/CustomAttributeProviderExtensionTests.cs
@@ -2,28 +2,28 @@
 // Licensed under the Apache License, Version 2.0
 
 using System;
-using NUnit.Framework;
 using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
 using System.Reflection;
 using Moryx.Tools;
-using System.ComponentModel.DataAnnotations;
+using NUnit.Framework;
 
 namespace Moryx.Tests.Extensions;
 
-internal class TestConstants
+file class TestConstants
 {
     public const string ClassDisplayName = "Some Display Name";
     public const string ClassDescription = "Some Description";
 }
 
 [Display(Name = TestConstants.ClassDisplayName, Description = TestConstants.ClassDescription)]
-internal class ClassDisplayAttributeDummy
+file class ClassDisplayAttributeDummy
 {
 }
 
 [DisplayName(TestConstants.ClassDisplayName)]
 [System.ComponentModel.Description(TestConstants.ClassDescription)]
-internal class DotnetAttributesDummy
+file class DotnetAttributesDummy
 {
 }
 

--- a/src/Tests/Moryx.Tests/Extensions/EnumExtensionTests.cs
+++ b/src/Tests/Moryx.Tests/Extensions/EnumExtensionTests.cs
@@ -1,0 +1,169 @@
+// Copyright (c) 2026 Phoenix Contact GmbH & Co. KG
+// Licensed under the Apache License, Version 2.0
+
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.Reflection;
+using Moryx.Tools;
+using NUnit.Framework;
+
+namespace Moryx.Tests.Extensions;
+
+file class TestConstants
+{
+    public const string EnumDisplayName = "Some Display Name";
+    public const string EnumDescription = "Some Description";
+}
+
+file enum DisplayAttributeEnum
+{
+    [Display(Name = TestConstants.EnumDisplayName, Description = TestConstants.EnumDescription)]
+    Decorated,
+
+    Undecorated
+}
+
+file enum DescriptionAttributeEnum
+{
+    [System.ComponentModel.Description(TestConstants.EnumDescription)]
+    Decorated,
+
+    Undecorated
+}
+
+[Flags]
+file enum FlagsDummyEnum
+{
+    [Display(Name = "None")]
+    None = 0,
+
+    [Display(Name = "Alpha")]
+    Alpha = 1,
+
+    [Display(Name = "Beta")]
+    Beta = 2,
+
+    [Display(Name = "Gamma")]
+    Gamma = 4
+}
+
+[TestFixture]
+public class EnumExtensionTests
+{
+    [Test(Description = "Returns the display name from the Display attribute")]
+    public void GetDisplayNameFromAttribute()
+    {
+        // Arrange
+        var value = DisplayAttributeEnum.Decorated;
+
+        // Act
+        var displayName = value.GetDisplayName();
+
+        // Assert
+        Assert.That(displayName, Is.EqualTo(TestConstants.EnumDisplayName));
+    }
+
+    [Test(Description = "Falls back to the field name when no display attribute is present")]
+    public void GetDisplayNameFallsBackToFieldName()
+    {
+        // Arrange
+        var value = DisplayAttributeEnum.Undecorated;
+
+        // Act
+        var displayName = value.GetDisplayName();
+
+        // Assert
+        Assert.That(displayName, Is.EqualTo(nameof(DisplayAttributeEnum.Undecorated)));
+    }
+
+    [Description("Returns the description from Display or Description attribute")]
+    [TestCase(DisplayAttributeEnum.Decorated)]
+    [TestCase(DescriptionAttributeEnum.Decorated)]
+    public void GetDescriptionFromAttribute(Enum value)
+    {
+        // Act
+        var description = value.GetDescription();
+
+        // Assert
+        Assert.That(description, Is.EqualTo(TestConstants.EnumDescription));
+    }
+
+    [Test(Description = "Returns null when no description attribute is present")]
+    public void GetDescriptionReturnsNullWhenMissing()
+    {
+        // Arrange
+        var value = DisplayAttributeEnum.Undecorated;
+
+        // Act
+        var description = value.GetDescription();
+
+        // Assert
+        Assert.That(description, Is.Null);
+    }
+
+    [Test]
+    public void GetValidCustomAttribute()
+    {
+        // Arrange
+        var value = DescriptionAttributeEnum.Decorated;
+
+        // Act
+        var attr = value.GetCustomAttribute<System.ComponentModel.DescriptionAttribute>();
+
+        // Assert
+        Assert.That(attr, Is.Not.Null);
+        Assert.That(attr.Description, Is.EqualTo(TestConstants.EnumDescription));
+    }
+
+    [Test]
+    public void GetInvalidCustomAttribute()
+    {
+        // Arrange
+        var value = DescriptionAttributeEnum.Decorated;
+
+        // Act
+        var attr = value.GetCustomAttribute<AssemblyTitleAttribute>();
+
+        // Assert
+        Assert.That(attr, Is.Null);
+    }
+
+    [Test(Description = "Returns null when requesting a custom attribute on an undecorated enum value")]
+    public void GetCustomAttributeReturnsNullOnUndecoratedValue()
+    {
+        // Arrange
+        var value = DisplayAttributeEnum.Undecorated;
+
+        // Act
+        var attr = value.GetCustomAttribute<DisplayAttribute>();
+
+        // Assert
+        Assert.That(attr, Is.Null);
+    }
+
+    [Test(Description = "Retrieves the display name for a single flag value in a Flags enum")]
+    public void GetDisplayNameForSingleFlag()
+    {
+        // Arrange
+        var value = FlagsDummyEnum.Alpha;
+
+        // Act
+        var displayName = value.GetDisplayName();
+
+        // Assert
+        Assert.That(displayName, Is.EqualTo("Alpha"));
+    }
+
+    [Test(Description = "Retrieves the display name of the zero-valued flag when the enum value itself is zero")]
+    public void GetDisplayNameForZeroFlag()
+    {
+        // Arrange
+        var value = FlagsDummyEnum.None;
+
+        // Act
+        var displayName = value.GetDisplayName();
+
+        // Assert
+        Assert.That(displayName, Is.EqualTo("None"));
+    }
+}


### PR DESCRIPTION
This PR is stacked onto #1434

[Add enum extensions](https://github.com/PHOENIXCONTACT/MORYX-Framework/commit/f988135b284a904263478a37878aa75f9b092764) 

Adds extension methods to retireve custom attributes for enum values, especially for display name and description. This works similar to the extensions on `ICustomAttributeProvider` that already exist.

_NOTE:_ This commit is facilitating a cleaner implementation but should actually be moved to the dev branch before the whole material management feature is done.

___

[Added a controller action to retrieve all held order references](https://github.com/PHOENIXCONTACT/MORYX-Framework/commit/6f827c88e210e0cde8f473303c3312274dba2e38) 

- Adds the controller action seperated on a dedicated region
- Adds a controller action allowing to check whether an order integration is available in the system
- Adds a facade to the order integration module to retrieve the information
- Adds required setup in the module controller and components