### PR TITLE
Add additional extensions to retrieve product information from processes

### DIFF
--- a/src/Moryx.AbstractionLayer.TestTools/DummyProductInstance.cs
+++ b/src/Moryx.AbstractionLayer.TestTools/DummyProductInstance.cs
@@ -10,4 +10,8 @@ namespace Moryx.AbstractionLayer.TestTools;
 /// </summary>
 public class DummyProductInstance : ProductInstance
 {
+    /// <summary>
+    /// Example information on an instance
+    /// </summary>
+    public string SerialNumber { get; set; }
 }

--- a/src/Moryx.AbstractionLayer.TestTools/DummyProductType.cs
+++ b/src/Moryx.AbstractionLayer.TestTools/DummyProductType.cs
@@ -8,6 +8,7 @@ namespace Moryx.AbstractionLayer.TestTools;
 /// <summary>
 /// Dummy implementation of a <see cref="ProductType"/>
 /// </summary>
+#pragma warning disable CS0659 // Type overrides Object.Equals(object o) but does not override Object.GetHashCode()
 public class DummyProductType : ProductType
 {
     /// <inheritdoc />
@@ -15,13 +16,14 @@ public class DummyProductType : ProductType
     {
         return new DummyProductInstance();
     }
-    /// <inheritdoc/>
 
+    /// <inheritdoc/>
     public override bool Equals(object obj)
     {
-        var toCompareWith = obj as DummyProductType;
-        if (toCompareWith == null)
+        if (obj is not DummyProductType toCompareWith)
+        {
             return false;
+        }
 
         return toCompareWith.Id == Id && toCompareWith.Name == Name && toCompareWith.State == State
                && ((toCompareWith.Identity is null && Identity is null) || toCompareWith.Identity.Equals(Identity));
@@ -52,14 +54,15 @@ public class DummyProductTypeWithParts : DummyProductType
     /// <inheritdoc/>
     public override bool Equals(object obj)
     {
-        var toCompareWith = obj as DummyProductTypeWithParts;
-        if (toCompareWith == null)
+        if (obj is not DummyProductTypeWithParts toCompareWith)
+        {
             return false;
+        }
 
-        return base.Equals(toCompareWith) &&
-               ((toCompareWith.ProductPartLink is null && ProductPartLink is null) ||
-                toCompareWith.ProductPartLink.Equals(ProductPartLink))
-               && ((toCompareWith.ProductPartLinkEnumerable is null && ProductPartLinkEnumerable is null) ||
-                   Enumerable.SequenceEqual<DummyProductPartLink>(toCompareWith.ProductPartLinkEnumerable, ProductPartLinkEnumerable));
+        return base.Equals(toCompareWith)
+            && ((toCompareWith.ProductPartLink is null && ProductPartLink is null)
+            || toCompareWith.ProductPartLink.Equals(ProductPartLink))
+            && ((toCompareWith.ProductPartLinkEnumerable is null && ProductPartLinkEnumerable is null)
+            || Enumerable.SequenceEqual(toCompareWith.ProductPartLinkEnumerable, ProductPartLinkEnumerable));
     }
 }

--- a/src/Moryx.AbstractionLayer/Processes/ProcessExtensions.cs
+++ b/src/Moryx.AbstractionLayer/Processes/ProcessExtensions.cs
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0
 
 using Moryx.AbstractionLayer.Activities;
+using Moryx.AbstractionLayer.Products;
+using Moryx.AbstractionLayer.Recipes;
 
 namespace Moryx.AbstractionLayer.Processes;
 
@@ -13,6 +15,164 @@ public static class ProcessExtensions
     /// <param name="process">Extended instance of <see cref="IProcess"/></param>
     extension(IProcess process)
     {
+        #region Product Types
+
+        /// <summary>
+        /// Returns the <see cref="ProductType"/> or null if <paramref name="process"/> is not a 
+        /// <see cref="ProductionProcess"/> or does not hold a <see cref="ProductionProcess.ProductInstance"/>        /// </summary>
+        /// <example>
+        /// <code>
+        /// <![CDATA[
+        /// var productType = process.GetProductType();
+        /// ]]>
+        /// </code>
+        /// </example>
+        public ProductType GetProductType()
+        {
+            if (process.Recipe is IProductRecipe prodcutRecipe)
+            {
+                return prodcutRecipe.Target;
+            }
+
+            return default;
+        }
+
+        /// <summary>
+        /// Returns the <see cref="ProductType"/> of type <typeparamref name="TType"/> or null if 
+        /// <paramref name="process"/> is not a <see cref="ProductionProcess"/>, does not hold a 
+        /// <see cref="ProductionProcess.ProductInstance"/>, or its product type does not implement 
+        /// <typeparamref name="TType"/>
+        /// </summary>
+        /// <typeparam name="TType">The expected type of the product type</typeparam>
+        /// <example>
+        /// <code>
+        /// <![CDATA[
+        /// var myType = process.GetProductType<MyProductType>();
+        /// ]]>
+        /// </code>
+        /// </example>
+        public TType GetProductType<TType>() where TType : ProductType => process.GetProductType() as TType;
+
+        #endregion
+
+        #region Product Instances
+
+        /// <summary>
+        /// Returns the <see cref="ProductInstance"/> or null if <see cref="ProductionProcess.ProductInstance"/> does 
+        /// not implement the specified type.
+        /// </summary>
+        /// <example>
+        /// <code>
+        /// <![CDATA[
+        /// var productInstance = process.GetProductInstance();
+        /// ]]>
+        /// </code>
+        /// </example>
+        public ProductInstance GetProductInstance()
+        {
+            if (process is not ProductionProcess productionProcess)
+            {
+                return null;
+            }
+
+            return productionProcess.ProductInstance;
+        }
+
+        /// <summary>
+        /// Returns the <see cref="ProductInstance"/> of type <typeparamref name="TInstance"/> or null if 
+        /// <see cref="ProductionProcess.ProductInstance"/> does not implement the specified type.
+        /// </summary>
+        /// <typeparam name="TInstance">The expected type of the product instance</typeparam>
+        /// <example>
+        /// <code>
+        /// <![CDATA[
+        /// var myInstance = process.GetProductInstance<MyProductInstance>();
+        /// ]]>
+        /// </code>
+        /// </example>
+        public TInstance GetProductInstance<TInstance>() where TInstance : ProductInstance
+        {
+            if (process is not ProductionProcess productionProcess)
+            {
+                return null;
+            }
+
+            if (productionProcess.ProductInstance is not TInstance instance)
+            {
+                return null;
+            }
+
+            return instance;
+        }
+
+        /// <summary>
+        /// Modifies the <see cref="ProductInstance"/> of type <typeparamref name="TInstance"/>
+        /// on the <see cref="IProcess"/> using the given <paramref name="setter"/>.
+        /// </summary>
+        /// <typeparam name="TInstance">The expected type of the product instance</typeparam>
+        /// <param name="setter">The action to be executed on the product instance</param>
+        /// <example>
+        /// <code>
+        /// <![CDATA[
+        /// process.Modify<MyProductInstance>((var instance) => instance.MyProperty = 1);
+        /// ]]>
+        /// </code>
+        /// </example>
+        /// <exception cref="InvalidCastException">Thrown if the given <paramref name="process"/> does
+        /// not hold a product instance of type <typeparamref name="TInstance"/></exception>
+        /// <exception cref="InvalidOperationException">Thrown if the given <paramref name="process"/>
+        /// is no <see cref="ProductionProcess"/></exception>
+        public TInstance Modify<TInstance>(Action<TInstance> setter) where TInstance : ProductInstance
+        {
+            if (process is not ProductionProcess productionProcess)
+            {
+                throw new InvalidOperationException($"Cannot modify an {nameof(ProductInstance)} on a process of type {process.GetType()}.");
+            }
+
+            if (productionProcess.ProductInstance is not TInstance instance)
+            {
+                throw new InvalidCastException($"Cannot cast {nameof(ProductionProcess.ProductInstance)} of type "
+                    + $"{productionProcess?.ProductInstance?.GetType()} to {typeof(TInstance)}");
+            }
+
+            setter.Invoke(instance);
+            return instance;
+        }
+
+        /// <summary>
+        /// Tries to modifies the <see cref="ProductInstance"/> of type <typeparamref name="TInstance"/>
+        /// on the <see cref="IProcess"/> using the given <paramref name="setter"/>. Returns false, if the
+        /// operation could not be executed.
+        /// </summary>
+        /// <typeparam name="TInstance">The expected type of the product instance</typeparam>
+        /// <param name="setter">The action to be executed on the product instance</param>
+        /// <example>
+        /// <code>
+        /// <![CDATA[
+        /// process.TryModify<MyProductInstance>((var instance) => instance.MyProperty = 1);
+        /// ]]>
+        /// </code>
+        /// </example>
+        public bool TryModify<TInstance>(Action<TInstance> setter) where TInstance : ProductInstance
+        {
+            if (process is not ProductionProcess productionProcess)
+            {
+                return false;
+            }
+
+            if (productionProcess.ProductInstance is not TInstance instance)
+            {
+                return false;
+            }
+
+            setter.Invoke(instance);
+            return true;
+        }
+
+        #endregion
+
+        #region Activities
+
         /// <summary>
         /// Get one prepared activity that will be dispatched as soon as a ready to work was send.
         /// Mention that, in case of parallel path in a workplan, a process could have multiple prepared activities!
@@ -87,5 +247,7 @@ public static class ProcessExtensions
         {
             return process.GetActivity(ActivitySelectionType.LastOrDefault, a => !exact && a is TActivity || exact && a.GetType() == typeof(TActivity));
         }
+
+        #endregion
     }
 }

--- a/src/Moryx.AbstractionLayer/Processes/ProcessExtensions.cs
+++ b/src/Moryx.AbstractionLayer/Processes/ProcessExtensions.cs
@@ -129,12 +129,7 @@ public static class ProcessExtensions
                 throw new InvalidOperationException($"Cannot modify an {nameof(ProductInstance)} on a process of type {process.GetType()}.");
             }
 
-            if (productionProcess.ProductInstance is not TInstance instance)
-            {
-                throw new InvalidCastException($"Cannot cast {nameof(ProductionProcess.ProductInstance)} of type "
-                    + $"{productionProcess?.ProductInstance?.GetType()} to {typeof(TInstance)}");
-            }
-
+            var instance = (TInstance)productionProcess.ProductInstance;
             setter.Invoke(instance);
             return instance;
         }

--- a/src/Moryx.AbstractionLayer/Processes/ProcessExtensions.cs
+++ b/src/Moryx.AbstractionLayer/Processes/ProcessExtensions.cs
@@ -105,65 +105,6 @@ public static class ProcessExtensions
             return instance;
         }
 
-        /// <summary>
-        /// Modifies the <see cref="ProductInstance"/> of type <typeparamref name="TInstance"/>
-        /// on the <see cref="IProcess"/> using the given <paramref name="setter"/>.
-        /// </summary>
-        /// <typeparam name="TInstance">The expected type of the product instance</typeparam>
-        /// <param name="setter">The action to be executed on the product instance</param>
-        /// <example>
-        /// <code>
-        /// <![CDATA[
-        /// process.Modify<MyProductInstance>((var instance) => instance.MyProperty = 1);
-        /// ]]>
-        /// </code>
-        /// </example>
-        /// <exception cref="InvalidCastException">Thrown if the given <paramref name="process"/> does
-        /// not hold a product instance of type <typeparamref name="TInstance"/></exception>
-        /// <exception cref="InvalidOperationException">Thrown if the given <paramref name="process"/>
-        /// is no <see cref="ProductionProcess"/></exception>
-        public TInstance Modify<TInstance>(Action<TInstance> setter) where TInstance : ProductInstance
-        {
-            if (process is not ProductionProcess productionProcess)
-            {
-                throw new InvalidOperationException($"Cannot modify an {nameof(ProductInstance)} on a process of type {process.GetType()}.");
-            }
-
-            var instance = (TInstance)productionProcess.ProductInstance;
-            setter.Invoke(instance);
-            return instance;
-        }
-
-        /// <summary>
-        /// Tries to modifies the <see cref="ProductInstance"/> of type <typeparamref name="TInstance"/>
-        /// on the <see cref="IProcess"/> using the given <paramref name="setter"/>. Returns false, if the
-        /// operation could not be executed.
-        /// </summary>
-        /// <typeparam name="TInstance">The expected type of the product instance</typeparam>
-        /// <param name="setter">The action to be executed on the product instance</param>
-        /// <example>
-        /// <code>
-        /// <![CDATA[
-        /// process.TryModify<MyProductInstance>((var instance) => instance.MyProperty = 1);
-        /// ]]>
-        /// </code>
-        /// </example>
-        public bool TryModify<TInstance>(Action<TInstance> setter) where TInstance : ProductInstance
-        {
-            if (process is not ProductionProcess productionProcess)
-            {
-                return false;
-            }
-
-            if (productionProcess.ProductInstance is not TInstance instance)
-            {
-                return false;
-            }
-
-            setter.Invoke(instance);
-            return true;
-        }
-
         #endregion
 
         #region Activities

--- a/src/Moryx.ControlSystem/Cells/SessionExtensions.cs
+++ b/src/Moryx.ControlSystem/Cells/SessionExtensions.cs
@@ -1,12 +1,11 @@
 // Copyright (c) 2026 Phoenix Contact GmbH & Co. KG
 // Licensed under the Apache License, Version 2.0
 
-using Moryx.AbstractionLayer.Recipes;
 using Moryx.AbstractionLayer.Activities;
 using Moryx.AbstractionLayer.Processes;
 using Moryx.AbstractionLayer.Products;
+using Moryx.AbstractionLayer.Recipes;
 using Moryx.ControlSystem.Recipes;
-using Moryx.ControlSystem.Processes;
 
 namespace Moryx.ControlSystem.Cells;
 
@@ -27,12 +26,8 @@ public static class SessionExtensions
         /// <see cref="ProductionProcess"/> and the <see cref="ProductionProcess"/> holds a <typeparamref name="TProductInstance"/>;
         /// Otherwise returns null
         /// </returns>
-        public TProductInstance GetProductInstance<TProductInstance>() where TProductInstance : ProductInstance
-        {
-            if (session.Process is not ProductionProcess process) return null;
-
-            return process.ProductInstance as TProductInstance;
-        }
+        public TProductInstance GetProductInstance<TProductInstance>() where TProductInstance : ProductInstance =>
+            session.Process.GetProductInstance<TProductInstance>();
 
         /// <summary>
         /// Modifies the <see cref="ProductInstance"/> of type <typeparamref name="TInstance"/>
@@ -54,7 +49,7 @@ public static class SessionExtensions
         /// <exception cref="InvalidOperationException">Thrown if the <see cref="Process"/> of the
         /// <paramref name="session"/> is no <see cref="ProductionProcess"/></exception>
         public TInstance ModifyProductInstance<TInstance>(Action<TInstance> setter)
-            where TInstance : ProductInstance => session.Process.ModifyProductInstance(setter);
+            where TInstance : ProductInstance => session.Process.Modify(setter);
 
         /// <summary>
         /// Tries to modifies the <see cref="ProductInstance"/> of type <typeparamref name="TInstance"/>
@@ -72,7 +67,7 @@ public static class SessionExtensions
         /// </code>
         /// </example>
         public bool TryModifyProductInstance<TInstance>(Action<TInstance> setter)
-            where TInstance : ProductInstance => session.Process.TryModifyProductInstance(setter);
+            where TInstance : ProductInstance => session.Process.TryModify(setter);
 
         /// <summary>
         /// Extension method to get the <see cref="Activity"/> from the <paramref name="session"/>
@@ -85,9 +80,14 @@ public static class SessionExtensions
         public TActivityType GetActivity<TActivityType>() where TActivityType : Activity
         {
             if (session is ActivityCompleted completed)
+            {
                 return completed.CompletedActivity as TActivityType;
+            }
+
             if (session is ActivityStart start)
+            {
                 return start.Activity as TActivityType;
+            }
 
             return null;
         }
@@ -114,10 +114,14 @@ public static class SessionExtensions
         public TProductType GetProductType<TProductType>() where TProductType : ProductType
         {
             if (session.Process.Recipe is SetupRecipe setupRecipe)
+            {
                 return setupRecipe.TargetRecipe.Target as TProductType;
+            }
 
             if (session.Process.Recipe is IProductRecipe prodcutRecipe)
+            {
                 return prodcutRecipe.Target as TProductType;
+            }
 
             return default;
         }

--- a/src/Moryx.ControlSystem/Cells/SessionExtensions.cs
+++ b/src/Moryx.ControlSystem/Cells/SessionExtensions.cs
@@ -5,6 +5,7 @@ using Moryx.AbstractionLayer.Activities;
 using Moryx.AbstractionLayer.Processes;
 using Moryx.AbstractionLayer.Products;
 using Moryx.AbstractionLayer.Recipes;
+using Moryx.ControlSystem.Processes;
 using Moryx.ControlSystem.Recipes;
 
 namespace Moryx.ControlSystem.Cells;
@@ -48,8 +49,9 @@ public static class SessionExtensions
         /// </exception>
         /// <exception cref="InvalidOperationException">Thrown if the <see cref="Process"/> of the
         /// <paramref name="session"/> is no <see cref="ProductionProcess"/></exception>
+        [Obsolete($"Use '{nameof(SessionExtensions.GetProductInstance)}' and direct property assignements instead of the delegate for cleaner stack traced during debugging.")]
         public TInstance ModifyProductInstance<TInstance>(Action<TInstance> setter)
-            where TInstance : ProductInstance => session.Process.Modify(setter);
+            where TInstance : ProductInstance => session.Process.ModifyProductInstance(setter);
 
         /// <summary>
         /// Tries to modifies the <see cref="ProductInstance"/> of type <typeparamref name="TInstance"/>
@@ -66,8 +68,9 @@ public static class SessionExtensions
         /// ]]>
         /// </code>
         /// </example>
+        [Obsolete($"Use '{nameof(ProcessExtensions.GetProductInstance)}' and direct property assignements instead of the delegate for cleaner stack traced during debugging.")]
         public bool TryModifyProductInstance<TInstance>(Action<TInstance> setter)
-            where TInstance : ProductInstance => session.Process.TryModify(setter);
+            where TInstance : ProductInstance => session.Process.TryModifyProductInstance(setter);
 
         /// <summary>
         /// Extension method to get the <see cref="Activity"/> from the <paramref name="session"/>

--- a/src/Moryx.ControlSystem/Processes/IProcessExtensions.cs
+++ b/src/Moryx.ControlSystem/Processes/IProcessExtensions.cs
@@ -32,7 +32,7 @@ public static class IProcessExtensions
         /// not hold a product instance of type <typeparamref name="TInstance"/></exception>
         /// <exception cref="InvalidOperationException">Thrown if the given <paramref name="process"/>
         /// is no <see cref="ProductionProcess"/></exception>
-        [Obsolete("Use 'Moryx.AbstractionLayer.Processes.ProcessExtensions.Modify<TInstance>(Action<TInstance> setter)' instead")]
+        [Obsolete($"Use '{nameof(ProcessExtensions.GetProductInstance)}' and direct property assignements instead of the delegate for cleaner stack traced during debugging.")]
         public TInstance ModifyProductInstance<TInstance>(Action<TInstance> setter)
             where TInstance : ProductInstance
         {
@@ -60,7 +60,7 @@ public static class IProcessExtensions
         /// ]]>
         /// </code>
         /// </example>
-        [Obsolete("Use 'Moryx.AbstractionLayer.Processes.ProcessExtensions.TryModify<TInstance>(Action<TInstance> setter)' instead")]
+        [Obsolete($"Use '{nameof(ProcessExtensions.GetProductInstance)}' and direct property assignements instead of the delegate for cleaner stack traced during debugging.")]
         public bool TryModifyProductInstance<TInstance>(Action<TInstance> setter)
             where TInstance : ProductInstance
         {

--- a/src/Moryx.ControlSystem/Processes/IProcessExtensions.cs
+++ b/src/Moryx.ControlSystem/Processes/IProcessExtensions.cs
@@ -41,12 +41,7 @@ public static class IProcessExtensions
                 throw new InvalidOperationException($"Cannot modify an {nameof(ProductInstance)} on a process of type {process.GetType()}.");
             }
 
-            if (productionProcess.ProductInstance is not TInstance instance)
-            {
-                throw new InvalidCastException($"Cannot cast {nameof(ProductionProcess.ProductInstance)} of type " +
-                                               $"{productionProcess?.ProductInstance?.GetType()} to {typeof(TInstance)}");
-            }
-
+            var instance = (TInstance)productionProcess.ProductInstance;
             setter.Invoke(instance);
             return instance;
         }

--- a/src/Moryx.ControlSystem/Processes/IProcessExtensions.cs
+++ b/src/Moryx.ControlSystem/Processes/IProcessExtensions.cs
@@ -1,8 +1,8 @@
 // Copyright (c) 2026 Phoenix Contact GmbH & Co. KG
 // Licensed under the Apache License, Version 2.0
 
-using Moryx.AbstractionLayer.Products;
 using Moryx.AbstractionLayer.Processes;
+using Moryx.AbstractionLayer.Products;
 using Moryx.ControlSystem.Recipes;
 
 namespace Moryx.ControlSystem.Processes;
@@ -32,14 +32,21 @@ public static class IProcessExtensions
         /// not hold a product instance of type <typeparamref name="TInstance"/></exception>
         /// <exception cref="InvalidOperationException">Thrown if the given <paramref name="process"/>
         /// is no <see cref="ProductionProcess"/></exception>
+        [Obsolete("Use 'Moryx.AbstractionLayer.Processes.ProcessExtensions.Modify<TInstance>(Action<TInstance> setter)' instead")]
         public TInstance ModifyProductInstance<TInstance>(Action<TInstance> setter)
             where TInstance : ProductInstance
         {
             if (process is not ProductionProcess productionProcess)
+            {
                 throw new InvalidOperationException($"Cannot modify an {nameof(ProductInstance)} on a process of type {process.GetType()}.");
+            }
+
             if (productionProcess.ProductInstance is not TInstance instance)
+            {
                 throw new InvalidCastException($"Cannot cast {nameof(ProductionProcess.ProductInstance)} of type " +
-                                               $"{productionProcess?.ProductInstance?.GetType()} to {typeof(TInstance)}.");
+                                               $"{productionProcess?.ProductInstance?.GetType()} to {typeof(TInstance)}");
+            }
+
             setter.Invoke(instance);
             return instance;
         }
@@ -58,13 +65,20 @@ public static class IProcessExtensions
         /// ]]>
         /// </code>
         /// </example>
+        [Obsolete("Use 'Moryx.AbstractionLayer.Processes.ProcessExtensions.TryModify<TInstance>(Action<TInstance> setter)' instead")]
         public bool TryModifyProductInstance<TInstance>(Action<TInstance> setter)
             where TInstance : ProductInstance
         {
             if (process is not ProductionProcess productionProcess)
+            {
                 return false;
+            }
+
             if (productionProcess.ProductInstance is not TInstance instance)
+            {
                 return false;
+            }
+
             setter.Invoke(instance);
             return true;
         }

--- a/src/Tests/Moryx.AbstractionLayer.Tests/Moryx.AbstractionLayer.Tests.csproj
+++ b/src/Tests/Moryx.AbstractionLayer.Tests/Moryx.AbstractionLayer.Tests.csproj
@@ -9,6 +9,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\Moryx.AbstractionLayer.TestTools\Moryx.AbstractionLayer.TestTools.csproj" />
     <ProjectReference Include="..\..\Moryx.AbstractionLayer\Moryx.AbstractionLayer.csproj" />
     <ProjectReference Include="..\..\Moryx.Products.Samples\Moryx.Products.Samples.csproj" />
     <ProjectReference Include="..\..\Moryx.Resources.Samples\Moryx.Resources.Samples.csproj" />

--- a/src/Tests/Moryx.AbstractionLayer.Tests/ProcessExtensionsTests.cs
+++ b/src/Tests/Moryx.AbstractionLayer.Tests/ProcessExtensionsTests.cs
@@ -105,53 +105,6 @@ public class ProcessExtensionsTests
         }
     }
 
-    [Test]
-    public void Modify_WhenProcessContainsExpectedInstance_UpdatesAndReturnsProductInstance()
-    {
-        // Arrange
-        var instance = CreateProductInstance();
-        var process = CreateProductionProcess(instance.Type, instance);
-
-        // Act
-        var modifiedInstance = process.Modify<DummyProductInstance>(product => product.SerialNumber = "12345");
-
-        // Assert
-        Assert.That(modifiedInstance, Is.SameAs(instance));
-        Assert.That(instance.SerialNumber, Is.EqualTo("12345"));
-    }
-
-    [TestCase(ProcessKind.Standard, typeof(InvalidOperationException))]
-    [TestCase(ProcessKind.ProductionWithOtherInstance, typeof(InvalidCastException))]
-    public void Modify_WhenProcessCannotProvideExpectedInstance_ThrowsExpectedException(ProcessKind processKind, Type exceptionType)
-    {
-        // Arrange
-        var process = CreateProcess(processKind);
-
-        // Act & Assert
-        Assert.Throws(exceptionType, () => process.Modify<DummyProductInstance>(_ => { }));
-    }
-
-    [TestCase(ProcessKind.ProductionWithExpectedInstance, true)]
-    [TestCase(ProcessKind.Standard, false)]
-    [TestCase(ProcessKind.ProductionWithOtherInstance, false)]
-    public void TryModify_WhenProcessIsResolved_ReturnsExpectedResult(ProcessKind processKind, bool expectedResult)
-    {
-        // Arrange
-        var process = CreateProcess(processKind);
-        var expectedSerialNumber = "12345";
-
-        // Act
-        var result = process.TryModify<DummyProductInstance>(product =>
-        {
-            product.SerialNumber = expectedSerialNumber;
-        });
-
-        // Assert
-        Assert.That(result, Is.EqualTo(expectedResult));
-        Assert.That(process.GetProductInstance<DummyProductInstance>()?.SerialNumber,
-            Is.EqualTo(expectedResult ? expectedSerialNumber : null));
-    }
-
     [TestCase(ActivityQuery.Next, 4)]
     [TestCase(ActivityQuery.Current, 5)]
     [TestCase(ActivityQuery.LastCompleted, 6)]

--- a/src/Tests/Moryx.AbstractionLayer.Tests/ProcessExtensionsTests.cs
+++ b/src/Tests/Moryx.AbstractionLayer.Tests/ProcessExtensionsTests.cs
@@ -1,0 +1,359 @@
+// Copyright (c) 2026 Phoenix Contact GmbH & Co. KG
+// Licensed under the Apache License, Version 2.0
+
+using System;
+using System.Linq;
+using Moryx.AbstractionLayer.Activities;
+using Moryx.AbstractionLayer.Processes;
+using Moryx.AbstractionLayer.Products;
+using Moryx.AbstractionLayer.Recipes;
+using Moryx.AbstractionLayer.Tests.TestData;
+using Moryx.AbstractionLayer.TestTools;
+using NUnit.Framework;
+
+namespace Moryx.AbstractionLayer.Tests;
+
+[TestFixture]
+public class ProcessExtensionsTests
+{
+    [TestCase(true, typeof(DummyProductType))]
+    [TestCase(false, null)]
+    public void GetProductType_WhenRecipeIsResolved_ReturnsExpectedProductType(bool useProductRecipe, Type expectedType)
+    {
+        // Arrange
+        var process = CreateProcess(useProductRecipe);
+
+        // Act
+        var productType = process.GetProductType();
+
+        // Assert
+        if (expectedType == null)
+        {
+            Assert.That(productType, Is.Null);
+        }
+        else
+        {
+            Assert.That(productType, Is.TypeOf(expectedType));
+        }
+    }
+
+    [TestCase(true, true)]
+    [TestCase(false, false)]
+    public void GetProductType_WhenTargetIsResolved_ReturnsExpectedProductType(bool useExpectedType, bool shouldResolveProductType)
+    {
+        // Arrange
+        ProductType productType = useExpectedType ? new DummyProductType() : new OtherTestProductType();
+        var process = CreateProductionProcess(productType, productType.CreateInstance());
+
+        // Act
+        var typedProductType = process.GetProductType<DummyProductType>();
+
+        // Assert
+        if (shouldResolveProductType)
+        {
+            Assert.That(typedProductType, Is.SameAs(productType));
+        }
+        else
+        {
+            Assert.That(typedProductType, Is.Null);
+        }
+    }
+
+    [TestCase(true, true)]
+    [TestCase(false, false)]
+    public void GetProductInstance_WhenProcessIsResolved_ReturnsExpectedProductInstance(bool useProductionProcess, bool shouldResolveProductInstance)
+    {
+        // Arrange
+        var instance = CreateProductInstance();
+        IProcess process = useProductionProcess ? CreateProductionProcess(instance.Type, instance)
+            : CreateProcess(useProductRecipe: false);
+
+        // Act
+        var productInstance = process.GetProductInstance();
+
+        // Assert
+        if (shouldResolveProductInstance)
+        {
+            Assert.That(productInstance, Is.SameAs(instance));
+        }
+        else
+        {
+            Assert.That(productInstance, Is.Null);
+        }
+    }
+
+    [TestCase(true, true)]
+    [TestCase(false, false)]
+    public void GetProductInstance_WhenInstanceIsResolved_ReturnsExpectedProductInstance(bool useExpectedInstance, bool shouldResolveProductInstance)
+    {
+        // Arrange
+        var instance = useExpectedInstance ? CreateProductInstance()
+            : new OtherTestProductType().CreateInstance();
+        var process = CreateProductionProcess(instance.Type, instance);
+
+        // Act
+        var typedProductInstance = process.GetProductInstance<DummyProductInstance>();
+
+        // Assert
+        if (shouldResolveProductInstance)
+        {
+            Assert.That(typedProductInstance, Is.SameAs(instance));
+        }
+        else
+        {
+            Assert.That(typedProductInstance, Is.Null);
+        }
+    }
+
+    [Test]
+    public void Modify_WhenProcessContainsExpectedInstance_UpdatesAndReturnsProductInstance()
+    {
+        // Arrange
+        var instance = CreateProductInstance();
+        var process = CreateProductionProcess(instance.Type, instance);
+
+        // Act
+        var modifiedInstance = process.Modify<DummyProductInstance>(product => product.SerialNumber = "12345");
+
+        // Assert
+        Assert.That(modifiedInstance, Is.SameAs(instance));
+        Assert.That(instance.SerialNumber, Is.EqualTo("12345"));
+    }
+
+    [TestCase(ProcessKind.Standard, typeof(InvalidOperationException))]
+    [TestCase(ProcessKind.ProductionWithOtherInstance, typeof(InvalidCastException))]
+    public void Modify_WhenProcessCannotProvideExpectedInstance_ThrowsExpectedException(ProcessKind processKind, Type exceptionType)
+    {
+        // Arrange
+        var process = CreateProcess(processKind);
+
+        // Act & Assert
+        Assert.Throws(exceptionType, () => process.Modify<DummyProductInstance>(_ => { }));
+    }
+
+    [TestCase(ProcessKind.ProductionWithExpectedInstance, true)]
+    [TestCase(ProcessKind.Standard, false)]
+    [TestCase(ProcessKind.ProductionWithOtherInstance, false)]
+    public void TryModify_WhenProcessIsResolved_ReturnsExpectedResult(ProcessKind processKind, bool expectedResult)
+    {
+        // Arrange
+        var process = CreateProcess(processKind);
+        var expectedSerialNumber = "12345";
+
+        // Act
+        var result = process.TryModify<DummyProductInstance>(product =>
+        {
+            product.SerialNumber = expectedSerialNumber;
+        });
+
+        // Assert
+        Assert.That(result, Is.EqualTo(expectedResult));
+        Assert.That(process.GetProductInstance<DummyProductInstance>()?.SerialNumber,
+            Is.EqualTo(expectedResult ? expectedSerialNumber : null));
+    }
+
+    [TestCase(ActivityQuery.Next, 4)]
+    [TestCase(ActivityQuery.Current, 5)]
+    [TestCase(ActivityQuery.LastCompleted, 6)]
+    public void ActivitySelector_WhenMatchingActivitiesExist_ReturnsExpectedActivity(ActivityQuery query, long expectedActivityId)
+    {
+        // Arrange
+        var process = CreateProcessWithActivityStates();
+
+        // Act
+        var activity = SelectActivity(process, query);
+
+        // Assert
+        Assert.That(activity.Id, Is.EqualTo(expectedActivityId));
+    }
+
+    [TestCase(ActivityQuery.Next)]
+    [TestCase(ActivityQuery.Current)]
+    [TestCase(ActivityQuery.LastCompleted)]
+    public void ActivitySelector_WhenNoMatchingActivityExists_ReturnsNull(ActivityQuery query)
+    {
+        // Arrange
+        var process = new Process();
+
+        // Act
+        var activity = SelectActivity(process, query);
+
+        // Assert
+        Assert.That(activity, Is.Null);
+    }
+
+    [TestCase(ActivityGroup.Next, new long[] { 1, 4 })]
+    [TestCase(ActivityGroup.Current, new long[] { 2, 5 })]
+    public void ActivityGroupSelector_WhenMatchingActivitiesExist_ReturnsExpectedActivities(ActivityGroup group, long[] expectedActivityIds)
+    {
+        // Arrange
+        var process = CreateProcessWithActivityStates();
+
+        // Act
+        var activityIds = SelectActivities(process, group).Select(activity => activity.Id).ToArray();
+
+        // Assert
+        Assert.That(activityIds, Is.EqualTo(expectedActivityIds));
+    }
+
+    [TestCase(nameof(TestActivity), 4)]
+    [TestCase(nameof(DerivedTestActivity), 3)]
+    [TestCase(nameof(OtherTestActivity), 2)]
+    [TestCase("UnknownActivity", null)]
+    public void LastActivityByTypeName_WhenTypeNameIsProvided_ReturnsExpectedActivity(string typeName, long? expectedActivityId)
+    {
+        // Arrange
+        var process = CreateProcessWithActivityTypes();
+
+        // Act
+        var activity = process.LastActivity(typeName);
+
+        // Assert
+        if (expectedActivityId.HasValue)
+        {
+            Assert.That(activity.Id, Is.EqualTo(expectedActivityId.Value));
+        }
+        else
+        {
+            Assert.That(activity, Is.Null);
+        }
+    }
+
+    [TestCase(false, 3)]
+    [TestCase(true, 1)]
+    public void LastActivityOfType_WhenExactFlagIsProvided_ReturnsExpectedActivity(bool exact, long expectedActivityId)
+    {
+        // Arrange
+        var process = CreateProcessWithDerivedActivityLast();
+
+        // Act
+        var activity = process.LastActivity<TestActivity>(exact);
+
+        // Assert
+        Assert.That(activity.Id, Is.EqualTo(expectedActivityId));
+    }
+
+    [Test]
+    public void LastActivityOfType_WhenExactFlagIsOmitted_IncludesDerivedActivities()
+    {
+        // Arrange
+        var process = CreateProcessWithDerivedActivityLast();
+
+        // Act
+        var activity = process.LastActivity<TestActivity>();
+
+        // Assert
+        Assert.That(activity.Id, Is.EqualTo(3));
+    }
+
+    private static Process CreateProcess(bool useProductRecipe) => new()
+    {
+        Recipe = useProductRecipe ? new ProductRecipe { Product = new DummyProductType() }
+                : new TestRecipe()
+    };
+
+    private static Process CreateProcess(ProcessKind processKind) => processKind switch
+    {
+        ProcessKind.ProductionWithExpectedInstance => CreateProductionProcess(new DummyProductType()),
+        ProcessKind.ProductionWithOtherInstance => CreateProductionProcess(new OtherTestProductType()),
+        _ => new Process()
+    };
+
+    private static ProductionProcess CreateProductionProcess(ProductType productType) =>
+        CreateProductionProcess(productType, productType.CreateInstance());
+
+    private static ProductionProcess CreateProductionProcess(ProductType productType, ProductInstance productInstance)
+    {
+        return new()
+        {
+            Recipe = new ProductRecipe { Product = productType },
+            ProductInstance = productInstance
+        };
+    }
+
+    private static DummyProductInstance CreateProductInstance() =>
+        (DummyProductInstance)new DummyProductType().CreateInstance();
+
+    private static Process CreateProcessWithActivityStates()
+    {
+        var process = new Process();
+        process.AddActivity(CreateActivity(1));
+        process.AddActivity(CreateActivity(2, started: true));
+        process.AddActivity(CreateActivity(3, started: true, completed: true));
+        process.AddActivity(CreateActivity(4));
+        process.AddActivity(CreateActivity(5, started: true));
+        process.AddActivity(CreateActivity(6, started: true, completed: true));
+        return process;
+    }
+
+    private static Process CreateProcessWithActivityTypes()
+    {
+        var process = new Process();
+        process.AddActivity(CreateActivity<TestActivity>(1));
+        process.AddActivity(CreateActivity<OtherTestActivity>(2));
+        process.AddActivity(CreateActivity<DerivedTestActivity>(3));
+        process.AddActivity(CreateActivity<TestActivity>(4));
+        return process;
+    }
+
+    private static Process CreateProcessWithDerivedActivityLast()
+    {
+        var process = new Process();
+        process.AddActivity(CreateActivity<TestActivity>(1));
+        process.AddActivity(CreateActivity<OtherTestActivity>(2));
+        process.AddActivity(CreateActivity<DerivedTestActivity>(3));
+        return process;
+    }
+
+    private static TestActivity CreateActivity(long id, bool started = false, bool completed = false)
+    {
+        var activity = CreateActivity<TestActivity>(id);
+
+        if (started)
+        {
+            activity.Tracing.Started = DateTime.Now;
+        }
+
+        if (completed)
+        {
+            activity.Result = ActivityResult.Create(true, 0);
+        }
+
+        return activity;
+    }
+
+    private static TActivity CreateActivity<TActivity>(long id) where TActivity : Activity, new() => new() { Id = id };
+
+    private static Activity SelectActivity(IProcess process, ActivityQuery query) => query switch
+    {
+        ActivityQuery.Next => process.NextActivity(),
+        ActivityQuery.Current => process.CurrentActivity(),
+        _ => process.LastActivity()
+    };
+
+    private static Activity[] SelectActivities(IProcess process, ActivityGroup group) => group switch
+    {
+        ActivityGroup.Next => [.. process.NextActivities()],
+        _ => [.. process.CurrentActivities()]
+    };
+
+    public enum ProcessKind
+    {
+        Standard,
+        ProductionWithExpectedInstance,
+        ProductionWithOtherInstance
+    }
+
+    public enum ActivityQuery
+    {
+        Next,
+        Current,
+        LastCompleted
+    }
+
+    public enum ActivityGroup
+    {
+        Next,
+        Current
+    }
+}

--- a/src/Tests/Moryx.AbstractionLayer.Tests/TestData/DerivedTestActivity.cs
+++ b/src/Tests/Moryx.AbstractionLayer.Tests/TestData/DerivedTestActivity.cs
@@ -1,0 +1,8 @@
+// Copyright (c) 2026 Phoenix Contact GmbH & Co. KG
+// Licensed under the Apache License, Version 2.0
+
+namespace Moryx.AbstractionLayer.Tests.TestData;
+
+public class DerivedTestActivity : TestActivity
+{
+}

--- a/src/Tests/Moryx.AbstractionLayer.Tests/TestData/OtherTestActivity.cs
+++ b/src/Tests/Moryx.AbstractionLayer.Tests/TestData/OtherTestActivity.cs
@@ -1,13 +1,12 @@
 // Copyright (c) 2026 Phoenix Contact GmbH & Co. KG
 // Licensed under the Apache License, Version 2.0
 
-using Moryx.AbstractionLayer.Capabilities;
 using Moryx.AbstractionLayer.Activities;
+using Moryx.AbstractionLayer.Capabilities;
 
 namespace Moryx.AbstractionLayer.Tests.TestData;
 
-[ActivityResults(typeof(TestResults))]
-public class TestActivity : Activity<NullActivityParameters>
+public class OtherTestActivity : Activity<NullActivityParameters>
 {
     public override ProcessRequirement ProcessRequirement => ProcessRequirement.Required;
 

--- a/src/Tests/Moryx.AbstractionLayer.Tests/TestData/OtherTestProductInstance.cs
+++ b/src/Tests/Moryx.AbstractionLayer.Tests/TestData/OtherTestProductInstance.cs
@@ -1,0 +1,10 @@
+// Copyright (c) 2026 Phoenix Contact GmbH & Co. KG
+// Licensed under the Apache License, Version 2.0
+
+using Moryx.AbstractionLayer.Products;
+
+namespace Moryx.AbstractionLayer.Tests.TestData;
+
+public class OtherTestProductInstance : ProductInstance<OtherTestProductType>
+{
+}

--- a/src/Tests/Moryx.AbstractionLayer.Tests/TestData/OtherTestProductType.cs
+++ b/src/Tests/Moryx.AbstractionLayer.Tests/TestData/OtherTestProductType.cs
@@ -1,0 +1,11 @@
+// Copyright (c) 2026 Phoenix Contact GmbH & Co. KG
+// Licensed under the Apache License, Version 2.0
+
+using Moryx.AbstractionLayer.Products;
+
+namespace Moryx.AbstractionLayer.Tests.TestData;
+
+public class OtherTestProductType : ProductType
+{
+    protected override ProductInstance Instantiate() => new OtherTestProductInstance();
+}

--- a/src/Tests/Moryx.AbstractionLayer.Tests/TestData/TestRecipe.cs
+++ b/src/Tests/Moryx.AbstractionLayer.Tests/TestData/TestRecipe.cs
@@ -1,0 +1,11 @@
+// Copyright (c) 2026 Phoenix Contact GmbH & Co. KG
+// Licensed under the Apache License, Version 2.0
+
+using Moryx.AbstractionLayer.Recipes;
+
+namespace Moryx.AbstractionLayer.Tests.TestData;
+
+public class TestRecipe : Recipe
+{
+    public override IRecipe Clone() => new TestRecipe();
+}


### PR DESCRIPTION
This is a usual case when populating activity parameters for example, where we want to retrieve information from Task, Recipe, Prodcut Type and maybe Product Instances