### PR TITLE
Support Password unit type in CommandCenter

### DIFF
--- a/src/Moryx.CommandCenter.Web/app/src/modules/components/ConfigEditor/StringEditor.tsx
+++ b/src/Moryx.CommandCenter.Web/app/src/modules/components/ConfigEditor/StringEditor.tsx
@@ -3,16 +3,20 @@
  * Licensed under the Apache License, Version 2.0
 */
 
-import { mdiFormatText } from "@mdi/js";
+import { mdiEye, mdiEyeOff, mdiFormatText } from "@mdi/js";
+import IconButton from "@mui/material/IconButton";
 import InputAdornment from "@mui/material/InputAdornment";
 import SvgIcon from "@mui/material/SvgIcon";
 import TextField from "@mui/material/TextField";
 import Tooltip from "@mui/material/Tooltip";
 import * as React from "react";
+import { EntryUnitType } from "../../models/EntryUnitType";
 import { InputEditorBasePropModel } from "./InputEditorBase";
 import SelectionEditorBase from "./SelectionEditorBase";
 
 export default class StringEditor extends SelectionEditorBase {
+  private showPassword: boolean = false;
+
   constructor(props: InputEditorBasePropModel) {
     super(props);
   }
@@ -22,12 +26,13 @@ export default class StringEditor extends SelectionEditorBase {
     // Changed inf the future.
     const isLoadError = this.props.Entry.displayName === "LoadError";
     const currentValue = this.props.Entry.value.current;
+    const isPassword = this.props.Entry.value.unitType === EntryUnitType.Password;
 
     return (
       isLoadError && currentValue == null
         ? null
         : <Tooltip title={this.props.Entry.description} placement="right">
-          <TextField type={this.props.Entry.validation.isPassword ? "password" : "text"}
+          <TextField type={isPassword && !this.showPassword ? "password" : "text"}
                      onChange={(e) => this.onValueChange(e.target.value, this.props.Entry)}
                      label={this.props.Entry.displayName}
                      aria-label={this.props.Entry.description}
@@ -43,7 +48,16 @@ export default class StringEditor extends SelectionEditorBase {
                        input: {
                          endAdornment: (
                            <InputAdornment position="end">
-                             <SvgIcon><path d={mdiFormatText} /></SvgIcon>
+                             {isPassword
+                               ? <IconButton
+                                   aria-label="toggle password visibility"
+                                   onClick={() => { this.showPassword = !this.showPassword; this.forceUpdate(); }}
+                                   edge="end"
+                                   size="small">
+                                   <SvgIcon><path d={this.showPassword ? mdiEyeOff : mdiEye} /></SvgIcon>
+                                 </IconButton>
+                               : <SvgIcon><path d={mdiFormatText} /></SvgIcon>
+                             }
                            </InputAdornment>
                          ),
                        },

--- a/src/Moryx.CommandCenter.Web/app/src/modules/models/EntryUnitType.ts
+++ b/src/Moryx.CommandCenter.Web/app/src/modules/models/EntryUnitType.ts
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2026 Phoenix Contact GmbH & Co. KG
+ * Licensed under the Apache License, Version 2.0
+ */
+
+export enum EntryUnitType {
+    None = "None",
+    Password = "Password",
+    FilePath = "FilePath",
+    DirectoryPath = "DirectoryPath",
+    Flags = "Flags",
+    Base64 = "Base64",
+}

--- a/src/Moryx.CommandCenter.Web/app/src/modules/models/EntryValidation.ts
+++ b/src/Moryx.CommandCenter.Web/app/src/modules/models/EntryValidation.ts
@@ -8,5 +8,4 @@ export default class EntryValidation {
     public maximum: number;
     public regex: string;
     public isRequired: boolean;
-    public isPassword: boolean;
 }

--- a/src/Moryx.CommandCenter.Web/app/src/modules/models/EntryValue.ts
+++ b/src/Moryx.CommandCenter.Web/app/src/modules/models/EntryValue.ts
@@ -4,10 +4,12 @@
 */
 
 import EntryPossible from "./EntryPossible";
+import { EntryUnitType } from "./EntryUnitType";
 import { EntryValueType } from "./EntryValueType";
 
 export default class EntryValue {
     public type: EntryValueType;
+    public unitType: EntryUnitType;
     public current: string;
     public default: string;
     public possible: EntryPossible[];


### PR DESCRIPTION
Supports passwords in entry-editor of command center

<img width="847" height="78" alt="Screenshot 2026-08-26 at 11 55 40" src="https://github.com/user-attachments/assets/b6b8b731-b2a4-40ac-a43c-fc5f0895b051" />

<img width="862" height="79" alt="Screenshot 2026-08-26 at 11 55 47" src="https://github.com/user-attachments/assets/8a296268-1788-4168-bb59-920305ee6323" />

---

Explicitly excluded: Database configurations. 
close #1451