### PR TITLE
Support IEEE754 special values in FloatColumnMapper

### DIFF
--- a/src/Moryx.Products.Management/Plugins/GenericStrategies/FloatColumnMapper.cs
+++ b/src/Moryx.Products.Management/Plugins/GenericStrategies/FloatColumnMapper.cs
@@ -1,7 +1,9 @@
 // Copyright (c) 2026 Phoenix Contact GmbH & Co. KG
 // Licensed under the Apache License, Version 2.0
 
+using System.Reflection;
 using Moryx.Container;
+using Moryx.Tools;
 
 namespace Moryx.Products.Management;
 
@@ -12,7 +14,80 @@ namespace Moryx.Products.Management;
 [Component(LifeCycle.Transient, typeof(IPropertyMapper), Name = nameof(FloatColumnMapper))]
 internal class FloatColumnMapper : ColumnMapper<double>
 {
+    // IEEE 754 special values (NaN, +/-Infinity) are not supported by all databases.
+    // PostgreSQL stores them natively in float8, but SQLite throws on REAL columns.
+    // To ensure cross-database compatibility, we encode these as sentinel values
+    // before writing to the database and decode them back when reading.
+    //
+    // The sentinels are created using double.BitIncrement, which returns the next
+    // representable double value (one ULP — unit of least precision — toward +Infinity).
+    // Starting from double.MinValue, each successive BitIncrement
+    // produces a distinct, double that is close to double.MinValue.
+    // At this extreme, the gap between representable values is heavily minimized, so
+    // these values are unlikely to collide with any real-world data.
+    //
+    // The sentinel values are stored as their raw long bit representation to ensure exact bit-level matching.
+    private static readonly long _sentinelNaNBits =
+        BitConverter.DoubleToInt64Bits(double.BitIncrement(double.MinValue));
+    private static readonly long _sentinelPositiveInfinityBits =
+        BitConverter.DoubleToInt64Bits(double.BitIncrement(double.BitIncrement(double.MinValue)));
+    private static readonly long _sentinelNegativeInfinityBits =
+        BitConverter.DoubleToInt64Bits(double.BitIncrement(double.BitIncrement(double.BitIncrement(double.MinValue))));
+
     public FloatColumnMapper(Type targetType) : base(targetType)
     {
+    }
+
+    /// <inheritdoc />
+    protected override IPropertyAccessor<object, double> CreatePropertyAccessor(PropertyInfo objectProp)
+    {
+        if (objectProp.PropertyType == typeof(double) || objectProp.PropertyType == typeof(float) || objectProp.PropertyType == typeof(decimal))
+        {
+            return new ConversionAccessor<double, double>(objectProp, ToColumn, ToProperty);
+        }
+
+        return base.CreatePropertyAccessor(objectProp);
+    }
+
+    private static double ToColumn(double value)
+    {
+        if (double.IsNaN(value))
+        {
+            return BitConverter.Int64BitsToDouble(_sentinelNaNBits);
+        }
+
+        if (double.IsPositiveInfinity(value))
+        {
+            return BitConverter.Int64BitsToDouble(_sentinelPositiveInfinityBits);
+        }
+
+        if (double.IsNegativeInfinity(value))
+        {
+            return BitConverter.Int64BitsToDouble(_sentinelNegativeInfinityBits);
+        }
+
+        return value;
+    }
+
+    private static double ToProperty(double value)
+    {
+        var bits = BitConverter.DoubleToInt64Bits(value);
+
+        if (bits == _sentinelNaNBits)
+        {
+            return double.NaN;
+        }
+
+        if (bits == _sentinelPositiveInfinityBits)
+        {
+            return double.PositiveInfinity;
+        }
+
+        if (bits == _sentinelNegativeInfinityBits)
+        {
+            return double.NegativeInfinity;
+        }
+
+        return value;
     }
 }

--- a/src/Moryx.Products.Management/Plugins/GenericStrategies/FloatColumnMapper.cs
+++ b/src/Moryx.Products.Management/Plugins/GenericStrategies/FloatColumnMapper.cs
@@ -27,12 +27,13 @@ internal class FloatColumnMapper : ColumnMapper<double>
     // these values are unlikely to collide with any real-world data.
     //
     // The sentinel values are stored as their raw long bit representation to ensure exact bit-level matching.
-    private static readonly long _sentinelNaNBits =
-        BitConverter.DoubleToInt64Bits(double.BitIncrement(double.MinValue));
-    private static readonly long _sentinelPositiveInfinityBits =
-        BitConverter.DoubleToInt64Bits(double.BitIncrement(double.BitIncrement(double.MinValue)));
-    private static readonly long _sentinelNegativeInfinityBits =
-        BitConverter.DoubleToInt64Bits(double.BitIncrement(double.BitIncrement(double.BitIncrement(double.MinValue))));
+    private static readonly double _sentinelNaN = double.BitIncrement(double.MinValue);
+    private static readonly double _sentinelPositiveInfinity = double.BitIncrement(_sentinelNaN);
+    private static readonly double _sentinelNegativeInfinity = double.BitIncrement(_sentinelPositiveInfinity);
+
+    private static readonly long _sentinelNaNBits = BitConverter.DoubleToInt64Bits(_sentinelNaN);
+    private static readonly long _sentinelPositiveInfinityBits = BitConverter.DoubleToInt64Bits(_sentinelPositiveInfinity);
+    private static readonly long _sentinelNegativeInfinityBits = BitConverter.DoubleToInt64Bits(_sentinelNegativeInfinity);
 
     public FloatColumnMapper(Type targetType) : base(targetType)
     {
@@ -53,17 +54,17 @@ internal class FloatColumnMapper : ColumnMapper<double>
     {
         if (double.IsNaN(value))
         {
-            return BitConverter.Int64BitsToDouble(_sentinelNaNBits);
+            return _sentinelNaN;
         }
 
         if (double.IsPositiveInfinity(value))
         {
-            return BitConverter.Int64BitsToDouble(_sentinelPositiveInfinityBits);
+            return _sentinelPositiveInfinity;
         }
 
         if (double.IsNegativeInfinity(value))
         {
-            return BitConverter.Int64BitsToDouble(_sentinelNegativeInfinityBits);
+            return _sentinelNegativeInfinity;
         }
 
         return value;

--- a/src/Tests/Moryx.Products.IntegrationTests/FloatColumnMapperTests.cs
+++ b/src/Tests/Moryx.Products.IntegrationTests/FloatColumnMapperTests.cs
@@ -1,0 +1,224 @@
+// Copyright (c) 2026 Phoenix Contact GmbH & Co. KG
+// Licensed under the Apache License, Version 2.0
+
+using Moq;
+using Moryx.Products.Management;
+using Moryx.Products.Management.Model;
+using NUnit.Framework;
+
+namespace Moryx.Products.IntegrationTests;
+
+[TestFixture]
+public class FloatColumnMapperTests
+{
+    private FloatColumnMapper _mapper;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _mapper = new FloatColumnMapper(typeof(TestObject));
+        _mapper.Initialize(new PropertyMapperConfig
+        {
+            PropertyName = nameof(TestObject.Value),
+            Column = nameof(IGenericColumns.Float1),
+            PluginName = nameof(FloatColumnMapper)
+        });
+    }
+
+    [TestCase(0.0)]
+    [TestCase(1.0)]
+    [TestCase(-1.0)]
+    [TestCase(42.5)]
+    [TestCase(double.MinValue)]
+    [TestCase(double.MaxValue)]
+    [TestCase(double.Epsilon)]
+    [Description("Regular double values are stored in the column and restored exactly after a write-read cycle.")]
+    public void RoundTripsRegularValues(double value)
+    {
+        // Arrange
+        var source = new TestObject(value);
+        var columns = CreateColumns();
+
+        // Act
+        _mapper.WriteValue(source, columns);
+        var target = new TestObject();
+        _mapper.ReadValue(columns, target);
+
+        // Assert
+        Assert.That(columns.Float1, Is.EqualTo(value));
+        Assert.That(target.Value, Is.EqualTo(value));
+    }
+
+    [Test(Description = "NaN is encoded as a sentinel for storage and decoded back to NaN after reading.")]
+    public void RoundTripsNaN()
+    {
+        // Arrange
+        var source = new TestObject(double.NaN);
+        var columns = CreateColumns();
+
+        // Act
+        _mapper.WriteValue(source, columns);
+        var target = new TestObject();
+        _mapper.ReadValue(columns, target);
+
+        // Assert
+        Assert.That(double.IsNaN(columns.Float1), Is.False);
+        Assert.That(double.IsNaN(target.Value), Is.True);
+    }
+
+    [Test(Description = "Positive infinity is encoded as a sentinel for storage and decoded back to positive infinity after reading.")]
+    public void RoundTripsPositiveInfinity()
+    {
+        // Arrange
+        var source = new TestObject(double.PositiveInfinity);
+        var columns = CreateColumns();
+
+        // Act
+        _mapper.WriteValue(source, columns);
+        var target = new TestObject();
+        _mapper.ReadValue(columns, target);
+
+        // Assert
+        Assert.That(double.IsInfinity(columns.Float1), Is.False);
+        Assert.That(target.Value, Is.EqualTo(double.PositiveInfinity));
+    }
+
+    [Test(Description = "Negative infinity is encoded as a sentinel for storage and decoded back to negative infinity after reading.")]
+    public void RoundTripsNegativeInfinity()
+    {
+        // Arrange
+        var source = new TestObject(double.NegativeInfinity);
+        var columns = CreateColumns();
+
+        // Act
+        _mapper.WriteValue(source, columns);
+        var target = new TestObject();
+        _mapper.ReadValue(columns, target);
+
+        // Assert
+        Assert.That(double.IsInfinity(columns.Float1), Is.False);
+        Assert.That(target.Value, Is.EqualTo(double.NegativeInfinity));
+    }
+
+    [Test(Description = "Writing NaN stores a sentinel instead of raw NaN, which would be rejected by some database providers.")]
+    public void DoesNotStoreRawNaNInColumn()
+    {
+        // Arrange
+        var source = new TestObject(double.NaN);
+        var columns = CreateColumns();
+
+        // Act
+        _mapper.WriteValue(source, columns);
+
+        // Assert — the column must not contain raw NaN (SQLite would reject it)
+        Assert.That(double.IsNaN(columns.Float1), Is.False);
+    }
+
+    [Test(Description = "Writing positive infinity stores a sentinel instead of raw infinity, which would be rejected by some database providers.")]
+    public void DoesNotStoreRawPositiveInfinityInColumn()
+    {
+        // Arrange
+        var source = new TestObject(double.PositiveInfinity);
+        var columns = CreateColumns();
+
+        // Act
+        _mapper.WriteValue(source, columns);
+
+        // Assert
+        Assert.That(double.IsInfinity(columns.Float1), Is.False);
+    }
+
+    [Test(Description = "Writing negative infinity stores a sentinel instead of raw infinity, which would be rejected by some database providers.")]
+    public void DoesNotStoreRawNegativeInfinityInColumn()
+    {
+        // Arrange
+        var source = new TestObject(double.NegativeInfinity);
+        var columns = CreateColumns();
+
+        // Act
+        _mapper.WriteValue(source, columns);
+
+        // Assert
+        Assert.That(double.IsInfinity(columns.Float1), Is.False);
+    }
+
+    [Test(Description = "NaN, positive infinity, and negative infinity each map to a unique sentinel value so they can be distinguished after reading.")]
+    public void SpecialValuesProduceDistinctSentinels()
+    {
+        // Arrange
+        var nanColumns = CreateColumns();
+        var posInfColumns = CreateColumns();
+        var negInfColumns = CreateColumns();
+
+        // Act
+        _mapper.WriteValue(new TestObject(double.NaN), nanColumns);
+        _mapper.WriteValue(new TestObject(double.PositiveInfinity), posInfColumns);
+        _mapper.WriteValue(new TestObject(double.NegativeInfinity), negInfColumns);
+
+        // Assert — all three sentinels must be distinct
+        Assert.That(nanColumns.Float1, Is.Not.EqualTo(posInfColumns.Float1));
+        Assert.That(nanColumns.Float1, Is.Not.EqualTo(negInfColumns.Float1));
+        Assert.That(posInfColumns.Float1, Is.Not.EqualTo(negInfColumns.Float1));
+    }
+
+    [Test(Description = "Reading a raw NaN from a column passes it through as NaN since it does not match any sentinel.")]
+    public void ReturnsNaNForRawNaNFromPostgres()
+    {
+        // Simulate a PostgreSQL database that already stored raw NaN
+        var columns = CreateColumns();
+        columns.Float1 = double.NaN;
+        var target = new TestObject();
+
+        // Act
+        _mapper.ReadValue(columns, target);
+
+        // Assert — raw NaN does not match any sentinel
+        Assert.That(double.IsNaN(columns.Float1), Is.True);
+        Assert.That(double.IsNaN(target.Value), Is.True);
+    }
+
+    [Test(Description = "HasChanged detects a difference between a raw NaN in the column and the sentinel-encoded NaN")]
+    public void DetectsChangeFromRawNaNToSentinelNaN()
+    {
+        // Simulate: PostgreSQL has raw NaN in the column, object has NaN
+        // which gets encoded as sentine
+        var columns = CreateColumns();
+        columns.Float1 = double.NaN;
+        var source = new TestObject(double.NaN);
+
+        // Act
+        var changed = _mapper.HasChanged(columns, source);
+
+        // Assert
+        Assert.That(double.IsNaN(columns.Float1), Is.True);
+        Assert.That(changed, Is.True);
+    }
+
+    [Test(Description = "After writing a sentinel value, HasChanged returns false for the same source value.")]
+    public void SentinelRoundTripShowsNoChange()
+    {
+        // Write sentinel, then check HasChanged against the same value
+        var source = new TestObject(double.NaN);
+        var columns = CreateColumns();
+        _mapper.WriteValue(source, columns);
+
+        // Act
+        var changed = _mapper.HasChanged(columns, source);
+
+        // Assert
+        Assert.That(double.IsNaN(columns.Float1), Is.False);
+        Assert.That(changed, Is.False);
+    }
+
+    private static IGenericColumns CreateColumns()
+    {
+        var mock = new Mock<IGenericColumns>();
+        mock.SetupAllProperties();
+        return mock.Object;
+    }
+
+    private class TestObject(double value = 0)
+    {
+        public double Value { get; set; } = value;
+    }
+}

--- a/src/Tests/Moryx.Products.IntegrationTests/FloatColumnMapperTests.cs
+++ b/src/Tests/Moryx.Products.IntegrationTests/FloatColumnMapperTests.cs
@@ -100,48 +100,6 @@ public class FloatColumnMapperTests
         Assert.That(target.Value, Is.EqualTo(double.NegativeInfinity));
     }
 
-    [Test(Description = "Writing NaN stores a sentinel instead of raw NaN, which would be rejected by some database providers.")]
-    public void DoesNotStoreRawNaNInColumn()
-    {
-        // Arrange
-        var source = new TestObject(double.NaN);
-        var columns = CreateColumns();
-
-        // Act
-        _mapper.WriteValue(source, columns);
-
-        // Assert — the column must not contain raw NaN (SQLite would reject it)
-        Assert.That(double.IsNaN(columns.Float1), Is.False);
-    }
-
-    [Test(Description = "Writing positive infinity stores a sentinel instead of raw infinity, which would be rejected by some database providers.")]
-    public void DoesNotStoreRawPositiveInfinityInColumn()
-    {
-        // Arrange
-        var source = new TestObject(double.PositiveInfinity);
-        var columns = CreateColumns();
-
-        // Act
-        _mapper.WriteValue(source, columns);
-
-        // Assert
-        Assert.That(double.IsInfinity(columns.Float1), Is.False);
-    }
-
-    [Test(Description = "Writing negative infinity stores a sentinel instead of raw infinity, which would be rejected by some database providers.")]
-    public void DoesNotStoreRawNegativeInfinityInColumn()
-    {
-        // Arrange
-        var source = new TestObject(double.NegativeInfinity);
-        var columns = CreateColumns();
-
-        // Act
-        _mapper.WriteValue(source, columns);
-
-        // Assert
-        Assert.That(double.IsInfinity(columns.Float1), Is.False);
-    }
-
     [Test(Description = "NaN, positive infinity, and negative infinity each map to a unique sentinel value so they can be distinguished after reading.")]
     public void SpecialValuesProduceDistinctSentinels()
     {
@@ -173,7 +131,6 @@ public class FloatColumnMapperTests
         _mapper.ReadValue(columns, target);
 
         // Assert — raw NaN does not match any sentinel
-        Assert.That(double.IsNaN(columns.Float1), Is.True);
         Assert.That(double.IsNaN(target.Value), Is.True);
     }
 
@@ -190,7 +147,6 @@ public class FloatColumnMapperTests
         var changed = _mapper.HasChanged(columns, source);
 
         // Assert
-        Assert.That(double.IsNaN(columns.Float1), Is.True);
         Assert.That(changed, Is.True);
     }
 


### PR DESCRIPTION
`double.NaN`, `double.PositiveInfinity` and `double.NegativeInfinity` are valid IEEE 754 values that can appear on product properties mapped to float columns. PostgreSQL accepts these in `float8` columns, but SQLite throws an exception when writing them to `REAL` columns.

The `FloatColumnMapper` now encodes NaN/+-Infinity as sentinel values before writing to the database and decodes them back when reading. 

The sentinels are created by stepping from `double.MinValue` by bit increment. each step produces the next representable double. Collision with real data is effectively impossible.

**PostgreSQL backward compatibility**

Existing PostgreSQL databases may already contain raw NaN/Infinity values. These are read correctly. On the next save, `HasChanged` detects the mismatch between the raw value in the column and the sentinel-encoded value, triggering a version update that writes the sentinel. No migration needed.

---

Add to docs later (to avoid conflicts): 

> IEEE 754 special values (`NaN`, `PositiveInfinity`, `NegativeInfinity`) are not natively supported by all databases — PostgreSQL accepts them in `float8` columns, but SQLite throws on `REAL` columns. To ensure cross-database compatibility, the mapper encodes these as sentinel values (distinct doubles near `double.MinValue`) on write and decodes them back on read. Existing PostgreSQL databases with raw NaN/Infinity values are handled automatically: the values are read correctly and converted to sentinels on the next save.

---

link #469 because its related