### PR TITLE
Support DateOnly, TimeOnly, DateTime, TimeSpan, DateTimeOffset and some structs in EntryConvert

### DIFF
--- a/docs/articles/framework/Serialization/entry-convert.md
+++ b/docs/articles/framework/Serialization/entry-convert.md
@@ -17,7 +17,7 @@ The `EntryConvert` API can convert objects and types as long as they comply with
 
 * Properties not fields: All attributes of a type must be defined as properties, not public fields. Therefor `public int Foo { get; set; }` instead of `public int Foo;`
 * Public parameter-less constructor: All types within the class hierarchy need to offer a public constructor without parameters. In Generics this would be defined as `new()` or in code `public Foo() { }`. For the root object `EntryConvert` can extract Constructors as `MethodEntry`, which can be exchanged with a client and used to create instances.
-* Primitives, classes or supported structs: The reflection approach used to deserialize the entry tree to objects requires reference access. Otherwise the modifications will only take part on a copy. Therefor properties need to be either of a primitive type like int, string, enum, a class, or a supported struct (`Vector2`, `Vector3`, `Quaternion`). Supported structs are automatically decomposed into editable sub-entries.
+* Primitives, classes or supported structs: The reflection approach used to deserialize the entry tree to objects requires reference access. Otherwise the modifications will only take part on a copy. Therefor properties need to be either of a primitive type like int, string, enum, a class, or a supported struct (`Vector2`, `Vector3`, `Vector4`, `Quaternion`, `Plane`). Supported structs are automatically decomposed into editable sub-entries.
 * Dictionaries of `<Primitive, Class`: Dictionaries are only supported if the key is a primitive type like `int` or `string` and the value is a class.
 
 ## Serialize Objects
@@ -143,7 +143,7 @@ public void Deserialize(Entry entry, FileStreamDummy dummy)
 
 ## Serialize Structs
 
-`EntryConvert` supports decomposed serialization for the following `System.Numerics` struct types: `Vector2`, `Vector3` and `Quaternion`. Instead of displaying unparseable strings like `<1.5, 2.5, 3.5>`, these structs are encoded as `Struct` entries with editable sub-entries for each component (X, Y, Z, W). When you serialize a class containing one of these types, the resulting entry will have sub-entries for each component of the struct.
+`EntryConvert` supports decomposed serialization for the following `System.Numerics` struct types: `Vector2`, `Vector3`, `Vector4`, `Quaternion` and `Plane`. Instead of displaying unparseable strings like `<1.5, 2.5, 3.5>`, these structs are encoded as `Struct` entries with editable sub-entries for each component (X, Y, Z, W). When you serialize a class containing one of these types, the resulting entry will have sub-entries for each component of the struct.
 
 ````cs
 public class RobotPosition

--- a/docs/articles/framework/Serialization/entry-convert.md
+++ b/docs/articles/framework/Serialization/entry-convert.md
@@ -11,6 +11,33 @@ Because the `EntryConvert`-API can be confusing on first sight, we will split it
 * **Deserialize:** The encoded entry tree can be converted into objects after modification by the client with the overloads of `CreateInstance` and `UpdateInstance`
 * **Customization:** The behavior of both encoding and decoding can be customized to specific needs by providing a strategy implementing `ICustomSerialization`
 
+## Supported Types
+
+| .NET Type | EntryValueType | Format | Limitations |
+|-----------|---------------|--------|-------------|
+| `byte` | Byte | — | — |
+| `bool` | Boolean | — | — |
+| `short`, `ushort` | Int16, UInt16 | — | — |
+| `int`, `uint` | Int32, UInt32 | — | — |
+| `long`, `ulong` | Int64, UInt64 | — | — |
+| `float` | Single | Culture-aware with invariant fallback | — |
+| `double` | Double | Culture-aware with invariant fallback | — |
+| `decimal` | Double | Culture-aware with invariant fallback | Mapped to `Double; may lose precision beyond ~15 significant digits |
+| `string` | String | — | — |
+| `enum` | Enum | String name | — |
+| `DateTime` | DateTime | ISO 8601 round-trip (`"O"`) | Converted to UTC; original `DateTimeKind` is lost |
+| `DateTimeOffset` | DateTime | ISO 8601 round-trip (`"O"`) | Converted to UTC; original timezone offset is lost |
+| `DateOnly` | Date | ISO 8601 round-trip (`"O"`) | — |
+| `TimeOnly` | Time | ISO 8601 round-trip (`"O"`) | — |
+| `TimeSpan` | TimeSpan | Constant format (`"c"`) | — |
+| `Stream` | Stream | Base64 encoded | Limited by available memory |
+| `Vector2`, `Vector3`, `Vector4` | Struct | Decomposed into sub-entries (X, Y, Z, W) | — |
+| `Quaternion` | Struct | Decomposed into sub-entries (X, Y, Z, W) | — |
+| `Plane` | Struct | Decomposed into sub-entries (X, Y, Z, D) | — |
+| Classes | Class | Recursive sub-entries | Requires public parameter-less constructor |
+| Collections | Collection | Recursive sub-entries | — |
+| Dictionaries | Collection | Recursive sub-entries | Key must be a type supported by `ToObject` |
+
 ## Limitations
 
 The `EntryConvert` API can convert objects and types as long as they comply with a few basic rules:
@@ -18,7 +45,7 @@ The `EntryConvert` API can convert objects and types as long as they comply with
 * Properties not fields: All attributes of a type must be defined as properties, not public fields. Therefor `public int Foo { get; set; }` instead of `public int Foo;`
 * Public parameter-less constructor: All types within the class hierarchy need to offer a public constructor without parameters. In Generics this would be defined as `new()` or in code `public Foo() { }`. For the root object `EntryConvert` can extract Constructors as `MethodEntry`, which can be exchanged with a client and used to create instances.
 * Primitives, classes or supported structs: The reflection approach used to deserialize the entry tree to objects requires reference access. Otherwise the modifications will only take part on a copy. Therefor properties need to be either of a primitive type like int, string, enum, a class, or a supported struct (`Vector2`, `Vector3`, `Vector4`, `Quaternion`, `Plane`). Supported structs are automatically decomposed into editable sub-entries.
-* Dictionaries of `<Primitive, Class`: Dictionaries are only supported if the key is a primitive type like `int` or `string` and the value is a class.
+* Dictionary keys: Dictionary keys must be a type supported by `ToObject`, i.e. any type that can be converted to and from a string representation.
 
 ## Serialize Objects
 

--- a/docs/articles/framework/Serialization/entry-convert.md
+++ b/docs/articles/framework/Serialization/entry-convert.md
@@ -16,7 +16,7 @@ Because the `EntryConvert`-API can be confusing on first sight, we will split it
 The `EntryConvert` API can convert objects and types as long as they comply with a few basic rules:
 
 * Properties not fields: All attributes of a type must be defined as properties, not public fields. Therefor `public int Foo { get; set; }` instead of `public int Foo;`
-* Public parameter-less constructor: All types within the class hierarchy need to offer a public constructor without parameters. In Generics this would be defined as `new()` or in code `public Foo() { }`. For the root object `EntryConvert` can extract Constructors as `MethodEntry`, which can be exchanged with a client and used to create instances. 
+* Public parameter-less constructor: All types within the class hierarchy need to offer a public constructor without parameters. In Generics this would be defined as `new()` or in code `public Foo() { }`. For the root object `EntryConvert` can extract Constructors as `MethodEntry`, which can be exchanged with a client and used to create instances.
 * Primitives, classes or supported structs: The reflection approach used to deserialize the entry tree to objects requires reference access. Otherwise the modifications will only take part on a copy. Therefor properties need to be either of a primitive type like int, string, enum, a class, or a supported struct (`Vector2`, `Vector3`, `Quaternion`). Supported structs are automatically decomposed into editable sub-entries.
 * Dictionaries of `<Primitive, Class`: Dictionaries are only supported if the key is a primitive type like `int` or `string` and the value is a class.
 
@@ -143,7 +143,7 @@ public void Deserialize(Entry entry, FileStreamDummy dummy)
 
 ## Serialize Structs
 
-`EntryConvert` supports decomposed serialization for the following `System.Numerics` struct types: `Vector2`, `Vector3` and `Quaternion`. Instead of displaying unparseable strings like `<1.5, 2.5, 3.5>`, these structs are encoded as `Struct` entries with editable sub-entries for each component (X, Y, Z, W). The UI renders them as expandable entries with individual number fields — no UI changes required.
+`EntryConvert` supports decomposed serialization for the following `System.Numerics` struct types: `Vector2`, `Vector3` and `Quaternion`. Instead of displaying unparseable strings like `<1.5, 2.5, 3.5>`, these structs are encoded as `Struct` entries with editable sub-entries for each component (X, Y, Z, W). When you serialize a class containing one of these types, the resulting entry will have sub-entries for each component of the struct.
 
 ````cs
 public class RobotPosition

--- a/docs/articles/framework/Serialization/entry-convert.md
+++ b/docs/articles/framework/Serialization/entry-convert.md
@@ -17,7 +17,7 @@ The `EntryConvert` API can convert objects and types as long as they comply with
 
 * Properties not fields: All attributes of a type must be defined as properties, not public fields. Therefor `public int Foo { get; set; }` instead of `public int Foo;`
 * Public parameter-less constructor: All types within the class hierarchy need to offer a public constructor without parameters. In Generics this would be defined as `new()` or in code `public Foo() { }`. For the root object `EntryConvert` can extract Constructors as `MethodEntry`, which can be exchanged with a client and used to create instances. 
-* Primitives or classes: The reflection approach used to deserialize the entry tree to objects requires reference access. Otherwise the modifications will only take part on a copy. Therefor properties need to be either of a primitive type like int, string, enum or a another class.
+* Primitives, classes or supported structs: The reflection approach used to deserialize the entry tree to objects requires reference access. Otherwise the modifications will only take part on a copy. Therefor properties need to be either of a primitive type like int, string, enum, a class, or a supported struct (`Vector2`, `Vector3`, `Quaternion`). Supported structs are automatically decomposed into editable sub-entries.
 * Dictionaries of `<Primitive, Class`: Dictionaries are only supported if the key is a primitive type like `int` or `string` and the value is a class.
 
 ## Serialize Objects
@@ -138,6 +138,37 @@ public void Deserialize(Entry entry, FileStreamDummy dummy)
 {
     // Apply entry data
     EntryConvert.UpdateInstance(dummy, entry);
+}
+````
+
+## Serialize Structs
+
+`EntryConvert` supports decomposed serialization for the following `System.Numerics` struct types: `Vector2`, `Vector3` and `Quaternion`. Instead of displaying unparseable strings like `<1.5, 2.5, 3.5>`, these structs are encoded as `Struct` entries with editable sub-entries for each component (X, Y, Z, W). The UI renders them as expandable entries with individual number fields — no UI changes required.
+
+````cs
+public class RobotPosition
+{
+    public Vector3 Position { get; set; }
+    public Quaternion Orientation { get; set; }
+}
+
+public void Serialize()
+{
+    var pos = new RobotPosition
+    {
+        Position = new Vector3(1.5f, 2.5f, 3.5f),
+        Orientation = new Quaternion(0, 0, 0, 1)
+    };
+    var entry = EntryConvert.EncodeObject(pos);
+    // entry.SubEntries[0] (Position) has SubEntries: X=1.5, Y=2.5, Z=3.5
+    // entry.SubEntries[1] (Orientation) has SubEntries: X=0, Y=0, Z=0, W=1
+}
+
+public void Deserialize(Entry entry)
+{
+    var pos = new RobotPosition();
+    EntryConvert.UpdateInstance(pos, entry);
+    // pos.Position and pos.Orientation are reconstructed from sub-entry values
 }
 ````
 

--- a/src/Moryx.ControlSystem.ProcessEngine.Web/app/package-lock.json
+++ b/src/Moryx.ControlSystem.ProcessEngine.Web/app/package-lock.json
@@ -18,7 +18,7 @@
         "@angular/platform-browser-dynamic": "^22.0.0",
         "@angular/router": "^22.0.0",
         "@fontsource/roboto": "^5.2.9",
-        "@moryx/ngx-web-framework": "^22.2.0",
+        "@moryx/ngx-web-framework": "^22.3.0",
         "@ngx-translate/core": "^18.0.0",
         "@ngx-translate/http-loader": "^18.0.0",
         "material-symbols": "^0.45.1",
@@ -2302,9 +2302,9 @@
       }
     },
     "node_modules/@moryx/ngx-web-framework": {
-      "version": "22.2.0",
-      "resolved": "https://www.myget.org/F/moryx-ci/auth/4cd70c3b-c8e8-4186-8c35-3d4c8789bbdd/npm/@moryx/ngx-web-framework/-/@moryx/ngx-web-framework-22.2.0.tgz",
-      "integrity": "sha1-7NL4hk7/4ESw0dV3O61tl7Wl7lM=",
+      "version": "22.3.0",
+      "resolved": "https://www.myget.org/F/moryx-ci/auth/4cd70c3b-c8e8-4186-8c35-3d4c8789bbdd/npm/@moryx/ngx-web-framework/-/@moryx/ngx-web-framework-22.3.0.tgz",
+      "integrity": "sha1-t8d/0QGLyshteh8jeqgbjHyCKAE=",
       "dependencies": {
         "tslib": "^2.3.0"
       },

--- a/src/Moryx.ControlSystem.ProcessEngine.Web/app/package.json
+++ b/src/Moryx.ControlSystem.ProcessEngine.Web/app/package.json
@@ -23,7 +23,7 @@
     "@angular/platform-browser-dynamic": "^22.0.0",
     "@angular/router": "^22.0.0",
     "@fontsource/roboto": "^5.2.9",
-    "@moryx/ngx-web-framework": "^22.2.0",
+    "@moryx/ngx-web-framework": "^22.3.0",
     "@ngx-translate/core": "^18.0.0",
     "@ngx-translate/http-loader": "^18.0.0",
     "material-symbols": "^0.45.1",

--- a/src/Moryx.FactoryMonitor.Web/app/package-lock.json
+++ b/src/Moryx.FactoryMonitor.Web/app/package-lock.json
@@ -17,7 +17,7 @@
         "@angular/platform-browser-dynamic": "^22.0.0",
         "@angular/router": "^22.0.0",
         "@fontsource/roboto": "^5.2.9",
-        "@moryx/ngx-web-framework": "^22.2.0",
+        "@moryx/ngx-web-framework": "^22.3.0",
         "@ngx-translate/core": "^18.0.0",
         "@ngx-translate/http-loader": "^18.0.0",
         "material-symbols": "^0.45.1",
@@ -2302,9 +2302,9 @@
       }
     },
     "node_modules/@moryx/ngx-web-framework": {
-      "version": "22.2.0",
-      "resolved": "https://www.myget.org/F/moryx-ci/auth/4cd70c3b-c8e8-4186-8c35-3d4c8789bbdd/npm/@moryx/ngx-web-framework/-/@moryx/ngx-web-framework-22.2.0.tgz",
-      "integrity": "sha1-7NL4hk7/4ESw0dV3O61tl7Wl7lM=",
+      "version": "22.3.0",
+      "resolved": "https://www.myget.org/F/moryx-ci/auth/4cd70c3b-c8e8-4186-8c35-3d4c8789bbdd/npm/@moryx/ngx-web-framework/-/@moryx/ngx-web-framework-22.3.0.tgz",
+      "integrity": "sha1-t8d/0QGLyshteh8jeqgbjHyCKAE=",
       "dependencies": {
         "tslib": "^2.3.0"
       },

--- a/src/Moryx.FactoryMonitor.Web/app/package.json
+++ b/src/Moryx.FactoryMonitor.Web/app/package.json
@@ -22,7 +22,7 @@
     "@angular/platform-browser-dynamic": "^22.0.0",
     "@angular/router": "^22.0.0",
     "@fontsource/roboto": "^5.2.9",
-    "@moryx/ngx-web-framework": "^22.2.0",
+    "@moryx/ngx-web-framework": "^22.3.0",
     "@ngx-translate/core": "^18.0.0",
     "@ngx-translate/http-loader": "^18.0.0",
     "material-symbols": "^0.45.1",

--- a/src/Moryx.Launcher/app/package-lock.json
+++ b/src/Moryx.Launcher/app/package-lock.json
@@ -18,7 +18,7 @@
         "@angular/platform-browser": "^22.0.0",
         "@angular/router": "^22.0.0",
         "@fontsource/roboto": "^5.2.10",
-        "@moryx/ngx-web-framework": "^22.2.0",
+        "@moryx/ngx-web-framework": "^22.3.0",
         "@ngx-translate/core": "^18.0.0",
         "@ngx-translate/http-loader": "^18.0.0",
         "material-symbols": "^0.45.1",
@@ -2300,9 +2300,9 @@
       }
     },
     "node_modules/@moryx/ngx-web-framework": {
-      "version": "22.2.0",
-      "resolved": "https://www.myget.org/F/moryx-ci/auth/4cd70c3b-c8e8-4186-8c35-3d4c8789bbdd/npm/@moryx/ngx-web-framework/-/@moryx/ngx-web-framework-22.2.0.tgz",
-      "integrity": "sha1-7NL4hk7/4ESw0dV3O61tl7Wl7lM=",
+      "version": "22.3.0",
+      "resolved": "https://www.myget.org/F/moryx-ci/auth/4cd70c3b-c8e8-4186-8c35-3d4c8789bbdd/npm/@moryx/ngx-web-framework/-/@moryx/ngx-web-framework-22.3.0.tgz",
+      "integrity": "sha1-t8d/0QGLyshteh8jeqgbjHyCKAE=",
       "dependencies": {
         "tslib": "^2.3.0"
       },

--- a/src/Moryx.Launcher/app/package.json
+++ b/src/Moryx.Launcher/app/package.json
@@ -24,7 +24,7 @@
     "@angular/platform-browser": "^22.0.0",
     "@angular/router": "^22.0.0",
     "@fontsource/roboto": "^5.2.10",
-    "@moryx/ngx-web-framework": "^22.2.0",
+    "@moryx/ngx-web-framework": "^22.3.0",
     "@ngx-translate/core": "^18.0.0",
     "@ngx-translate/http-loader": "^18.0.0",
     "material-symbols": "^0.45.1",

--- a/src/Moryx.Media.Web/app/package-lock.json
+++ b/src/Moryx.Media.Web/app/package-lock.json
@@ -18,7 +18,7 @@
         "@angular/platform-browser-dynamic": "^22.0.0",
         "@angular/router": "^22.0.0",
         "@fontsource/roboto": "^5.2.9",
-        "@moryx/ngx-web-framework": "^22.2.0",
+        "@moryx/ngx-web-framework": "^22.3.0",
         "@ngx-translate/core": "^18.0.0",
         "@ngx-translate/http-loader": "^18.0.0",
         "material-symbols": "^0.45.1",
@@ -2303,9 +2303,9 @@
       }
     },
     "node_modules/@moryx/ngx-web-framework": {
-      "version": "22.2.0",
-      "resolved": "https://www.myget.org/F/moryx-ci/auth/4cd70c3b-c8e8-4186-8c35-3d4c8789bbdd/npm/@moryx/ngx-web-framework/-/@moryx/ngx-web-framework-22.2.0.tgz",
-      "integrity": "sha1-7NL4hk7/4ESw0dV3O61tl7Wl7lM=",
+      "version": "22.3.0",
+      "resolved": "https://www.myget.org/F/moryx-ci/auth/4cd70c3b-c8e8-4186-8c35-3d4c8789bbdd/npm/@moryx/ngx-web-framework/-/@moryx/ngx-web-framework-22.3.0.tgz",
+      "integrity": "sha1-t8d/0QGLyshteh8jeqgbjHyCKAE=",
       "dependencies": {
         "tslib": "^2.3.0"
       },

--- a/src/Moryx.Media.Web/app/package.json
+++ b/src/Moryx.Media.Web/app/package.json
@@ -23,7 +23,7 @@
     "@angular/platform-browser-dynamic": "^22.0.0",
     "@angular/router": "^22.0.0",
     "@fontsource/roboto": "^5.2.9",
-    "@moryx/ngx-web-framework": "^22.2.0",
+    "@moryx/ngx-web-framework": "^22.3.0",
     "@ngx-translate/core": "^18.0.0",
     "@ngx-translate/http-loader": "^18.0.0",
     "material-symbols": "^0.45.1",

--- a/src/Moryx.Notifications.Web/app/package-lock.json
+++ b/src/Moryx.Notifications.Web/app/package-lock.json
@@ -18,7 +18,7 @@
         "@angular/platform-browser-dynamic": "^22.0.0",
         "@angular/router": "^22.0.0",
         "@fontsource/roboto": "^5.2.9",
-        "@moryx/ngx-web-framework": "^22.2.0",
+        "@moryx/ngx-web-framework": "^22.3.0",
         "@ngx-translate/core": "^18.0.0",
         "@ngx-translate/http-loader": "^18.0.0",
         "material-symbols": "^0.45.1",
@@ -2303,9 +2303,9 @@
       }
     },
     "node_modules/@moryx/ngx-web-framework": {
-      "version": "22.2.0",
-      "resolved": "https://www.myget.org/F/moryx-ci/auth/4cd70c3b-c8e8-4186-8c35-3d4c8789bbdd/npm/@moryx/ngx-web-framework/-/@moryx/ngx-web-framework-22.2.0.tgz",
-      "integrity": "sha1-7NL4hk7/4ESw0dV3O61tl7Wl7lM=",
+      "version": "22.3.0",
+      "resolved": "https://www.myget.org/F/moryx-ci/auth/4cd70c3b-c8e8-4186-8c35-3d4c8789bbdd/npm/@moryx/ngx-web-framework/-/@moryx/ngx-web-framework-22.3.0.tgz",
+      "integrity": "sha1-t8d/0QGLyshteh8jeqgbjHyCKAE=",
       "dependencies": {
         "tslib": "^2.3.0"
       },

--- a/src/Moryx.Notifications.Web/app/package.json
+++ b/src/Moryx.Notifications.Web/app/package.json
@@ -23,7 +23,7 @@
     "@angular/platform-browser-dynamic": "^22.0.0",
     "@angular/router": "^22.0.0",
     "@fontsource/roboto": "^5.2.9",
-    "@moryx/ngx-web-framework": "^22.2.0",
+    "@moryx/ngx-web-framework": "^22.3.0",
     "@ngx-translate/core": "^18.0.0",
     "@ngx-translate/http-loader": "^18.0.0",
     "material-symbols": "^0.45.1",

--- a/src/Moryx.Operators.Web/app/package-lock.json
+++ b/src/Moryx.Operators.Web/app/package-lock.json
@@ -18,7 +18,7 @@
         "@angular/platform-browser-dynamic": "^22.0.0",
         "@angular/router": "^22.0.0",
         "@fontsource/roboto": "^5.2.9",
-        "@moryx/ngx-web-framework": "^22.2.0",
+        "@moryx/ngx-web-framework": "^22.3.0",
         "@ngx-translate/core": "^18.0.0",
         "@ngx-translate/http-loader": "^18.0.0",
         "material-symbols": "^0.45.1",
@@ -2303,9 +2303,9 @@
       }
     },
     "node_modules/@moryx/ngx-web-framework": {
-      "version": "22.2.0",
-      "resolved": "https://www.myget.org/F/moryx-ci/auth/4cd70c3b-c8e8-4186-8c35-3d4c8789bbdd/npm/@moryx/ngx-web-framework/-/@moryx/ngx-web-framework-22.2.0.tgz",
-      "integrity": "sha1-7NL4hk7/4ESw0dV3O61tl7Wl7lM=",
+      "version": "22.3.0",
+      "resolved": "https://www.myget.org/F/moryx-ci/auth/4cd70c3b-c8e8-4186-8c35-3d4c8789bbdd/npm/@moryx/ngx-web-framework/-/@moryx/ngx-web-framework-22.3.0.tgz",
+      "integrity": "sha1-t8d/0QGLyshteh8jeqgbjHyCKAE=",
       "dependencies": {
         "tslib": "^2.3.0"
       },

--- a/src/Moryx.Operators.Web/app/package.json
+++ b/src/Moryx.Operators.Web/app/package.json
@@ -23,7 +23,7 @@
     "@angular/platform-browser-dynamic": "^22.0.0",
     "@angular/router": "^22.0.0",
     "@fontsource/roboto": "^5.2.9",
-    "@moryx/ngx-web-framework": "^22.2.0",
+    "@moryx/ngx-web-framework": "^22.3.0",
     "@ngx-translate/core": "^18.0.0",
     "@ngx-translate/http-loader": "^18.0.0",
     "material-symbols": "^0.45.1",

--- a/src/Moryx.Orders.Web/app/package-lock.json
+++ b/src/Moryx.Orders.Web/app/package-lock.json
@@ -18,7 +18,7 @@
         "@angular/platform-browser-dynamic": "^22.0.0",
         "@angular/router": "^22.0.0",
         "@fontsource/roboto": "^5.2.9",
-        "@moryx/ngx-web-framework": "^22.2.0",
+        "@moryx/ngx-web-framework": "^22.3.0",
         "@ngx-translate/core": "^18.0.0",
         "@ngx-translate/http-loader": "^18.0.0",
         "material-symbols": "^0.45.1",
@@ -2303,9 +2303,9 @@
       }
     },
     "node_modules/@moryx/ngx-web-framework": {
-      "version": "22.2.0",
-      "resolved": "https://www.myget.org/F/moryx-ci/auth/4cd70c3b-c8e8-4186-8c35-3d4c8789bbdd/npm/@moryx/ngx-web-framework/-/@moryx/ngx-web-framework-22.2.0.tgz",
-      "integrity": "sha1-7NL4hk7/4ESw0dV3O61tl7Wl7lM=",
+      "version": "22.3.0",
+      "resolved": "https://www.myget.org/F/moryx-ci/auth/4cd70c3b-c8e8-4186-8c35-3d4c8789bbdd/npm/@moryx/ngx-web-framework/-/@moryx/ngx-web-framework-22.3.0.tgz",
+      "integrity": "sha1-t8d/0QGLyshteh8jeqgbjHyCKAE=",
       "dependencies": {
         "tslib": "^2.3.0"
       },

--- a/src/Moryx.Orders.Web/app/package.json
+++ b/src/Moryx.Orders.Web/app/package.json
@@ -23,7 +23,7 @@
     "@angular/platform-browser-dynamic": "^22.0.0",
     "@angular/router": "^22.0.0",
     "@fontsource/roboto": "^5.2.9",
-    "@moryx/ngx-web-framework": "^22.2.0",
+    "@moryx/ngx-web-framework": "^22.3.0",
     "@ngx-translate/core": "^18.0.0",
     "@ngx-translate/http-loader": "^18.0.0",
     "material-symbols": "^0.45.1",

--- a/src/Moryx.Products.Web/app/package-lock.json
+++ b/src/Moryx.Products.Web/app/package-lock.json
@@ -18,7 +18,7 @@
         "@angular/platform-browser-dynamic": "^22.0.0",
         "@angular/router": "^22.0.0",
         "@fontsource/roboto": "^5.2.9",
-        "@moryx/ngx-web-framework": "^22.2.0",
+        "@moryx/ngx-web-framework": "^22.3.0",
         "@ngx-translate/core": "^18.0.0",
         "@ngx-translate/http-loader": "^18.0.0",
         "material-symbols": "^0.45.1",
@@ -2302,9 +2302,9 @@
       }
     },
     "node_modules/@moryx/ngx-web-framework": {
-      "version": "22.2.0",
-      "resolved": "https://www.myget.org/F/moryx-ci/auth/4cd70c3b-c8e8-4186-8c35-3d4c8789bbdd/npm/@moryx/ngx-web-framework/-/@moryx/ngx-web-framework-22.2.0.tgz",
-      "integrity": "sha1-7NL4hk7/4ESw0dV3O61tl7Wl7lM=",
+      "version": "22.3.0",
+      "resolved": "https://www.myget.org/F/moryx-ci/auth/4cd70c3b-c8e8-4186-8c35-3d4c8789bbdd/npm/@moryx/ngx-web-framework/-/@moryx/ngx-web-framework-22.3.0.tgz",
+      "integrity": "sha1-t8d/0QGLyshteh8jeqgbjHyCKAE=",
       "dependencies": {
         "tslib": "^2.3.0"
       },

--- a/src/Moryx.Products.Web/app/package.json
+++ b/src/Moryx.Products.Web/app/package.json
@@ -23,7 +23,7 @@
     "@angular/platform-browser-dynamic": "^22.0.0",
     "@angular/router": "^22.0.0",
     "@fontsource/roboto": "^5.2.9",
-    "@moryx/ngx-web-framework": "^22.2.0",
+    "@moryx/ngx-web-framework": "^22.3.0",
     "@ngx-translate/core": "^18.0.0",
     "@ngx-translate/http-loader": "^18.0.0",
     "material-symbols": "^0.45.1",

--- a/src/Moryx.Resources.Web/app/package-lock.json
+++ b/src/Moryx.Resources.Web/app/package-lock.json
@@ -18,7 +18,7 @@
         "@angular/platform-browser-dynamic": "^22.0.0",
         "@angular/router": "^22.0.0",
         "@fontsource/roboto": "^5.2.9",
-        "@moryx/ngx-web-framework": "^22.2.0",
+        "@moryx/ngx-web-framework": "^22.3.0",
         "@ngx-translate/core": "^18.0.0",
         "@ngx-translate/http-loader": "^18.0.0",
         "material-symbols": "^0.45.1",
@@ -2302,9 +2302,9 @@
       }
     },
     "node_modules/@moryx/ngx-web-framework": {
-      "version": "22.2.0",
-      "resolved": "https://www.myget.org/F/moryx-ci/auth/4cd70c3b-c8e8-4186-8c35-3d4c8789bbdd/npm/@moryx/ngx-web-framework/-/@moryx/ngx-web-framework-22.2.0.tgz",
-      "integrity": "sha1-7NL4hk7/4ESw0dV3O61tl7Wl7lM=",
+      "version": "22.3.0",
+      "resolved": "https://www.myget.org/F/moryx-ci/auth/4cd70c3b-c8e8-4186-8c35-3d4c8789bbdd/npm/@moryx/ngx-web-framework/-/@moryx/ngx-web-framework-22.3.0.tgz",
+      "integrity": "sha1-t8d/0QGLyshteh8jeqgbjHyCKAE=",
       "dependencies": {
         "tslib": "^2.3.0"
       },

--- a/src/Moryx.Resources.Web/app/package.json
+++ b/src/Moryx.Resources.Web/app/package.json
@@ -23,7 +23,7 @@
     "@angular/platform-browser-dynamic": "^22.0.0",
     "@angular/router": "^22.0.0",
     "@fontsource/roboto": "^5.2.9",
-    "@moryx/ngx-web-framework": "^22.2.0",
+    "@moryx/ngx-web-framework": "^22.3.0",
     "@ngx-translate/core": "^18.0.0",
     "@ngx-translate/http-loader": "^18.0.0",
     "material-symbols": "^0.45.1",

--- a/src/Moryx.Shifts.Web/app/package-lock.json
+++ b/src/Moryx.Shifts.Web/app/package-lock.json
@@ -18,7 +18,7 @@
         "@angular/platform-browser-dynamic": "^22.0.0",
         "@angular/router": "^22.0.0",
         "@fontsource/roboto": "^5.2.9",
-        "@moryx/ngx-web-framework": "^22.2.0",
+        "@moryx/ngx-web-framework": "^22.3.0",
         "@ngx-translate/core": "^18.0.0",
         "@ngx-translate/http-loader": "^18.0.0",
         "material-symbols": "^0.45.1",
@@ -2304,9 +2304,9 @@
       }
     },
     "node_modules/@moryx/ngx-web-framework": {
-      "version": "22.2.0",
-      "resolved": "https://www.myget.org/F/moryx-ci/auth/4cd70c3b-c8e8-4186-8c35-3d4c8789bbdd/npm/@moryx/ngx-web-framework/-/@moryx/ngx-web-framework-22.2.0.tgz",
-      "integrity": "sha1-7NL4hk7/4ESw0dV3O61tl7Wl7lM=",
+      "version": "22.3.0",
+      "resolved": "https://www.myget.org/F/moryx-ci/auth/4cd70c3b-c8e8-4186-8c35-3d4c8789bbdd/npm/@moryx/ngx-web-framework/-/@moryx/ngx-web-framework-22.3.0.tgz",
+      "integrity": "sha1-t8d/0QGLyshteh8jeqgbjHyCKAE=",
       "dependencies": {
         "tslib": "^2.3.0"
       },

--- a/src/Moryx.Shifts.Web/app/package.json
+++ b/src/Moryx.Shifts.Web/app/package.json
@@ -23,7 +23,7 @@
     "@angular/platform-browser-dynamic": "^22.0.0",
     "@angular/router": "^22.0.0",
     "@fontsource/roboto": "^5.2.9",
-    "@moryx/ngx-web-framework": "^22.2.0",
+    "@moryx/ngx-web-framework": "^22.3.0",
     "@ngx-translate/core": "^18.0.0",
     "@ngx-translate/http-loader": "^18.0.0",
     "material-symbols": "^0.45.1",

--- a/src/Moryx.VisualInstructions.Web/app/package-lock.json
+++ b/src/Moryx.VisualInstructions.Web/app/package-lock.json
@@ -18,7 +18,7 @@
         "@angular/platform-browser-dynamic": "^22.0.0",
         "@angular/router": "^22.0.0",
         "@fontsource/roboto": "^5.2.9",
-        "@moryx/ngx-web-framework": "^22.2.0",
+        "@moryx/ngx-web-framework": "^22.3.0",
         "@ngx-translate/core": "^18.0.0",
         "@ngx-translate/http-loader": "^18.0.0",
         "material-symbols": "^0.45.1",
@@ -2304,9 +2304,9 @@
       }
     },
     "node_modules/@moryx/ngx-web-framework": {
-      "version": "22.2.0",
-      "resolved": "https://www.myget.org/F/moryx-ci/auth/4cd70c3b-c8e8-4186-8c35-3d4c8789bbdd/npm/@moryx/ngx-web-framework/-/@moryx/ngx-web-framework-22.2.0.tgz",
-      "integrity": "sha1-7NL4hk7/4ESw0dV3O61tl7Wl7lM=",
+      "version": "22.3.0",
+      "resolved": "https://www.myget.org/F/moryx-ci/auth/4cd70c3b-c8e8-4186-8c35-3d4c8789bbdd/npm/@moryx/ngx-web-framework/-/@moryx/ngx-web-framework-22.3.0.tgz",
+      "integrity": "sha1-t8d/0QGLyshteh8jeqgbjHyCKAE=",
       "dependencies": {
         "tslib": "^2.3.0"
       },

--- a/src/Moryx.VisualInstructions.Web/app/package.json
+++ b/src/Moryx.VisualInstructions.Web/app/package.json
@@ -23,7 +23,7 @@
     "@angular/platform-browser-dynamic": "^22.0.0",
     "@angular/router": "^22.0.0",
     "@fontsource/roboto": "^5.2.9",
-    "@moryx/ngx-web-framework": "^22.2.0",
+    "@moryx/ngx-web-framework": "^22.3.0",
     "@ngx-translate/core": "^18.0.0",
     "@ngx-translate/http-loader": "^18.0.0",
     "material-symbols": "^0.45.1",

--- a/src/Moryx.Workplans.Web/app/package-lock.json
+++ b/src/Moryx.Workplans.Web/app/package-lock.json
@@ -18,7 +18,7 @@
         "@angular/platform-browser-dynamic": "^22.0.0",
         "@angular/router": "^22.0.0",
         "@fontsource/roboto": "^5.2.9",
-        "@moryx/ngx-web-framework": "^22.2.0",
+        "@moryx/ngx-web-framework": "^22.3.0",
         "@ngx-translate/core": "^18.0.0",
         "@ngx-translate/http-loader": "^18.0.0",
         "hammerjs": "^2.0.8",
@@ -2304,9 +2304,9 @@
       }
     },
     "node_modules/@moryx/ngx-web-framework": {
-      "version": "22.2.0",
-      "resolved": "https://www.myget.org/F/moryx-ci/auth/4cd70c3b-c8e8-4186-8c35-3d4c8789bbdd/npm/@moryx/ngx-web-framework/-/@moryx/ngx-web-framework-22.2.0.tgz",
-      "integrity": "sha1-7NL4hk7/4ESw0dV3O61tl7Wl7lM=",
+      "version": "22.3.0",
+      "resolved": "https://www.myget.org/F/moryx-ci/auth/4cd70c3b-c8e8-4186-8c35-3d4c8789bbdd/npm/@moryx/ngx-web-framework/-/@moryx/ngx-web-framework-22.3.0.tgz",
+      "integrity": "sha1-t8d/0QGLyshteh8jeqgbjHyCKAE=",
       "dependencies": {
         "tslib": "^2.3.0"
       },

--- a/src/Moryx.Workplans.Web/app/package.json
+++ b/src/Moryx.Workplans.Web/app/package.json
@@ -23,7 +23,7 @@
     "@angular/platform-browser-dynamic": "^22.0.0",
     "@angular/router": "^22.0.0",
     "@fontsource/roboto": "^5.2.9",
-    "@moryx/ngx-web-framework": "^22.2.0",
+    "@moryx/ngx-web-framework": "^22.3.0",
     "@ngx-translate/core": "^18.0.0",
     "@ngx-translate/http-loader": "^18.0.0",
     "hammerjs": "^2.0.8",

--- a/src/Moryx/Moryx.csproj.DotSettings
+++ b/src/Moryx/Moryx.csproj.DotSettings
@@ -41,6 +41,7 @@
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=serialization_005Centryconvert_005Ccollectionstrategy/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=serialization_005Centryconvert_005Centrytomodel/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=serialization_005Centryconvert_005Centrytomodel_005Ctypewrapper/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=serialization_005Centryconvert_005Cstructs/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=serialization_005Centrytomodel/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=serialization_005Centrytomodel_005Ctypewrapper/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=serialization_005Cpossiblevalues/@EntryIndexedValue">True</s:Boolean>

--- a/src/Moryx/Serialization/DefaultSerialization.cs
+++ b/src/Moryx/Serialization/DefaultSerialization.cs
@@ -235,6 +235,8 @@ public class DefaultSerialization : ICustomSerialization
 
                 return targetStream;
 
+            case EntryValueType.Struct:
+                return currentValue ?? Activator.CreateInstance(memberType);
             case EntryValueType.Class:
                 return currentValue ?? Activator.CreateInstance(memberType);
             case EntryValueType.Collection:

--- a/src/Moryx/Serialization/EntryConvert/EntryConvert.TypeConversion.cs
+++ b/src/Moryx/Serialization/EntryConvert/EntryConvert.TypeConversion.cs
@@ -41,6 +41,7 @@ public static partial class EntryConvert
     {
         return value switch
         {
+            DateTimeOffset dto => dto.UtcDateTime.ToString("O", formatProvider),
             DateTime dt => dt.ToUniversalTime().ToString("O", formatProvider),
             DateOnly d => d.ToString("O", formatProvider),
             TimeOnly t => t.ToString("O", formatProvider),
@@ -118,7 +119,7 @@ public static partial class EntryConvert
         {
             valueType = EntryValueType.TimeSpan;
         }
-        else if (propertyType == typeof(DateTime))
+        else if (propertyType == typeof(DateTime) || propertyType == typeof(DateTimeOffset))
         {
             valueType = EntryValueType.DateTime;
         }
@@ -210,6 +211,10 @@ public static partial class EntryConvert
         else if (type == typeof(DateTime))
         {
             result = ConvertToUtc(DateTime.Parse(value, formatProvider));
+        }
+        else if (type == typeof(DateTimeOffset))
+        {
+            result = new DateTimeOffset(DateTime.Parse(value, formatProvider, DateTimeStyles.AdjustToUniversal));
         }
         else if (type == typeof(DateOnly))
         {

--- a/src/Moryx/Serialization/EntryConvert/EntryConvert.TypeConversion.cs
+++ b/src/Moryx/Serialization/EntryConvert/EntryConvert.TypeConversion.cs
@@ -7,10 +7,47 @@ using System.Globalization;
 namespace Moryx.Serialization;
 
 /// <summary>
-/// Helper class to converts types to enum and vice versa
+/// Type conversion, struct serializer registry and string formatting for EntryConvert
 /// </summary>
 public static partial class EntryConvert
 {
+    /// <summary>
+    /// Registry of serializers for structs that are decomposed into sub-entries
+    /// </summary>
+    private static readonly Dictionary<Type, IStructSerializer> _structSerializers = new IStructSerializer[]
+    {
+        new Vector2EntrySerializer(),
+        new Vector3EntrySerializer(),
+        new QuaternionEntrySerializer()
+    }.ToDictionary(s => s.TargetType);
+
+    /// <summary>
+    /// Try to find a registered <see cref="IStructSerializer"/> for the given type
+    /// </summary>
+    private static bool TryGetSerializer(Type type, out IStructSerializer serializer)
+    {
+        return _structSerializers.TryGetValue(type, out serializer);
+    }
+
+    /// <summary>
+    /// Converts given value typed instance to a string with the given <see cref="IFormatProvider"/>
+    /// </summary>
+    /// <param name="value">Value to convert</param>
+    /// <param name="formatProvider">Format provider used to convert the value to string</param>
+    /// <returns></returns>
+    internal static string ConvertToString(object value, IFormatProvider formatProvider)
+    {
+        return value switch
+        {
+            DateTime dt => dt.ToUniversalTime().ToString("O", formatProvider),
+            DateOnly d => d.ToString("O", formatProvider),
+            TimeOnly t => t.ToString("O", formatProvider),
+            TimeSpan ts => ts.ToString("c", formatProvider),
+            IConvertible convertible => convertible.ToString(formatProvider),
+            _ => value?.ToString()
+        };
+    }
+
     /// <summary>
     /// Transform type of entry
     /// </summary>

--- a/src/Moryx/Serialization/EntryConvert/EntryConvert.TypeConversion.cs
+++ b/src/Moryx/Serialization/EntryConvert/EntryConvert.TypeConversion.cs
@@ -99,6 +99,11 @@ public static partial class EntryConvert
         {
             valueType = EntryValueType.Double;
         }
+        // TODO: Consider adding a dedicated EntryValueType.Decimal for higher precision
+        else if (propertyType == typeof(decimal))
+        {
+            valueType = EntryValueType.Double;
+        }
         else if (propertyType.IsEnum)
         {
             valueType = EntryValueType.Enum;

--- a/src/Moryx/Serialization/EntryConvert/EntryConvert.TypeConversion.cs
+++ b/src/Moryx/Serialization/EntryConvert/EntryConvert.TypeConversion.cs
@@ -34,7 +34,7 @@ public static partial class EntryConvert
     /// </summary>
     /// <param name="value">Value to convert</param>
     /// <param name="formatProvider">Format provider used to convert the value to string</param>
-    /// <returns></returns>
+    /// <returns>Formatted string representation</returns>
     internal static string ConvertToString(object value, IFormatProvider formatProvider)
     {
         return value switch

--- a/src/Moryx/Serialization/EntryConvert/EntryConvert.TypeConversion.cs
+++ b/src/Moryx/Serialization/EntryConvert/EntryConvert.TypeConversion.cs
@@ -18,7 +18,9 @@ public static partial class EntryConvert
     {
         new Vector2EntrySerializer(),
         new Vector3EntrySerializer(),
-        new QuaternionEntrySerializer()
+        new Vector4EntrySerializer(),
+        new QuaternionEntrySerializer(),
+        new PlaneEntrySerializer()
     }.ToDictionary(s => s.TargetType);
 
     /// <summary>

--- a/src/Moryx/Serialization/EntryConvert/EntryConvert.cs
+++ b/src/Moryx/Serialization/EntryConvert/EntryConvert.cs
@@ -15,6 +15,16 @@ namespace Moryx.Serialization;
 public static partial class EntryConvert
 {
     /// <summary>
+    /// Registry of serializers for structs that are decomposed into sub-entries
+    /// </summary>
+    private static readonly Dictionary<Type, IStructSerializer> _structSerializers = new IStructSerializer[]
+    {
+        new Vector2EntrySerializer(),
+        new Vector3EntrySerializer(),
+        new QuaternionEntrySerializer()
+    }.ToDictionary(s => s.TargetType);
+
+    /// <summary>
     /// Default strategy instance
     /// </summary>
     internal static ICustomSerialization Serialization = new DefaultSerialization();
@@ -125,15 +135,15 @@ public static partial class EntryConvert
             entryValue.Default = defaultAttribute.Value.ToString();
         else if (entryValue.Possible != null && entryValue.Possible.Length >= 1)
             entryValue.Default = entryValue.Possible[0].Key;
-        else if (property.PropertyType.IsValueType)
+        else if (property.PropertyType.IsValueType && entryValue.Type != EntryValueType.Struct)
         {
             var underlyingType = Nullable.GetUnderlyingType(property.PropertyType);
             entryValue.Default = underlyingType != null
                 ? Activator.CreateInstance(underlyingType).ToString()
                 : Activator.CreateInstance(property.PropertyType).ToString();
         }
-        // Value types should have the default value as current value
-        if (ValueOrStringType(property.PropertyType))
+        // Value types should have the default value as current value (except decomposed structs)
+        if (ValueOrStringType(property.PropertyType) && entryValue.Type != EntryValueType.Struct)
             entryValue.Current = ConvertToString(entryValue.Default, customSerialization.FormatProvider);
 
         return entryValue;
@@ -225,6 +235,12 @@ public static partial class EntryConvert
                 var subentry = EncodeClass(property.PropertyType, customSerialization);
                 converted.SubEntries.AddRange(subentry.SubEntries);
             }
+            // Decomposed structs use the serializer to create default sub-entries
+            else if (converted.Value.Type == EntryValueType.Struct && TryGetSerializer(property.PropertyType, out var serializer))
+            {
+                var structEntry = serializer.Encode(Activator.CreateInstance(property.PropertyType), customSerialization.FormatProvider);
+                converted.SubEntries.AddRange(structEntry.SubEntries);
+            }
 
             encodedClass.SubEntries.Add(converted);
         }
@@ -249,6 +265,14 @@ public static partial class EntryConvert
         var isValueType = ValueOrStringType(instanceType);
 
         var converted = CreateFromType(instanceType, customSerialization);
+
+        // Structs with registered serializers are encoded via sub-entries
+        if (converted.Value.Type == EntryValueType.Struct && TryGetSerializer(instanceType, out var serializer))
+        {
+            var structEntry = serializer.Encode(instance, customSerialization.FormatProvider);
+            converted.SubEntries = structEntry.SubEntries;
+            return converted;
+        }
 
         // Value or string are easily value encoded
         if (isValueType)
@@ -306,6 +330,13 @@ public static partial class EntryConvert
                     {
                         entry.Value.Possible = possibleElementValues;
                         convertedProperty.SubEntries.Add(entry);
+                    }
+                    break;
+                case EntryValueType.Struct:
+                    if (value != null && TryGetSerializer(propertyType, out var structSerializer))
+                    {
+                        var structEntry = structSerializer.Encode(value, customSerialization.FormatProvider);
+                        convertedProperty.SubEntries = structEntry.SubEntries;
                     }
                     break;
                 case EntryValueType.Class:
@@ -484,7 +515,7 @@ public static partial class EntryConvert
         };
 
         // mark the parameter as required when there is no default value
-        parameterModel.Validation.IsRequired = parameter.HasDefaultValue ? false : true;
+        parameterModel.Validation.IsRequired = !parameter.HasDefaultValue;
 
         switch (parameterModel.Value.Type)
         {
@@ -602,9 +633,14 @@ public static partial class EntryConvert
                 : customSerialization.ConvertValue(propertyType, property, mapped.Entry, currentValue);
 
             // Value types, strings and streams do not need recursion
-            if (ValueOrStringType(propertyType) || typeof(Stream).IsAssignableFrom(propertyType))
+            if (ValueOrStringType(propertyType) && !TryGetSerializer(propertyType, out _) || typeof(Stream).IsAssignableFrom(propertyType))
             {
 
+            }
+            // Structs with registered serializers are reconstructed from sub-entries
+            else if (TryGetSerializer(propertyType, out var structSerializer) && mapped.Entry != null)
+            {
+                value = structSerializer.Decode(mapped.Entry, customSerialization.FormatProvider);
             }
             // Update collection from entry
             else if (IsCollection(propertyType) && mapped.Entry != null)
@@ -881,7 +917,16 @@ public static partial class EntryConvert
     /// <returns></returns>
     internal static string ConvertToString(object value, IFormatProvider formatProvider)
     {
-        var convertible = value as IConvertible;
-        return convertible != null ? convertible.ToString(formatProvider) : value?.ToString();
+        return value is IConvertible convertible
+            ? convertible.ToString(formatProvider)
+            : value?.ToString();
+    }
+
+    /// <summary>
+    /// Try to find a registered <see cref="IStructSerializer"/> for the given type
+    /// </summary>
+    private static bool TryGetSerializer(Type type, out IStructSerializer serializer)
+    {
+        return _structSerializers.TryGetValue(type, out serializer);
     }
 }

--- a/src/Moryx/Serialization/EntryConvert/EntryConvert.cs
+++ b/src/Moryx/Serialization/EntryConvert/EntryConvert.cs
@@ -17,7 +17,7 @@ public static partial class EntryConvert
     /// <summary>
     /// Default strategy instance
     /// </summary>
-    internal static ICustomSerialization Serialization = new DefaultSerialization();
+    private static readonly ICustomSerialization _serialization = new DefaultSerialization();
 
     /// <summary>
     /// Check if a certain type is what we consider a collection
@@ -65,10 +65,10 @@ public static partial class EntryConvert
     /// <summary>
     /// Convert a single property into a simple entry
     /// </summary>
-    /// <returns>Covnerted property</returns>
+    /// <returns>Converted property</returns>
     public static Entry EncodeProperty(PropertyInfo property)
     {
-        return EncodeProperty(property, Serialization);
+        return EncodeProperty(property, _serialization);
     }
 
     /// <summary>
@@ -162,7 +162,7 @@ public static partial class EntryConvert
     /// </summary>
     public static Entry Prototype(EntryPrototype prototype)
     {
-        return Prototype(prototype, Serialization);
+        return Prototype(prototype, _serialization);
     }
 
     /// <summary>
@@ -201,7 +201,7 @@ public static partial class EntryConvert
     /// </summary>
     public static Entry EncodeClass(Type objType)
     {
-        return EncodeClass(objType, Serialization);
+        return EncodeClass(objType, _serialization);
     }
     /// <summary>
     /// Convert class into a list of generic entries using custom strategy
@@ -242,7 +242,7 @@ public static partial class EntryConvert
     /// </summary>
     public static Entry EncodeObject(object instance)
     {
-        return EncodeObject(instance, Serialization);
+        return EncodeObject(instance, _serialization);
     }
 
     /// <summary>
@@ -393,11 +393,11 @@ public static partial class EntryConvert
     /// Encode a <see cref="MethodBase"/> to the transmittable <see cref="MethodEntry"/>
     /// using <see cref="DefaultSerialization"/>
     /// </summary>
-    /// <param name="method"></param>
-    /// <returns></returns>
+    /// <param name="method">Method to encode</param>
+    /// <returns>Encoded method entry</returns>
     public static MethodEntry EncodeMethod(MethodBase method)
     {
-        return EncodeMethod(method, Serialization);
+        return EncodeMethod(method, _serialization);
     }
 
     /// <summary>
@@ -434,7 +434,7 @@ public static partial class EntryConvert
     /// </summary>
     public static IEnumerable<MethodEntry> EncodeMethods(object source)
     {
-        return EncodeMethods(source.GetType(), Serialization);
+        return EncodeMethods(source.GetType(), _serialization);
     }
 
     /// <summary>
@@ -450,7 +450,7 @@ public static partial class EntryConvert
     /// </summary>
     public static IEnumerable<MethodEntry> EncodeMethods(Type objType)
     {
-        return EncodeMethods(objType, Serialization);
+        return EncodeMethods(objType, _serialization);
     }
 
     /// <summary>
@@ -467,7 +467,7 @@ public static partial class EntryConvert
     /// </summary>
     public static IEnumerable<MethodEntry> EncodeConstructors(Type objType)
     {
-        return EncodeConstructors(objType, Serialization);
+        return EncodeConstructors(objType, _serialization);
     }
 
     /// <summary>
@@ -534,7 +534,7 @@ public static partial class EntryConvert
         where T : class, new()
     {
         var instance = new T();
-        UpdateInstance(instance, encoded, Serialization);
+        UpdateInstance(instance, encoded, _serialization);
         return instance;
     }
 
@@ -554,7 +554,7 @@ public static partial class EntryConvert
     /// </summary>
     public static object CreateInstance(Type type, Entry encoded)
     {
-        return CreateInstance(type, encoded, Serialization);
+        return CreateInstance(type, encoded, _serialization);
     }
 
     /// <summary>
@@ -571,7 +571,7 @@ public static partial class EntryConvert
     /// </summary>
     public static object CreateInstance(Type type, MethodEntry encodedConstructor)
     {
-        return CreateInstance(type, encodedConstructor, Serialization);
+        return CreateInstance(type, encodedConstructor, _serialization);
     }
 
     /// <summary>
@@ -595,7 +595,7 @@ public static partial class EntryConvert
     /// </summary>
     public static object UpdateInstance(object instance, Entry encoded)
     {
-        return UpdateInstance(instance, encoded, Serialization);
+        return UpdateInstance(instance, encoded, _serialization);
     }
 
     /// <summary>
@@ -777,7 +777,7 @@ public static partial class EntryConvert
     /// </summary>
     public static Entry InvokeMethod(object target, MethodEntry methodEntry)
     {
-        return InvokeMethod(target, methodEntry, Serialization);
+        return InvokeMethod(target, methodEntry, _serialization);
     }
 
     /// <summary>
@@ -786,7 +786,7 @@ public static partial class EntryConvert
     /// </summary>
     public static Task<Entry> InvokeMethodAsync(object target, MethodEntry methodEntry, CancellationToken cancellationToken = default)
     {
-        return InvokeMethodAsync(target, methodEntry, Serialization, cancellationToken);
+        return InvokeMethodAsync(target, methodEntry, _serialization, cancellationToken);
     }
 
     /// <summary>

--- a/src/Moryx/Serialization/EntryConvert/EntryConvert.cs
+++ b/src/Moryx/Serialization/EntryConvert/EntryConvert.cs
@@ -385,7 +385,7 @@ public static partial class EntryConvert
     private static string ConvertToBase64(Stream stream)
     {
         var bytes = new byte[stream.Length];
-        stream.Read(bytes, 0, (int)stream.Length);
+        stream.ReadExactly(bytes, 0, (int)stream.Length);
         return Convert.ToBase64String(bytes);
     }
 

--- a/src/Moryx/Serialization/EntryConvert/EntryConvert.cs
+++ b/src/Moryx/Serialization/EntryConvert/EntryConvert.cs
@@ -138,9 +138,8 @@ public static partial class EntryConvert
         else if (property.PropertyType.IsValueType && entryValue.Type != EntryValueType.Struct)
         {
             var underlyingType = Nullable.GetUnderlyingType(property.PropertyType);
-            entryValue.Default = underlyingType != null
-                ? Activator.CreateInstance(underlyingType).ToString()
-                : Activator.CreateInstance(property.PropertyType).ToString();
+            var defaultInstance = Activator.CreateInstance(underlyingType ?? property.PropertyType);
+            entryValue.Default = ConvertToString(defaultInstance, customSerialization.FormatProvider);
         }
         // Value types should have the default value as current value (except decomposed structs)
         if (ValueOrStringType(property.PropertyType) && entryValue.Type != EntryValueType.Struct)
@@ -917,9 +916,15 @@ public static partial class EntryConvert
     /// <returns></returns>
     internal static string ConvertToString(object value, IFormatProvider formatProvider)
     {
-        return value is IConvertible convertible
-            ? convertible.ToString(formatProvider)
-            : value?.ToString();
+        return value switch
+        {
+            DateTime dt => dt.ToUniversalTime().ToString("O", formatProvider),
+            DateOnly d => d.ToString("O", formatProvider),
+            TimeOnly t => t.ToString("O", formatProvider),
+            TimeSpan ts => ts.ToString("c", formatProvider),
+            IConvertible convertible => convertible.ToString(formatProvider),
+            _ => value?.ToString()
+        };
     }
 
     /// <summary>

--- a/src/Moryx/Serialization/EntryConvert/EntryConvert.cs
+++ b/src/Moryx/Serialization/EntryConvert/EntryConvert.cs
@@ -15,16 +15,6 @@ namespace Moryx.Serialization;
 public static partial class EntryConvert
 {
     /// <summary>
-    /// Registry of serializers for structs that are decomposed into sub-entries
-    /// </summary>
-    private static readonly Dictionary<Type, IStructSerializer> _structSerializers = new IStructSerializer[]
-    {
-        new Vector2EntrySerializer(),
-        new Vector3EntrySerializer(),
-        new QuaternionEntrySerializer()
-    }.ToDictionary(s => s.TargetType);
-
-    /// <summary>
     /// Default strategy instance
     /// </summary>
     internal static ICustomSerialization Serialization = new DefaultSerialization();
@@ -908,30 +898,4 @@ public static partial class EntryConvert
 
     #endregion
 
-    /// <summary>
-    /// Converts given value typed instance to a string with the given <see cref="IFormatProvider"/>
-    /// </summary>
-    /// <param name="value">Value to convert</param>
-    /// <param name="formatProvider">Format provider used to convert the value to string</param>
-    /// <returns></returns>
-    internal static string ConvertToString(object value, IFormatProvider formatProvider)
-    {
-        return value switch
-        {
-            DateTime dt => dt.ToUniversalTime().ToString("O", formatProvider),
-            DateOnly d => d.ToString("O", formatProvider),
-            TimeOnly t => t.ToString("O", formatProvider),
-            TimeSpan ts => ts.ToString("c", formatProvider),
-            IConvertible convertible => convertible.ToString(formatProvider),
-            _ => value?.ToString()
-        };
-    }
-
-    /// <summary>
-    /// Try to find a registered <see cref="IStructSerializer"/> for the given type
-    /// </summary>
-    private static bool TryGetSerializer(Type type, out IStructSerializer serializer)
-    {
-        return _structSerializers.TryGetValue(type, out serializer);
-    }
 }

--- a/src/Moryx/Serialization/EntryConvert/EntryConvertGenerator.cs
+++ b/src/Moryx/Serialization/EntryConvert/EntryConvertGenerator.cs
@@ -79,6 +79,10 @@ public static partial class EntryConvert
         {
             valueType = EntryValueType.TimeSpan;
         }
+        else if (_structSerializers.ContainsKey(propertyType))
+        {
+            valueType = EntryValueType.Struct;
+        }
         else if (typeof(IEnumerable).IsAssignableFrom(propertyType) && propertyType != typeof(string))
         {
             valueType = EntryValueType.Collection;

--- a/src/Moryx/Serialization/EntryConvert/EntryConvertGenerator.cs
+++ b/src/Moryx/Serialization/EntryConvert/EntryConvertGenerator.cs
@@ -79,6 +79,10 @@ public static partial class EntryConvert
         {
             valueType = EntryValueType.TimeSpan;
         }
+        else if (propertyType == typeof(DateTime))
+        {
+            valueType = EntryValueType.DateTime;
+        }
         else if (_structSerializers.ContainsKey(propertyType))
         {
             valueType = EntryValueType.Struct;
@@ -164,7 +168,6 @@ public static partial class EntryConvert
         {
             result = Enum.Parse(type, value);
         }
-        // TODO: Add EntryValueType.DateTime in next major version
         else if (type == typeof(DateTime))
         {
             result = ConvertToUtc(DateTime.Parse(value, formatProvider));
@@ -292,6 +295,10 @@ public static partial class EntryConvert
 
             case EntryValueType.TimeSpan:
                 result = TimeSpan.Parse(value, formatProvider);
+                break;
+
+            case EntryValueType.DateTime:
+                result = ConvertToUtc(DateTime.Parse(value, formatProvider));
                 break;
         }
         return result;

--- a/src/Moryx/Serialization/EntryConvert/EntryConvertGenerator.cs
+++ b/src/Moryx/Serialization/EntryConvert/EntryConvertGenerator.cs
@@ -67,6 +67,18 @@ public static partial class EntryConvert
         {
             valueType = EntryValueType.Stream;
         }
+        else if (propertyType == typeof(DateOnly))
+        {
+            valueType = EntryValueType.Date;
+        }
+        else if (propertyType == typeof(TimeOnly))
+        {
+            valueType = EntryValueType.Time;
+        }
+        else if (propertyType == typeof(TimeSpan))
+        {
+            valueType = EntryValueType.TimeSpan;
+        }
         else if (typeof(IEnumerable).IsAssignableFrom(propertyType) && propertyType != typeof(string))
         {
             valueType = EntryValueType.Collection;
@@ -148,9 +160,22 @@ public static partial class EntryConvert
         {
             result = Enum.Parse(type, value);
         }
+        // TODO: Add EntryValueType.DateTime in next major version
         else if (type == typeof(DateTime))
         {
             result = ConvertToUtc(DateTime.Parse(value, formatProvider));
+        }
+        else if (type == typeof(DateOnly))
+        {
+            result = DateOnly.Parse(value, formatProvider);
+        }
+        else if (type == typeof(TimeOnly))
+        {
+            result = TimeOnly.Parse(value, formatProvider);
+        }
+        else if (type == typeof(TimeSpan))
+        {
+            result = TimeSpan.Parse(value, formatProvider);
         }
 
         return result;
@@ -251,6 +276,18 @@ public static partial class EntryConvert
                 result = ParseWithFallback<double>(
                     value, formatProvider, NumberStyles.Float,
                     double.TryParse);
+                break;
+
+            case EntryValueType.Date:
+                result = DateOnly.Parse(value, formatProvider);
+                break;
+
+            case EntryValueType.Time:
+                result = TimeOnly.Parse(value, formatProvider);
+                break;
+
+            case EntryValueType.TimeSpan:
+                result = TimeSpan.Parse(value, formatProvider);
                 break;
         }
         return result;

--- a/src/Moryx/Serialization/EntryConvert/EntryValueType.cs
+++ b/src/Moryx/Serialization/EntryConvert/EntryValueType.cs
@@ -71,5 +71,17 @@ public enum EntryValueType
     /// <summary>
     /// Value type stream
     /// </summary>
-    Stream
+    Stream,
+    /// <summary>
+    /// Value type DateOnly
+    /// </summary>
+    Date,
+    /// <summary>
+    /// Value type TimeOnly
+    /// </summary>
+    Time,
+    /// <summary>
+    /// Value type TimeSpan
+    /// </summary>
+    TimeSpan
 }

--- a/src/Moryx/Serialization/EntryConvert/EntryValueType.cs
+++ b/src/Moryx/Serialization/EntryConvert/EntryValueType.cs
@@ -73,6 +73,14 @@ public enum EntryValueType
     /// </summary>
     Stream,
     /// <summary>
+    /// Decomposed struct with sub-entries
+    /// </summary>
+    Struct,
+    /// <summary>
+    /// Value type DateTime
+    /// </summary>
+    DateTime,
+    /// <summary>
     /// Value type DateOnly
     /// </summary>
     Date,
@@ -83,9 +91,5 @@ public enum EntryValueType
     /// <summary>
     /// Value type TimeSpan
     /// </summary>
-    TimeSpan,
-    /// <summary>
-    /// Decomposed struct with sub-entries (e.g. Vector2, Vector3, Quaternion)
-    /// </summary>
-    Struct
+    TimeSpan
 }

--- a/src/Moryx/Serialization/EntryConvert/EntryValueType.cs
+++ b/src/Moryx/Serialization/EntryConvert/EntryValueType.cs
@@ -83,5 +83,9 @@ public enum EntryValueType
     /// <summary>
     /// Value type TimeSpan
     /// </summary>
-    TimeSpan
+    TimeSpan,
+    /// <summary>
+    /// Decomposed struct with sub-entries (e.g. Vector2, Vector3, Quaternion)
+    /// </summary>
+    Struct
 }

--- a/src/Moryx/Serialization/EntryConvert/Structs/IStructSerializer.cs
+++ b/src/Moryx/Serialization/EntryConvert/Structs/IStructSerializer.cs
@@ -1,0 +1,25 @@
+// Copyright (c) 2026 Phoenix Contact GmbH & Co. KG
+// Licensed under the Apache License, Version 2.0
+
+namespace Moryx.Serialization;
+
+/// <summary>
+/// Interface for custom struct serialization to Entry sub-entries
+/// </summary>
+internal interface IStructSerializer
+{
+    /// <summary>
+    /// The type this serializer handles
+    /// </summary>
+    Type TargetType { get; }
+
+    /// <summary>
+    /// Encode a struct value into an Entry with sub-entries
+    /// </summary>
+    Entry Encode(object value, IFormatProvider formatProvider);
+
+    /// <summary>
+    /// Decode an Entry with sub-entries back into a struct value
+    /// </summary>
+    object Decode(Entry entry, IFormatProvider formatProvider);
+}

--- a/src/Moryx/Serialization/EntryConvert/Structs/NumericStructEntrySerializer.cs
+++ b/src/Moryx/Serialization/EntryConvert/Structs/NumericStructEntrySerializer.cs
@@ -1,0 +1,43 @@
+// Copyright (c) 2026 Phoenix Contact GmbH & Co. KG
+// Licensed under the Apache License, Version 2.0
+
+namespace Moryx.Serialization;
+
+internal abstract class NumericStructEntrySerializer : IStructSerializer
+{
+    public abstract Type TargetType { get; }
+
+    public abstract Entry Encode(object value, IFormatProvider formatProvider);
+
+    public abstract object Decode(Entry entry, IFormatProvider formatProvider);
+
+    protected static Entry CreateFloatEntry(string name, float value, IFormatProvider formatProvider)
+    {
+        var str = EntryConvert.ConvertToString(value, formatProvider);
+        return new Entry
+        {
+            DisplayName = name,
+            Identifier = name,
+            Value = new EntryValue
+            {
+                Type = EntryValueType.Single,
+                Current = str,
+                Default = EntryConvert.ConvertToString(0f, formatProvider)
+            },
+            Validation = new EntryValidation
+            {
+                Minimum = float.MinValue,
+                Maximum = float.MaxValue
+            }
+        };
+    }
+
+    protected static float ReadFloat(Entry entry, string name, IFormatProvider formatProvider)
+    {
+        var sub = entry.SubEntries.Find(e => e.Identifier == name);
+        var value = sub?.Value.Current;
+        return value != null
+            ? (float)EntryConvert.ToObject(typeof(float), value, formatProvider)
+            : 0f;
+    }
+}

--- a/src/Moryx/Serialization/EntryConvert/Structs/NumericStructEntrySerializer.cs
+++ b/src/Moryx/Serialization/EntryConvert/Structs/NumericStructEntrySerializer.cs
@@ -23,11 +23,6 @@ internal abstract class NumericStructEntrySerializer : IStructSerializer
                 Type = EntryValueType.Single,
                 Current = str,
                 Default = EntryConvert.ConvertToString(0f, formatProvider)
-            },
-            Validation = new EntryValidation
-            {
-                Minimum = float.MinValue,
-                Maximum = float.MaxValue
             }
         };
     }

--- a/src/Moryx/Serialization/EntryConvert/Structs/PlaneEntrySerializer.cs
+++ b/src/Moryx/Serialization/EntryConvert/Structs/PlaneEntrySerializer.cs
@@ -1,0 +1,35 @@
+// Copyright (c) 2026 Phoenix Contact GmbH & Co. KG
+// Licensed under the Apache License, Version 2.0
+
+using System.Numerics;
+
+namespace Moryx.Serialization;
+
+internal class PlaneEntrySerializer : NumericStructEntrySerializer
+{
+    public override Type TargetType => typeof(Plane);
+
+    public override Entry Encode(object value, IFormatProvider formatProvider)
+    {
+        var p = (Plane)value;
+        return new Entry
+        {
+            SubEntries =
+            [
+                CreateFloatEntry("X", p.Normal.X, formatProvider),
+                CreateFloatEntry("Y", p.Normal.Y, formatProvider),
+                CreateFloatEntry("Z", p.Normal.Z, formatProvider),
+                CreateFloatEntry("D", p.D, formatProvider)
+            ]
+        };
+    }
+
+    public override object Decode(Entry entry, IFormatProvider formatProvider)
+    {
+        var x = ReadFloat(entry, "X", formatProvider);
+        var y = ReadFloat(entry, "Y", formatProvider);
+        var z = ReadFloat(entry, "Z", formatProvider);
+        var d = ReadFloat(entry, "D", formatProvider);
+        return new Plane(new Vector3(x, y, z), d);
+    }
+}

--- a/src/Moryx/Serialization/EntryConvert/Structs/QuaternionEntrySerializer.cs
+++ b/src/Moryx/Serialization/EntryConvert/Structs/QuaternionEntrySerializer.cs
@@ -1,0 +1,35 @@
+// Copyright (c) 2026 Phoenix Contact GmbH & Co. KG
+// Licensed under the Apache License, Version 2.0
+
+using System.Numerics;
+
+namespace Moryx.Serialization;
+
+internal class QuaternionEntrySerializer : NumericStructEntrySerializer
+{
+    public override Type TargetType => typeof(Quaternion);
+
+    public override Entry Encode(object value, IFormatProvider formatProvider)
+    {
+        var q = (Quaternion)value;
+        return new Entry
+        {
+            SubEntries =
+            [
+                CreateFloatEntry("X", q.X, formatProvider),
+                CreateFloatEntry("Y", q.Y, formatProvider),
+                CreateFloatEntry("Z", q.Z, formatProvider),
+                CreateFloatEntry("W", q.W, formatProvider)
+            ]
+        };
+    }
+
+    public override object Decode(Entry entry, IFormatProvider formatProvider)
+    {
+        var x = ReadFloat(entry, "X", formatProvider);
+        var y = ReadFloat(entry, "Y", formatProvider);
+        var z = ReadFloat(entry, "Z", formatProvider);
+        var w = ReadFloat(entry, "W", formatProvider);
+        return new Quaternion(x, y, z, w);
+    }
+}

--- a/src/Moryx/Serialization/EntryConvert/Structs/Vector2EntrySerializer.cs
+++ b/src/Moryx/Serialization/EntryConvert/Structs/Vector2EntrySerializer.cs
@@ -1,0 +1,31 @@
+// Copyright (c) 2026 Phoenix Contact GmbH & Co. KG
+// Licensed under the Apache License, Version 2.0
+
+using System.Numerics;
+
+namespace Moryx.Serialization;
+
+internal class Vector2EntrySerializer : NumericStructEntrySerializer
+{
+    public override Type TargetType => typeof(Vector2);
+
+    public override Entry Encode(object value, IFormatProvider formatProvider)
+    {
+        var v = (Vector2)value;
+        return new Entry
+        {
+            SubEntries =
+            [
+                CreateFloatEntry("X", v.X, formatProvider),
+                CreateFloatEntry("Y", v.Y, formatProvider)
+            ]
+        };
+    }
+
+    public override object Decode(Entry entry, IFormatProvider formatProvider)
+    {
+        var x = ReadFloat(entry, "X", formatProvider);
+        var y = ReadFloat(entry, "Y", formatProvider);
+        return new Vector2(x, y);
+    }
+}

--- a/src/Moryx/Serialization/EntryConvert/Structs/Vector3EntrySerializer.cs
+++ b/src/Moryx/Serialization/EntryConvert/Structs/Vector3EntrySerializer.cs
@@ -1,0 +1,33 @@
+// Copyright (c) 2026 Phoenix Contact GmbH & Co. KG
+// Licensed under the Apache License, Version 2.0
+
+using System.Numerics;
+
+namespace Moryx.Serialization;
+
+internal class Vector3EntrySerializer : NumericStructEntrySerializer
+{
+    public override Type TargetType => typeof(Vector3);
+
+    public override Entry Encode(object value, IFormatProvider formatProvider)
+    {
+        var v = (Vector3)value;
+        return new Entry
+        {
+            SubEntries =
+            [
+                CreateFloatEntry("X", v.X, formatProvider),
+                CreateFloatEntry("Y", v.Y, formatProvider),
+                CreateFloatEntry("Z", v.Z, formatProvider)
+            ]
+        };
+    }
+
+    public override object Decode(Entry entry, IFormatProvider formatProvider)
+    {
+        var x = ReadFloat(entry, "X", formatProvider);
+        var y = ReadFloat(entry, "Y", formatProvider);
+        var z = ReadFloat(entry, "Z", formatProvider);
+        return new Vector3(x, y, z);
+    }
+}

--- a/src/Moryx/Serialization/EntryConvert/Structs/Vector4EntrySerializer.cs
+++ b/src/Moryx/Serialization/EntryConvert/Structs/Vector4EntrySerializer.cs
@@ -1,0 +1,35 @@
+// Copyright (c) 2026 Phoenix Contact GmbH & Co. KG
+// Licensed under the Apache License, Version 2.0
+
+using System.Numerics;
+
+namespace Moryx.Serialization;
+
+internal class Vector4EntrySerializer : NumericStructEntrySerializer
+{
+    public override Type TargetType => typeof(Vector4);
+
+    public override Entry Encode(object value, IFormatProvider formatProvider)
+    {
+        var v = (Vector4)value;
+        return new Entry
+        {
+            SubEntries =
+            [
+                CreateFloatEntry("X", v.X, formatProvider),
+                CreateFloatEntry("Y", v.Y, formatProvider),
+                CreateFloatEntry("Z", v.Z, formatProvider),
+                CreateFloatEntry("W", v.W, formatProvider)
+            ]
+        };
+    }
+
+    public override object Decode(Entry entry, IFormatProvider formatProvider)
+    {
+        var x = ReadFloat(entry, "X", formatProvider);
+        var y = ReadFloat(entry, "Y", formatProvider);
+        var z = ReadFloat(entry, "Z", formatProvider);
+        var w = ReadFloat(entry, "W", formatProvider);
+        return new Vector4(x, y, z, w);
+    }
+}

--- a/src/Tests/Moryx.Products.IntegrationTests/ProductStorageTests.cs
+++ b/src/Tests/Moryx.Products.IntegrationTests/ProductStorageTests.cs
@@ -1248,11 +1248,12 @@ public class ProductStorageTests
     public async Task SaveAndLoadTypeWithVector3()
     {
         // Arrange
+        var expectedPosition = new Vector3(1.5f, 2.5f, 3.5f);
         var product = new VectorProductType
         {
             Name = "Vector Product",
             Identity = new ProductIdentity("VEC001", 1),
-            Position = new Vector3(1.5f, 2.5f, 3.5f)
+            Position = expectedPosition
         };
 
         // Act
@@ -1260,18 +1261,19 @@ public class ProductStorageTests
         var loaded = (VectorProductType)await _storage.LoadTypeAsync(savedId);
 
         // Assert
-        Assert.That(loaded.Position, Is.EqualTo(new Vector3(1.5f, 2.5f, 3.5f)));
+        Assert.That(loaded.Position, Is.EqualTo(expectedPosition));
     }
 
     [Test]
     public async Task SaveAndLoadTypeWithQuaternion()
     {
         // Arrange
+        var expectedOrientation = new Quaternion(0.1f, 0.2f, 0.3f, 0.9f);
         var product = new VectorProductType
         {
             Name = "Quaternion Product",
             Identity = new ProductIdentity("QUAT001", 1),
-            Orientation = new Quaternion(0.1f, 0.2f, 0.3f, 0.9f)
+            Orientation = expectedOrientation
         };
 
         // Act
@@ -1279,7 +1281,7 @@ public class ProductStorageTests
         var loaded = (VectorProductType)await _storage.LoadTypeAsync(savedId);
 
         // Assert
-        Assert.That(loaded.Orientation, Is.EqualTo(new Quaternion(0.1f, 0.2f, 0.3f, 0.9f)));
+        Assert.That(loaded.Orientation, Is.EqualTo(expectedOrientation));
     }
 
     [Test]
@@ -1326,11 +1328,12 @@ public class ProductStorageTests
     public async Task SaveAndLoadTypeWithDateOnly()
     {
         // Arrange
+        var expectedDate = new DateOnly(2026, 8, 18);
         var product = new DatedProductType
         {
             Name = "DateOnly Product",
             Identity = new ProductIdentity("DATE001", 1),
-            ValidFrom = new DateOnly(2026, 8, 18)
+            ValidFrom = expectedDate
         };
 
         // Act
@@ -1338,18 +1341,19 @@ public class ProductStorageTests
         var loaded = (DatedProductType)await _storage.LoadTypeAsync(savedId);
 
         // Assert
-        Assert.That(loaded.ValidFrom, Is.EqualTo(new DateOnly(2026, 8, 18)));
+        Assert.That(loaded.ValidFrom, Is.EqualTo(expectedDate));
     }
 
     [Test]
     public async Task SaveAndLoadTypeWithTimeOnly()
     {
         // Arrange
+        var expectedTime = new TimeOnly(14, 30, 45);
         var product = new DatedProductType
         {
             Name = "TimeOnly Product",
             Identity = new ProductIdentity("TIME001", 1),
-            ProductionTime = new TimeOnly(14, 30, 45)
+            ProductionTime = expectedTime
         };
 
         // Act
@@ -1357,7 +1361,7 @@ public class ProductStorageTests
         var loaded = (DatedProductType)await _storage.LoadTypeAsync(savedId);
 
         // Assert
-        Assert.That(loaded.ProductionTime, Is.EqualTo(new TimeOnly(14, 30, 45)));
+        Assert.That(loaded.ProductionTime, Is.EqualTo(expectedTime));
     }
 
     [Test]

--- a/src/Tests/Moryx.Tests/Serialization/DummyClass.cs
+++ b/src/Tests/Moryx.Tests/Serialization/DummyClass.cs
@@ -1,6 +1,7 @@
 // Copyright (c) 2026 Phoenix Contact GmbH & Co. KG
 // Licensed under the Apache License, Version 2.0
 
+using System;
 using System.Collections.Generic;
 
 namespace Moryx.Tests.Serialization;
@@ -10,6 +11,10 @@ public class DummyClass
     public int Number { get; set; }
 
     public string Name { get; set; }
+
+    public DateTime ModifiedAt { get; set; }
+
+    public DateTimeOffset CreatedAt { get; set; }
 
     public int ReadOnly => 10;
 

--- a/src/Tests/Moryx.Tests/Serialization/EntryConvertSerializationTests.cs
+++ b/src/Tests/Moryx.Tests/Serialization/EntryConvertSerializationTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0
 
 using System;
+using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Numerics;
@@ -130,119 +131,136 @@ public class EntryConvertSerializationTests
         Assert.That(doubleWithFallback, Is.EqualTo(3.14d).Within(1e-10));
     }
 
-    [Test]
-    public void EncodesVector3AsStructWithSubEntries()
+    [TestCase(nameof(StructPropertiesClass.Position2D), 2, new[] { "X", "Y" })]
+    [TestCase(nameof(StructPropertiesClass.Position3D), 3, new[] { "X", "Y", "Z" })]
+    [TestCase(nameof(StructPropertiesClass.Position4D), 4, new[] { "X", "Y", "Z", "W" })]
+    [TestCase(nameof(StructPropertiesClass.Rotation), 4, new[] { "X", "Y", "Z", "W" })]
+    [TestCase(nameof(StructPropertiesClass.Surface), 4, new[] { "X", "Y", "Z", "D" })]
+    public void EncodesStructWithSubEntries(string propertyName, int expectedCount, string[] expectedIdentifiers)
     {
         // Arrange
-        var obj = new StructPropertiesClass { Position3D = new Vector3(1.5f, 2.5f, 3.5f) };
-
-        // Act
-        var entry = EntryConvert.EncodeObject(obj);
-        var vectorEntry = entry.SubEntries.First(e => e.Identifier == nameof(StructPropertiesClass.Position3D));
-
-        // Assert
-        Assert.That(vectorEntry.Value.Type, Is.EqualTo(EntryValueType.Struct));
-        Assert.That(vectorEntry.SubEntries, Has.Count.EqualTo(3));
-        Assert.That(vectorEntry.SubEntries.Select(e => e.Identifier), Is.EquivalentTo(new[] { "X", "Y", "Z" }));
-        Assert.That(vectorEntry.SubEntries.All(e => e.Value.Type == EntryValueType.Single), Is.True);
-    }
-
-    [Test]
-    public void EncodesVector2AsStructWithSubEntries()
-    {
-        // Arrange
-        var obj = new StructPropertiesClass { Position2D = new Vector2(10f, 20f) };
-
-        // Act
-        var entry = EntryConvert.EncodeObject(obj);
-        var vectorEntry = entry.SubEntries.First(e => e.Identifier == nameof(StructPropertiesClass.Position2D));
-
-        // Assert
-        Assert.That(vectorEntry.Value.Type, Is.EqualTo(EntryValueType.Struct));
-        Assert.That(vectorEntry.SubEntries, Has.Count.EqualTo(2));
-        Assert.That(vectorEntry.SubEntries.Select(e => e.Identifier), Is.EquivalentTo(new[] { "X", "Y" }));
-    }
-
-    [Test]
-    public void EncodesQuaternionAsStructWithSubEntries()
-    {
-        // Arrange
-        var obj = new StructPropertiesClass { Rotation = new Quaternion(1f, 2f, 3f, 4f) };
-
-        // Act
-        var entry = EntryConvert.EncodeObject(obj);
-        var quatEntry = entry.SubEntries.First(e => e.Identifier == nameof(StructPropertiesClass.Rotation));
-
-        // Assert
-        Assert.That(quatEntry.Value.Type, Is.EqualTo(EntryValueType.Struct));
-        Assert.That(quatEntry.SubEntries, Has.Count.EqualTo(4));
-        Assert.That(quatEntry.SubEntries.Select(e => e.Identifier), Is.EquivalentTo(new[] { "X", "Y", "Z", "W" }));
-    }
-
-    [Test]
-    public void Vector3ValuesOnRoundTripPreserved()
-    {
-        // Arrange
-        var original = new StructPropertiesClass
+        var obj = new StructPropertiesClass
         {
-            Position3D = new Vector3(1.5f, 2.5f, 3.5f)
+            Position2D = new Vector2(10f, 20f),
+            Position3D = new Vector3(1.5f, 2.5f, 3.5f),
+            Position4D = new Vector4(1f, 2f, 3f, 4f),
+            Rotation = new Quaternion(1f, 2f, 3f, 4f),
+            Surface = new Plane(new Vector3(0f, 1f, 0f), 5f)
         };
 
+        // Act
+        var entry = EntryConvert.EncodeObject(obj);
+        var structEntry = entry.SubEntries.First(e => e.Identifier == propertyName);
+
+        // Assert
+        Assert.That(structEntry.Value.Type, Is.EqualTo(EntryValueType.Struct));
+        Assert.That(structEntry.SubEntries, Has.Count.EqualTo(expectedCount));
+        Assert.That(structEntry.SubEntries.Select(e => e.Identifier), Is.EquivalentTo(expectedIdentifiers));
+        Assert.That(structEntry.SubEntries.All(e => e.Value.Type == EntryValueType.Single), Is.True);
+    }
+
+    private static IEnumerable<TestCaseData> StructRoundTripCases()
+    {
+        yield return new TestCaseData(new StructPropertiesClass { Position2D = new Vector2(10f, 20f) }, nameof(StructPropertiesClass.Position2D))
+            .SetName(nameof(StructValuesOnRoundTripPreserved) + "(Vector2)");
+        yield return new TestCaseData(new StructPropertiesClass { Position3D = new Vector3(1.5f, 2.5f, 3.5f) }, nameof(StructPropertiesClass.Position3D))
+            .SetName(nameof(StructValuesOnRoundTripPreserved) + "(Vector3)");
+        yield return new TestCaseData(new StructPropertiesClass { Position4D = new Vector4(1f, 2f, 3f, 4f) }, nameof(StructPropertiesClass.Position4D))
+            .SetName(nameof(StructValuesOnRoundTripPreserved) + "(Vector4)");
+        yield return new TestCaseData(new StructPropertiesClass { Rotation = new Quaternion(1f, 2f, 3f, 4f) }, nameof(StructPropertiesClass.Rotation))
+            .SetName(nameof(StructValuesOnRoundTripPreserved) + "(Quaternion)");
+        yield return new TestCaseData(new StructPropertiesClass { Surface = new Plane(new Vector3(0f, 1f, 0f), 5f) }, nameof(StructPropertiesClass.Surface))
+            .SetName(nameof(StructValuesOnRoundTripPreserved) + "(Plane)");
+    }
+
+    [TestCaseSource(nameof(StructRoundTripCases))]
+    public void StructValuesOnRoundTripPreserved(StructPropertiesClass original, string propertyName)
+    {
         // Act
         var entry = EntryConvert.EncodeObject(original);
         var restored = new StructPropertiesClass();
         EntryConvert.UpdateInstance(restored, entry);
 
         // Assert
-        Assert.That(restored.Position3D, Is.EqualTo(original.Position3D));
+        var property = typeof(StructPropertiesClass).GetProperty(propertyName)!;
+        var originalValue = property.GetValue(original);
+        var restoredValue = property.GetValue(restored);
+
+        Assert.That(restoredValue, Is.EqualTo(originalValue));
     }
 
-    [Test]
-    public void Vector2ValuesOnRoundTripPreserved()
-    {
-        // Arrange
-        var original = new StructPropertiesClass
-        {
-            Position2D = new Vector2(10f, 20f)
-        };
-
-        // Act
-        var entry = EntryConvert.EncodeObject(original);
-        var restored = new StructPropertiesClass();
-        EntryConvert.UpdateInstance(restored, entry);
-
-        // Assert
-        Assert.That(restored.Position2D, Is.EqualTo(original.Position2D));
-    }
-
-    [Test]
-    public void QuaternionValuesOnRoundTripPreserved()
-    {
-        // Arrange
-        var original = new StructPropertiesClass
-        {
-            Rotation = new Quaternion(1f, 2f, 3f, 4f)
-        };
-
-        // Act
-        var entry = EntryConvert.EncodeObject(original);
-        var restored = new StructPropertiesClass();
-        EntryConvert.UpdateInstance(restored, entry);
-
-        // Assert
-        Assert.That(restored.Rotation, Is.EqualTo(original.Rotation));
-    }
-
-    [Test]
-    public void CreatesDefaultSubEntriesForVector3OnEncodeClass()
+    [TestCase(nameof(StructPropertiesClass.Position2D), 2)]
+    [TestCase(nameof(StructPropertiesClass.Position3D), 3)]
+    [TestCase(nameof(StructPropertiesClass.Position4D), 4)]
+    [TestCase(nameof(StructPropertiesClass.Rotation), 4)]
+    [TestCase(nameof(StructPropertiesClass.Surface), 4)]
+    public void CreatesDefaultSubEntriesOnEncodeClass(string propertyName, int expectedCount)
     {
         // Act
         var entry = EntryConvert.EncodeClass(typeof(StructPropertiesClass));
-        var vectorEntry = entry.SubEntries.First(e => e.Identifier == nameof(StructPropertiesClass.Position3D));
+        var structEntry = entry.SubEntries.First(e => e.Identifier == propertyName);
 
         // Assert
-        Assert.That(vectorEntry.Value.Type, Is.EqualTo(EntryValueType.Struct));
-        Assert.That(vectorEntry.SubEntries, Has.Count.EqualTo(3));
+        Assert.That(structEntry.Value.Type, Is.EqualTo(EntryValueType.Struct));
+        Assert.That(structEntry.SubEntries, Has.Count.EqualTo(expectedCount));
+    }
+
+    [Test(Description = "DateTime maps to EntryValueType.DateTime.")]
+    public void DateTimeMapsToDateTimeValueType()
+    {
+        // Act
+        var valueType = EntryConvert.TransformType(typeof(DateTime));
+
+        // Assert
+        Assert.That(valueType, Is.EqualTo(EntryValueType.DateTime));
+    }
+
+    [Test(Description = "DateTime values are converted to UTC and preserved on round-trip.")]
+    public void DateTimeValuesOnRoundTripPreservedAsUtc()
+    {
+        // Arrange
+        var original = new DummyClass
+        {
+            ModifiedAt = new DateTime(2026, 8, 18, 14, 30, 0, DateTimeKind.Utc)
+        };
+
+        // Act
+        var entry = EntryConvert.EncodeObject(original);
+        var restored = new DummyClass();
+        EntryConvert.UpdateInstance(restored, entry);
+
+        // Assert
+        Assert.That(restored.ModifiedAt, Is.EqualTo(original.ModifiedAt));
+        Assert.That(restored.ModifiedAt.Kind, Is.EqualTo(DateTimeKind.Utc));
+    }
+
+    [Test(Description = "DateTimeOffset maps to EntryValueType.DateTime, same as DateTime.")]
+    public void DateTimeOffsetMapsToDateTimeValueType()
+    {
+        // Act
+        var valueType = EntryConvert.TransformType(typeof(DateTimeOffset));
+
+        // Assert
+        Assert.That(valueType, Is.EqualTo(EntryValueType.DateTime));
+    }
+
+    [Test(Description = "DateTimeOffset UTC instant is preserved on round-trip, but the original offset is lost.")]
+    public void DateTimeOffsetValuesOnRoundTripPreserved()
+    {
+        // Arrange
+        var original = new DummyClass
+        {
+            CreatedAt = new DateTimeOffset(2026, 8, 18, 14, 30, 0, TimeSpan.FromHours(2))
+        };
+
+        // Act
+        var entry = EntryConvert.EncodeObject(original);
+        var restored = new DummyClass();
+        EntryConvert.UpdateInstance(restored, entry);
+
+        // Assert
+        // Offset is lost, but the UTC instant is preserved
+        Assert.That(restored.CreatedAt.UtcDateTime, Is.EqualTo(original.CreatedAt.UtcDateTime));
     }
 
     [Test]

--- a/src/Tests/Moryx.Tests/Serialization/EntryConvertSerializationTests.cs
+++ b/src/Tests/Moryx.Tests/Serialization/EntryConvertSerializationTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Globalization;
 using System.Linq;
+using System.Numerics;
 using System.Threading;
 using Moryx.Serialization;
 using NUnit.Framework;
@@ -128,7 +129,122 @@ public class EntryConvertSerializationTests
         Assert.That(singleWithProvider, Is.EqualTo(3.14f).Within(1e-5));
         Assert.That(doubleWithFallback, Is.EqualTo(3.14d).Within(1e-10));
     }
-     
+
+    [Test]
+    public void EncodesVector3AsStructWithSubEntries()
+    {
+        // Arrange
+        var obj = new StructPropertiesClass { Position3D = new Vector3(1.5f, 2.5f, 3.5f) };
+
+        // Act
+        var entry = EntryConvert.EncodeObject(obj);
+        var vectorEntry = entry.SubEntries.First(e => e.Identifier == nameof(StructPropertiesClass.Position3D));
+
+        // Assert
+        Assert.That(vectorEntry.Value.Type, Is.EqualTo(EntryValueType.Struct));
+        Assert.That(vectorEntry.SubEntries, Has.Count.EqualTo(3));
+        Assert.That(vectorEntry.SubEntries.Select(e => e.Identifier), Is.EquivalentTo(new[] { "X", "Y", "Z" }));
+        Assert.That(vectorEntry.SubEntries.All(e => e.Value.Type == EntryValueType.Single), Is.True);
+    }
+
+    [Test]
+    public void EncodesVector2AsStructWithSubEntries()
+    {
+        // Arrange
+        var obj = new StructPropertiesClass { Position2D = new Vector2(10f, 20f) };
+
+        // Act
+        var entry = EntryConvert.EncodeObject(obj);
+        var vectorEntry = entry.SubEntries.First(e => e.Identifier == nameof(StructPropertiesClass.Position2D));
+
+        // Assert
+        Assert.That(vectorEntry.Value.Type, Is.EqualTo(EntryValueType.Struct));
+        Assert.That(vectorEntry.SubEntries, Has.Count.EqualTo(2));
+        Assert.That(vectorEntry.SubEntries.Select(e => e.Identifier), Is.EquivalentTo(new[] { "X", "Y" }));
+    }
+
+    [Test]
+    public void EncodesQuaternionAsStructWithSubEntries()
+    {
+        // Arrange
+        var obj = new StructPropertiesClass { Rotation = new Quaternion(1f, 2f, 3f, 4f) };
+
+        // Act
+        var entry = EntryConvert.EncodeObject(obj);
+        var quatEntry = entry.SubEntries.First(e => e.Identifier == nameof(StructPropertiesClass.Rotation));
+
+        // Assert
+        Assert.That(quatEntry.Value.Type, Is.EqualTo(EntryValueType.Struct));
+        Assert.That(quatEntry.SubEntries, Has.Count.EqualTo(4));
+        Assert.That(quatEntry.SubEntries.Select(e => e.Identifier), Is.EquivalentTo(new[] { "X", "Y", "Z", "W" }));
+    }
+
+    [Test]
+    public void Vector3ValuesOnRoundTripPreserved()
+    {
+        // Arrange
+        var original = new StructPropertiesClass
+        {
+            Position3D = new Vector3(1.5f, 2.5f, 3.5f)
+        };
+
+        // Act
+        var entry = EntryConvert.EncodeObject(original);
+        var restored = new StructPropertiesClass();
+        EntryConvert.UpdateInstance(restored, entry);
+
+        // Assert
+        Assert.That(restored.Position3D, Is.EqualTo(original.Position3D));
+    }
+
+    [Test]
+    public void Vector2ValuesOnRoundTripPreserved()
+    {
+        // Arrange
+        var original = new StructPropertiesClass
+        {
+            Position2D = new Vector2(10f, 20f)
+        };
+
+        // Act
+        var entry = EntryConvert.EncodeObject(original);
+        var restored = new StructPropertiesClass();
+        EntryConvert.UpdateInstance(restored, entry);
+
+        // Assert
+        Assert.That(restored.Position2D, Is.EqualTo(original.Position2D));
+    }
+
+    [Test]
+    public void QuaternionValuesOnRoundTripPreserved()
+    {
+        // Arrange
+        var original = new StructPropertiesClass
+        {
+            Rotation = new Quaternion(1f, 2f, 3f, 4f)
+        };
+
+        // Act
+        var entry = EntryConvert.EncodeObject(original);
+        var restored = new StructPropertiesClass();
+        EntryConvert.UpdateInstance(restored, entry);
+
+        // Assert
+        Assert.That(restored.Rotation, Is.EqualTo(original.Rotation));
+    }
+
+    [Test]
+    public void CreatesDefaultSubEntriesForVector3OnEncodeClass()
+    {
+        // Act
+        var entry = EntryConvert.EncodeClass(typeof(StructPropertiesClass));
+        var vectorEntry = entry.SubEntries.First(e => e.Identifier == nameof(StructPropertiesClass.Position3D));
+
+        // Assert
+        Assert.That(vectorEntry.Value.Type, Is.EqualTo(EntryValueType.Struct));
+        Assert.That(vectorEntry.SubEntries, Has.Count.EqualTo(3));
+    }
+
     [Test]
     public void ParametersShouldRespectRequiredAttribute()
     {
@@ -138,7 +254,7 @@ public class EntryConvertSerializationTests
 
         // Act
         var entry = EntryConvert.EncodeMethod(method);
-      
+
         var plainParameterValidation = entry.Parameters.SubEntries.First(x => x.DisplayName == "plainParameter").Validation;
         var requiredParameterValidation = entry.Parameters.SubEntries.First(x => x.DisplayName == "requiredParameter").Validation;
         var nullableValidation = entry.Parameters.SubEntries.First(x => x.DisplayName == "nullableString").Validation;

--- a/src/Tests/Moryx.Tests/Serialization/EntryConvertSerializationTests.cs
+++ b/src/Tests/Moryx.Tests/Serialization/EntryConvertSerializationTests.cs
@@ -205,6 +205,16 @@ public class EntryConvertSerializationTests
         Assert.That(structEntry.SubEntries, Has.Count.EqualTo(expectedCount));
     }
 
+    [Test(Description = "Decimal maps to EntryValueType.Double.")]
+    public void DecimalMapsToDoubleValueType()
+    {
+        // Act
+        var valueType = EntryConvert.TransformType(typeof(decimal));
+
+        // Assert
+        Assert.That(valueType, Is.EqualTo(EntryValueType.Double));
+    }
+
     [Test(Description = "DateTime maps to EntryValueType.DateTime.")]
     public void DateTimeMapsToDateTimeValueType()
     {

--- a/src/Tests/Moryx.Tests/Serialization/LocalizationSerializationTests.cs
+++ b/src/Tests/Moryx.Tests/Serialization/LocalizationSerializationTests.cs
@@ -55,8 +55,8 @@ public class LocalizationSerializationTests
         var entriesGerman = EntryConvert.EncodeObject(dummyClass);
 
         // Assert
-        Assert.That(entriesGerman.SubEntries[14].DisplayName, Is.EqualTo(nameof(DummyClass.SingleClassNonLocalized)));
-        Assert.That(entriesGerman.SubEntries[14].Description, Is.Null);
+        Assert.That(entriesGerman.SubEntries[16].DisplayName, Is.EqualTo(nameof(DummyClass.SingleClassNonLocalized)));
+        Assert.That(entriesGerman.SubEntries[16].Description, Is.Null);
     }
 
     [Test]

--- a/src/Tests/Moryx.Tests/Serialization/SerializationTests.cs
+++ b/src/Tests/Moryx.Tests/Serialization/SerializationTests.cs
@@ -399,15 +399,13 @@ public class SerializationTests
 
         // Act
         var encoded = EntryConvert.EncodeObject(dummy).SubEntries;
-        var encodedSub = encoded[4].SubEntries[0].SubEntries;
+        var encodedSub = encoded[6].SubEntries[0].SubEntries;
 
         // Assert
         DummyAssert(encoded, encodedSub);
-        var expected = new[] { "10", "Thomas", "10" };
-        for (var i = 0; i < 3; i++)
-        {
-            Assert.That(encoded[i].Value.Current, Is.EqualTo(expected[i]), "Property value missmatch");
-        }
+        Assert.That(encoded[0].Value.Current, Is.EqualTo("10"), "Property value missmatch");
+        Assert.That(encoded[1].Value.Current, Is.EqualTo("Thomas"), "Property value missmatch");
+        Assert.That(encoded[4].Value.Current, Is.EqualTo("10"), "Property value missmatch");
     }
 
     [Test]
@@ -669,11 +667,11 @@ public class SerializationTests
         // Act
         encoded.SubEntries[0].Value.Current = "10";
         encoded.SubEntries[1].Value.Current = "Thomas";
-        encoded.SubEntries[3].SubEntries[1].Value.Current = encoded.SubEntries[3].SubEntries[1].Value.Possible[2].Key;
-        for (var i = 4; i < 7; i++)
+        encoded.SubEntries[5].SubEntries[1].Value.Current = encoded.SubEntries[5].SubEntries[1].Value.Possible[2].Key;
+        for (var i = 6; i < 9; i++)
         {
             var colEntry = encoded.SubEntries[i];
-            for (var j = 0; j < i; j++)
+            for (var j = 0; j < i - 2; j++)
             {
                 var newInstance = colEntry.Prototypes[0].Instantiate();
                 newInstance.SubEntries[0].Value.Current = j.ToString("F2", defaultSerialization.FormatProvider);
@@ -953,7 +951,7 @@ public class SerializationTests
         // Assert
         var buffer = new byte[targetStreamDummy.FileStream.Length];
         targetStreamDummy.FileStream.Seek(0, SeekOrigin.Begin);
-        targetStreamDummy.FileStream.Read(buffer, 0, buffer.Length);
+        targetStreamDummy.FileStream.ReadExactly(buffer, 0, buffer.Length);
 
         var stringValue = Encoding.UTF8.GetString(buffer);
 
@@ -991,7 +989,7 @@ public class SerializationTests
 
         // Assert
         Assert.That(encoded.SubEntries[0].Value.Current, Is.EqualTo(1001.ToString(formatProvider)));
-        Assert.That(encoded.SubEntries[3].SubEntries[0].Value.Current, Is.EqualTo(1.1234f.ToString(formatProvider)));
+        Assert.That(encoded.SubEntries[5].SubEntries[0].Value.Current, Is.EqualTo(1.1234f.ToString(formatProvider)));
 
         Assert.That(dummyDecoded.Number, Is.EqualTo(1001));
         Assert.That(dummyDecoded.SingleClass.Foo, Is.EqualTo(1.1234f));
@@ -1179,30 +1177,31 @@ public class SerializationTests
         // Assert
         var expected = new[]
         {
-            new {Name = "Number", Type = EntryValueType.Int32, ReadOnly = false},
-            new {Name = "Name", Type = EntryValueType.String, ReadOnly = false},
-            new {Name = "ReadOnly", Type = EntryValueType.Int32, ReadOnly = true},
-            new {Name = "SingleClass", Type = EntryValueType.Class, ReadOnly = false},
-            new {Name = "SubArray", Type = EntryValueType.Collection, ReadOnly = false},
-            new {Name = "SubList", Type = EntryValueType.Collection, ReadOnly = false},
-            new {Name = "SubEnumerable", Type = EntryValueType.Collection, ReadOnly = false},
-            new {Name = "SubDictionary", Type = EntryValueType.Collection, ReadOnly = false},
-            new {Name = "EnumArray", Type = EntryValueType.Collection, ReadOnly = false},
-            new {Name = "EnumList", Type = EntryValueType.Collection, ReadOnly = false},
-            new {Name = "EnumEnumerable", Type = EntryValueType.Collection, ReadOnly = false},
-            new {Name = "BoolArray", Type = EntryValueType.Collection, ReadOnly = false},
-            new {Name = "BoolList", Type = EntryValueType.Collection, ReadOnly = false},
-            new {Name = "BoolEnumerable", Type = EntryValueType.Collection, ReadOnly = false},
-            new {Name = "SingleClassNonLocalized", Type = EntryValueType.Class, ReadOnly = false}
+            new { Name = "Number", Type = EntryValueType.Int32, ReadOnly = false }, new { Name = "Name", Type = EntryValueType.String, ReadOnly = false },
+            new { Name = "ModifiedAt", Type = EntryValueType.DateTime, ReadOnly = false },
+            new { Name = "CreatedAt", Type = EntryValueType.DateTime, ReadOnly = false },
+            new { Name = "ReadOnly", Type = EntryValueType.Int32, ReadOnly = true },
+            new { Name = "SingleClass", Type = EntryValueType.Class, ReadOnly = false },
+            new { Name = "SubArray", Type = EntryValueType.Collection, ReadOnly = false },
+            new { Name = "SubList", Type = EntryValueType.Collection, ReadOnly = false },
+            new { Name = "SubEnumerable", Type = EntryValueType.Collection, ReadOnly = false },
+            new { Name = "SubDictionary", Type = EntryValueType.Collection, ReadOnly = false },
+            new { Name = "EnumArray", Type = EntryValueType.Collection, ReadOnly = false },
+            new { Name = "EnumList", Type = EntryValueType.Collection, ReadOnly = false },
+            new { Name = "EnumEnumerable", Type = EntryValueType.Collection, ReadOnly = false },
+            new { Name = "BoolArray", Type = EntryValueType.Collection, ReadOnly = false },
+            new { Name = "BoolList", Type = EntryValueType.Collection, ReadOnly = false },
+            new { Name = "BoolEnumerable", Type = EntryValueType.Collection, ReadOnly = false },
+            new { Name = "SingleClassNonLocalized", Type = EntryValueType.Class, ReadOnly = false }
         };
         Assert.That(encoded.Count, Is.EqualTo(expected.Length), "Number of entries does not match");
         for (var i = 0; i < encoded.Count; i++)
         {
-            Assert.That(encoded[i].Identifier, Is.EqualTo(expected[i].Name), "Property name missmatch");
-            Assert.That(encoded[i].Value.Type, Is.EqualTo(expected[i].Type), "Type missmatch");
-            Assert.That(encoded[i].Value.IsReadOnly, Is.EqualTo(expected[i].ReadOnly), "ReadOnly missmatch");
+            Assert.That(encoded[i].Identifier, Is.EqualTo(expected[i].Name), "Property name mismatch");
+            Assert.That(encoded[i].Value.Type, Is.EqualTo(expected[i].Type), "Type mismatch");
+            Assert.That(encoded[i].Value.IsReadOnly, Is.EqualTo(expected[i].ReadOnly), "ReadOnly mismatch");
         }
-        Assert.That(encodedSub[0].Identifier, Is.EqualTo("Foo"), "Name missmatch");
+        Assert.That(encodedSub[0].Identifier, Is.EqualTo("Foo"), "Name mismatch");
         Assert.That(encodedSub[0].Value.Type, Is.EqualTo(EntryValueType.Single), "Float not detected");
         Assert.That(encodedSub[1].Identifier, Is.EqualTo("Enum"));
         Assert.That(encodedSub[1].Value.Type, Is.EqualTo(EntryValueType.Enum), "Enum not detected");

--- a/src/Tests/Moryx.Tests/Serialization/StructPropertiesClass.cs
+++ b/src/Tests/Moryx.Tests/Serialization/StructPropertiesClass.cs
@@ -1,0 +1,15 @@
+// Copyright (c) 2026 Phoenix Contact GmbH & Co. KG
+// Licensed under the Apache License, Version 2.0
+
+using System.Numerics;
+
+namespace Moryx.Tests.Serialization;
+
+public class StructPropertiesClass
+{
+    public Vector2 Position2D { get; set; }
+
+    public Vector3 Position3D { get; set; }
+
+    public Quaternion Rotation { get; set; }
+}

--- a/src/Tests/Moryx.Tests/Serialization/StructPropertiesClass.cs
+++ b/src/Tests/Moryx.Tests/Serialization/StructPropertiesClass.cs
@@ -11,5 +11,9 @@ public class StructPropertiesClass
 
     public Vector3 Position3D { get; set; }
 
+    public Vector4 Position4D { get; set; }
+
     public Quaternion Rotation { get; set; }
+
+    public Plane Surface { get; set; }
 }


### PR DESCRIPTION
based on #1443

- Added DateOnly, TimeOnly, DateTime and TimeSpan (requested by #1071) to EntryUnitType for official support
- Support serialization of structs with custom serializers. Implemented: Vector2, Vector3, Quaternion
- Add support for DateTimeOffset treated as DateTime and mapped to UTC


<img width="867" height="172" alt="Screenshot 2026-08-18 at 17 32 55" src="https://github.com/user-attachments/assets/9bae3bba-b448-4363-893b-06048f800bb2" />

<img width="879" height="336" alt="Screenshot 2026-08-18 at 17 33 24" src="https://github.com/user-attachments/assets/c1668cd9-d263-417f-860a-c3dbd2a8e375" />




close #1071