### PR TITLE
Sockets: Added configurable time for reconnect on validation issue

### DIFF
--- a/src/Moryx/Communication/Sockets/Client/TcpClientConnection.cs
+++ b/src/Moryx/Communication/Sockets/Client/TcpClientConnection.cs
@@ -253,7 +253,8 @@ public class TcpClientConnection : IBinaryConnection, IStateContext
         if (!_validator.Validate(message))
         {
             // If you send us crap we shut you off!
-            Reconnect();
+            Logger.LogWarning("Validation of received message failed. Reconnecting in {delayMs}ms.", Config.RetryWaitMs);
+            Reconnect(Config.RetryWaitMs);
             return;
         }
 

--- a/src/Moryx/Communication/Sockets/Server/TcpListenerConfig.cs
+++ b/src/Moryx/Communication/Sockets/Server/TcpListenerConfig.cs
@@ -39,6 +39,14 @@ public class TcpListenerConfig : BinaryConnectionConfig
     public bool ValidateBeforeAssignment { get; set; }
 
     /// <summary>
+    /// Time to wait between attempts to open a connection in ms.
+    /// </summary>
+    [DataMember]
+    [Description("Time to wait between attempts to open a connection in ms.")]
+    [DefaultValue(500)]
+    public int RetryWaitMs { get; set; }
+
+    /// <summary>
     /// The TCP KeepAlive configuration
     /// </summary>
     [DataMember]

--- a/src/Moryx/Communication/Sockets/Server/TcpListenerConnection.cs
+++ b/src/Moryx/Communication/Sockets/Server/TcpListenerConnection.cs
@@ -260,7 +260,8 @@ public class TcpListenerConnection : IBinaryConnection, IStateContext
         if (!Validator.Validate(message))
         {
             // If you send us crap we shut you off!
-            Reconnect();
+            Logger.LogWarning("Validation of received message failed. Reconnecting in {delayMs}ms.", _config.RetryWaitMs);
+            Reconnect(_config.RetryWaitMs);
             return;
         }
 


### PR DESCRIPTION
`TcpListernerConnection`: had no configurable time a reconnect should be executed on validation issues. Added `RetryWaitMs` to the `TcpListenerConfig` and also a log-output.

`TcpClientConnnection`: already had a configuration property `RetryWaitMs` but it was not used during validation issues. Use is there now too.

I have not added tests because there is a Test which explicitly covers that [ReconnectAfterInvalidMessage](https://github.com/PHOENIXCONTACT/MORYX-Framework/blob/ede30a2acf1cd29d88aee2756a582cc50b76a974/src/Tests/Moryx.Communication.Sockets.IntegrationTests/HeaderProtocol/HeaderedCommunicationSocketTests.cs#L22) but the test is marked to ignore because of several timing issues which leads to test failures on different systems. These tests must be reworked at all (still sometimes fail) and remove this Thread.Sleep things. But this rework should not be part of this PR.

close #296