### PR TITLE
Use PropertyAccessor in bindings ReflectionResolver

### DIFF
--- a/src/Moryx/Bindings/ReflectionResolver.cs
+++ b/src/Moryx/Bindings/ReflectionResolver.cs
@@ -2,11 +2,12 @@
 // Licensed under the Apache License, Version 2.0
 
 using System.Reflection;
+using Moryx.Tools;
 
 namespace Moryx.Bindings;
 
 /// <summary>
-/// Resolve binding using reflection
+/// Resolve binding using optimized property access
 /// </summary>
 public class ReflectionResolver : BindingResolverBase
 {
@@ -14,6 +15,16 @@ public class ReflectionResolver : BindingResolverBase
     /// Name of the property
     /// </summary>
     private readonly string _propertyName;
+
+    /// <summary>
+    /// Type of the last resolved source object to detect type changes
+    /// </summary>
+    private Type _cachedType;
+
+    /// <summary>
+    /// PropertyAccessor to access the property of the type
+    /// </summary>
+    private IPropertyAccessor<object, object> _cachedAccessor;
 
     /// <summary>
     /// Create new <see cref="ReflectionResolver"/> for a property
@@ -26,34 +37,46 @@ public class ReflectionResolver : BindingResolverBase
     /// <inheritdoc />
     protected sealed override object Resolve(object source)
     {
-        var property = GetProperty(source);
-        return property == null ? null : property.GetValue(source);
+        var accessor = GetAccessor(source);
+        return accessor?.ReadProperty(source);
     }
 
     /// <inheritdoc />
     protected sealed override bool Update(object source, object value)
     {
-        var property = GetProperty(source);
-        if (property == null || !property.CanWrite)
+        var accessor = GetAccessor(source);
+        if (accessor == null || !accessor.Property.CanWrite)
+        {
             return false;
+        }
 
-        if (value is IConvertible && typeof(IConvertible).IsAssignableFrom(property.PropertyType))
-            property.SetValue(source, Convert.ChangeType(value, property.PropertyType));
-        else
-            property.SetValue(source, value);
+        accessor.WriteProperty(source, value);
         return true;
     }
 
-    /// <summary>
-    /// Find property by name on the source object
-    /// </summary>
-    private PropertyInfo GetProperty(object source)
+    private IPropertyAccessor<object, object> GetAccessor(object source)
     {
-        var type = source.GetType();
+        var sourceType = source.GetType();
+        if (_cachedType == sourceType)
+        {
+            return _cachedAccessor;
+        }
 
+        var property = FindProperty(sourceType);
+        _cachedAccessor = property != null ? ReflectionTool.PropertyAccessor(property) : null;
+        _cachedType = sourceType;
+        return _cachedAccessor;
+    }
+
+    /// <summary>
+    /// Find property by name on the source type
+    /// </summary>
+    private PropertyInfo FindProperty(Type type)
+    {
         // Find correct property by navigating down the type tree
         PropertyInfo property = null;
         const BindingFlags filter = BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static | BindingFlags.DeclaredOnly;
+
         while (property == null && type != null)
         {
             property = type.GetProperty(_propertyName, filter);


### PR DESCRIPTION
The ReflectionResolver now uses PropertyAccessor with compiled delegates instead of PropertyInfo.GetValue()/SetValue() for property access, replacing repeated reflection overhead with a direct method invocation. 

The accessor is cached per source type to handle polymorphic objects while still providing fast access on subsequent calls.

No additional tests, the Binding-Tests already check the behavior.

close #11
