### PR TITLE
Add MoveToken to TransitionBase

### DIFF
--- a/src/Moryx/Workplans/Transitions/NullTransition.cs
+++ b/src/Moryx/Workplans/Transitions/NullTransition.cs
@@ -33,8 +33,7 @@ public class NullTransition : TransitionBase
     {
         Executing(delegate
         {
-            TakeToken((IPlace)sender, token);
-            PlaceToken(Outputs[_index], token);
+            MoveToken((IPlace)sender, Outputs[_index], token);
         });
     }
 }

--- a/src/Moryx/Workplans/Transitions/TransitionBase.cs
+++ b/src/Moryx/Workplans/Transitions/TransitionBase.cs
@@ -77,11 +77,24 @@ public abstract class TransitionBase : ITransition
     /// <summary>
     /// Place a stored token on an output and remove it from <see cref="StoredTokens"/>
     /// </summary>
-    /// <returns>True if token was placed otherwise false</returns>
     protected void PlaceToken(IPlace output, IToken token)
     {
+        if (!StoredTokens.Contains(token))
+        {
+            throw new InvalidOperationException($"Token was not taken from input before placing on output. Call {nameof(TakeToken)} first or use {nameof(MoveToken)}.");
+        }
+
         output.Add(token);
         StoredTokens.Remove(token);
+    }
+
+    /// <summary>
+    /// Take token from input and place it on an output in a single operation
+    /// </summary>
+    protected void MoveToken(IPlace input, IPlace output, IToken token)
+    {
+        TakeToken(input, token);
+        PlaceToken(output, token);
     }
 
     /// <summary>

--- a/src/Tests/Moryx.Tests/Workplans/Dummies/MoveTransition.cs
+++ b/src/Tests/Moryx.Tests/Workplans/Dummies/MoveTransition.cs
@@ -1,0 +1,20 @@
+// Copyright (c) 2026 Phoenix Contact GmbH & Co. KG
+// Licensed under the Apache License, Version 2.0
+
+using Moryx.Workplans;
+using Moryx.Workplans.Transitions;
+
+namespace Moryx.Tests.Workplans;
+
+internal class MoveTransition : TransitionBase
+{
+    protected override void InputTokenAdded(object sender, IToken token)
+    {
+        Executing(() => MoveToken((IPlace)sender, Outputs[0], token));
+    }
+
+    public void PlaceUntaken(IPlace output, IToken token)
+    {
+        PlaceToken(output, token);
+    }
+}

--- a/src/Tests/Moryx.Tests/Workplans/TransitionTests.cs
+++ b/src/Tests/Moryx.Tests/Workplans/TransitionTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) 2026 Phoenix Contact GmbH & Co. KG
 // Licensed under the Apache License, Version 2.0
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Moryx.Workplans;
@@ -117,6 +118,47 @@ public class TransitionTests
             Assert.That(_inputs[(index + 1) % 2].Tokens, Is.Empty);
             Assert.That(_outputs[0].Tokens, Is.Empty);
         });
+    }
+
+    [Test(Description = "MoveToken takes token from input and places it on output in one call")]
+    public void MoveTokenTakesAndPlaces()
+    {
+        // Arrange
+        var input = _inputs[0];
+        var output = _outputs[0];
+        var trans = new MoveTransition
+        {
+            Id = 1,
+            Inputs = [input],
+            Outputs = [output]
+        };
+
+        // Act
+        trans.Initialize();
+        input.Add(_token);
+
+        // Assert
+        Assert.That(input.Tokens, Is.Empty);
+        Assert.That(output.Tokens.Count(), Is.EqualTo(1));
+        Assert.That(output.Tokens.First(), Is.EqualTo(_token));
+    }
+
+    [Test(Description = "PlaceToken throws if the token was not taken first")]
+    public void PlaceTokenWithoutTakeThrows()
+    {
+        // Arrange
+        var output = _outputs[0];
+        var trans = new MoveTransition
+        {
+            Id = 1,
+            Inputs = [_inputs[0]],
+            Outputs = [output]
+        };
+        trans.Initialize();
+
+        // Act & Assert
+        var untakenToken = new DummyToken();
+        Assert.Throws<InvalidOperationException>(() => trans.PlaceUntaken(output, untakenToken));
     }
 
     [Test]


### PR DESCRIPTION
- Added `MoveToken` method to TransitionBase that combines TakeToken and PlaceToken in a single call, preventing accidental token duplication (fixes #117)
- Added a guard in PlaceToken that throws InvalidOperationException if the token was not taken first
- Tests for both

close #117