### PR TITLE
Improve state machine validation

### DIFF
--- a/src/Moryx/StateMachines/StateBase.cs
+++ b/src/Moryx/StateMachines/StateBase.cs
@@ -148,7 +148,7 @@ public abstract class StateBase
             var initialStates = definedStates.Where(s => s.IsInitial).ToArray();
             if (initialStates.Length == 0)
             {
-                throw new InvalidOperationException("No state is marked as initial. Set one explicitly using the StateDefinitionAttribute or set it explicitly ");
+                 throw new InvalidOperationException($"No state is marked as initial. Set one using the {nameof(StateDefinitionAttribute)} or pass an initial key explicitly");
             }
             else if (initialStates.Length > 1)
             {

--- a/src/Moryx/StateMachines/StateBase.cs
+++ b/src/Moryx/StateMachines/StateBase.cs
@@ -148,7 +148,7 @@ public abstract class StateBase
             var initialStates = definedStates.Where(s => s.IsInitial).ToArray();
             if (initialStates.Length == 0)
             {
-                 throw new InvalidOperationException($"No state is marked as initial. Set one using the {nameof(StateDefinitionAttribute)} or pass an initial key explicitly");
+                throw new InvalidOperationException($"No state is marked as initial. Set one using the {nameof(StateDefinitionAttribute)} or pass an initial key explicitly");
             }
             else if (initialStates.Length > 1)
             {

--- a/src/Moryx/StateMachines/StateBase.cs
+++ b/src/Moryx/StateMachines/StateBase.cs
@@ -79,8 +79,6 @@ public abstract class StateBase
         return new InvalidOperationException(error);
     }
 
-
-    private record StateDefinition(int Key, bool IsInitial, Type Type);
     /// <summary>
     /// Create a state machine of the given base type. Returns the initial state after initialization.
     /// </summary>
@@ -132,7 +130,7 @@ public abstract class StateBase
     {
         if (definedStates.Length == 0)
         {
-            throw new InvalidOperationException("There was no state constant defined in the given base type." +
+            throw new InvalidOperationException("There was no state constant defined in the given base type. " +
                                                 $"There must be at least one constant integer attributed with the {nameof(StateDefinitionAttribute)}.");
         }
 
@@ -150,33 +148,25 @@ public abstract class StateBase
             var initialStates = definedStates.Where(s => s.IsInitial).ToArray();
             if (initialStates.Length == 0)
             {
-                throw new InvalidOperationException("No state is marked as initial. Set one explicitly using the StateDefinitionAttribute or the ");
+                throw new InvalidOperationException("No state is marked as initial. Set one explicitly using the StateDefinitionAttribute or set it explicitly ");
             }
             else if (initialStates.Length > 1)
             {
                 var initialStateString = string.Join(", ", initialStates.Select(i => i.Type.Name));
-                throw new InvalidOperationException($"Multipe states are marked as initial: '{initialStateString}'. Define exactly one or set an initial state explicitly");
+                throw new InvalidOperationException($"Multiple states are marked as initial: '{initialStateString}'. Define exactly one or set an initial state explicitly");
             }
         }
 
         // Group by type to find states types that are used multiple times
-        var duplicateStates = definedStates
-            .GroupBy(state => state.Type)
-            .Where(g => g.Count() > 1)
-            .Select(g => g.Key)
-            .ToArray();
-        if (duplicateStates.Any())
+        var duplicateStates = FindDuplicates(definedStates, (s) => s.Type);
+        if (duplicateStates.Count != 0)
         {
             var typeNames = string.Join(", ", duplicateStates.Select(type => type.Name));
             throw new InvalidOperationException($"State types are only allowed once: {typeNames}");
         }
         // Group by key to find statemachine keys that are used multiple times
-        var duplicateKeys = definedStates
-            .GroupBy(state => state.Key)
-            .Where(g => g.Count() > 1)
-            .Select(g => g.Key)
-            .ToArray();
-        if (duplicateKeys.Any())
+        var duplicateKeys = FindDuplicates(definedStates, s => s.Key);
+        if (duplicateKeys.Count != 0)
         {
             var stateKeys = string.Join(", ", duplicateKeys);
             throw new InvalidOperationException($"State keys are only allowed once: {stateKeys}");
@@ -214,8 +204,28 @@ public abstract class StateBase
         return $"{GetType().Name} ({Key})";
     }
 
+    private static HashSet<T> FindDuplicates<T>(StateDefinition[] states, Func<StateDefinition, T> selector)
+    {
+        var seen = new HashSet<T>();
+        var duplicates = new HashSet<T>();
+        foreach (var state in states)
+        {
+            var elem = selector(state);
+            if (!seen.Add(elem))
+            {
+                duplicates.Add(elem);
+            }
+        }
+        return duplicates;
+    }
+
     /// <summary>
     /// Shortcut class for the stateMap dictionary
     /// </summary>
     public sealed class StateMap : Dictionary<int, StateBase>;
+
+    /// <summary>
+    /// Temporary container for state metadata 
+    /// </summary>
+    private record StateDefinition(int Key, bool IsInitial, Type Type);
 }

--- a/src/Moryx/StateMachines/StateBase.cs
+++ b/src/Moryx/StateMachines/StateBase.cs
@@ -79,6 +79,8 @@ public abstract class StateBase
         return new InvalidOperationException(error);
     }
 
+
+    private record StateDefinition(int Key, bool IsInitial, Type Type);
     /// <summary>
     /// Create a state machine of the given base type. Returns the initial state after initialization.
     /// </summary>
@@ -86,60 +88,99 @@ public abstract class StateBase
     {
         // Check the base type
         if (!stateBaseType.IsAbstract)
+        {
             throw new ArgumentException("The state base class must be abstract!");
+        }
 
         if (!typeof(StateBase).IsAssignableFrom(stateBaseType))
+        {
             throw new ArgumentException($"'{stateBaseType.Name}' class is not a valid 'StateBase'!");
+        }
 
         // Load all fields
         // 1. Get all fields which are static constant with the attribute
         // 2. let attribute and create an anonymous array
-        var definedStates = (from stateField in GetStateFields(stateBaseType)
-            let att = stateField.GetCustomAttribute<StateDefinitionAttribute>()
-            select new { Key = (int)stateField.GetValue(null), att.IsInitial, att.Type }).ToArray();
+        StateDefinition[] definedStates =
+            (from stateField in GetStateFields(stateBaseType)
+             let att = stateField.GetCustomAttribute<StateDefinitionAttribute>()
+             select new StateDefinition((int)stateField.GetValue(null), att.IsInitial, att.Type)).ToArray();
 
-        if (definedStates.Length == 0)
-            throw new InvalidOperationException("There was no state constant defined in the given base type." +
-                                                $"There must be at least one constant integer attributed with the {nameof(StateDefinitionAttribute)}.");
-
-        // If an initial key is set, we check if it exists
-        if (initialKey.HasValue && definedStates.All(s => s.Key != initialKey.Value))
-            throw new InvalidOperationException($"There was no state defined with key: {initialKey}");
-
-        // Group by type to find multiple defined state types
-        var duplicates = definedStates.GroupBy(state => state.Type).Where(g => g.Count() > 1).Select(g => g.Key).ToArray();
-        if (duplicates.Any())
-        {
-            var typeNames = string.Join(", ", duplicates.Select(type => type.Name));
-            throw new InvalidOperationException($"State types are only allowed once: {typeNames}");
-        }
+        ValidateStateDefinitions(definedStates, initialKey);
 
         var stateMap = new StateMap();
         StateBase initialState = null;
         foreach (var definedState in definedStates)
         {
-            var instance = Activator.CreateInstance(definedState.Type, context, stateMap) as StateBase;
-            if (instance == null)
-                throw new InvalidOperationException($"Could not create instance of State type {definedState.Type.Name}");
+            var instance = Activator.CreateInstance(definedState.Type, context, stateMap) as StateBase
+                ?? throw new InvalidOperationException($"Could not create instance of State type {definedState.Type.Name}");
 
             instance.Key = definedState.Key;
 
-            if (initialKey.HasValue && initialKey.Value == definedState.Key)
+            if ((initialKey.HasValue && initialKey.Value == definedState.Key)
+                || (!initialKey.HasValue && definedState.IsInitial))
+            {
                 initialState = instance;
-            else if (definedState.IsInitial && initialState == null)
-                initialState = instance;
-            else if (definedState.IsInitial && initialState != null)
-                throw new InvalidOperationException("At least one state must be flagged as '" +
-                                                    $"{nameof(StateDefinitionAttribute.IsInitial)} = true'.");
+            }
 
             stateMap.Add(definedState.Key, instance);
         }
 
-        if (initialState == null)
-            throw new InvalidOperationException("There is no state flagged with " +
-                                                $"'{nameof(StateDefinitionAttribute.IsInitial)} = true'.");
-
         return initialState;
+    }
+
+    private static void ValidateStateDefinitions(StateDefinition[] definedStates, int? initialKey)
+    {
+        if (definedStates.Length == 0)
+        {
+            throw new InvalidOperationException("There was no state constant defined in the given base type." +
+                                                $"There must be at least one constant integer attributed with the {nameof(StateDefinitionAttribute)}.");
+        }
+
+        if (initialKey.HasValue)
+        {
+            // If an initial key is set, we check if it exists
+            if (definedStates.All(s => s.Key != initialKey.Value))
+            {
+                throw new InvalidOperationException($"There was no state defined with key: {initialKey}");
+            }
+        }
+        else
+        {
+            // Otherwise we check that exactly one key is marked as initial
+            var initialStates = definedStates.Where(s => s.IsInitial).ToArray();
+            if (initialStates.Length == 0)
+            {
+                throw new InvalidOperationException("No state is marked as initial. Set one explicitly using the StateDefinitionAttribute or the ");
+            }
+            else if (initialStates.Length > 1)
+            {
+                var initialStateString = string.Join(", ", initialStates.Select(i => i.Type.Name));
+                throw new InvalidOperationException($"Multipe states are marked as initial: '{initialStateString}'. Define exactly one or set an initial state explicitly");
+            }
+        }
+
+        // Group by type to find states types that are used multiple times
+        var duplicateStates = definedStates
+            .GroupBy(state => state.Type)
+            .Where(g => g.Count() > 1)
+            .Select(g => g.Key)
+            .ToArray();
+        if (duplicateStates.Any())
+        {
+            var typeNames = string.Join(", ", duplicateStates.Select(type => type.Name));
+            throw new InvalidOperationException($"State types are only allowed once: {typeNames}");
+        }
+        // Group by key to find statemachine keys that are used multiple times
+        var duplicateKeys = definedStates
+            .GroupBy(state => state.Key)
+            .Where(g => g.Count() > 1)
+            .Select(g => g.Key)
+            .ToArray();
+        if (duplicateKeys.Any())
+        {
+            var stateKeys = string.Join(", ", duplicateKeys);
+            throw new InvalidOperationException($"State keys are only allowed once: {stateKeys}");
+        }
     }
 
     /// <summary>
@@ -147,14 +188,14 @@ public abstract class StateBase
     /// </summary>
     internal static IEnumerable<FieldInfo> GetStateFields(Type stateBaseType)
     {
-        var stateFields = from field in stateBaseType.GetFields(BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.FlattenHierarchy)
+        var stateFields =
+            from field in stateBaseType.GetFields(BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.FlattenHierarchy)
             where field.IsLiteral && !field.IsInitOnly &&
                   field.FieldType.IsAssignableFrom(typeof(int)) &&
                   field.GetCustomAttribute<StateDefinitionAttribute>() != null
             select field;
         return stateFields;
     }
-
 
     /// <summary>
     /// Will return the protected map.

--- a/src/Tests/Moryx.Tests/StateMachines/AsyncStateMachineTests.cs
+++ b/src/Tests/Moryx.Tests/StateMachines/AsyncStateMachineTests.cs
@@ -78,25 +78,17 @@ public class AsyncStateMachineTests
     [Test(Description = "Create a StateMachine with a specific initial state key.")]
     public async Task CreateWithSpecificInitialState()
     {
-        // Assert
+        // Arrange
         var context = new MyAsyncContext();
-        await StateMachine.ForAsyncContext(context).WithAsync<MyAsyncStateBase>();
-        await context.State.AtoBAsync();
+        var bkey = MyAsyncStateBase.StateB;
 
         // Act
-        var reloadedContext = new MyAsyncContext();
-        var bkey = context.State.Key;
-        await StateMachine.ForAsyncContext(reloadedContext).WithAsync<MyAsyncStateBase>(bkey);
+        await StateMachine.ForAsyncContext(context).WithAsync<MyAsyncStateBase>(bkey);
 
         // Assert
-        Assert.ThrowsAsync<InvalidOperationException>(() => reloadedContext.State.InitialAsync());
-
-        // Act
-        await context.State.BtoCAsync();
-
-        // Assert
-        Assert.That(context.BtoCTriggered);
-        Assert.That(context.CtoATriggered, Is.False);
+        using var _ = Assert.EnterMultipleScope();
+        Assert.That(context.State.Key == bkey);
+        Assert.ThrowsAsync<InvalidOperationException>(() => context.State.InitialAsync());
     }
 
     [Test(Description = "Brings the StateMachine to B and force to A without exit the current or enter the forced state.")]

--- a/src/Tests/Moryx.Tests/StateMachines/AsyncTestMachine/MyAsyncStateBase.cs
+++ b/src/Tests/Moryx.Tests/StateMachines/AsyncTestMachine/MyAsyncStateBase.cs
@@ -34,6 +34,9 @@ public abstract class MyAsyncStateBase : AsyncStateBase<MyAsyncContext>
         return InvalidStateAsync();
     }
 
+    // StateDefinitions A and B are out of the expected order.
+    // This enures that the statemachine can't rely on the assumption that the
+    // initial state is first
     [StateDefinition(typeof(BAsyncState))]
     public const int StateB = 20;
 

--- a/src/Tests/Moryx.Tests/StateMachines/AsyncTestMachine/MyAsyncStateBase.cs
+++ b/src/Tests/Moryx.Tests/StateMachines/AsyncTestMachine/MyAsyncStateBase.cs
@@ -34,11 +34,11 @@ public abstract class MyAsyncStateBase : AsyncStateBase<MyAsyncContext>
         return InvalidStateAsync();
     }
 
-    [StateDefinition(typeof(AAsyncState), IsInitial = true)]
-    public const int StateA = 10;
-
     [StateDefinition(typeof(BAsyncState))]
     public const int StateB = 20;
+
+    [StateDefinition(typeof(AAsyncState), IsInitial = true)]
+    public const int StateA = 10;
 
     [StateDefinition(typeof(CAsyncState))]
     public const int StateC = 30;

--- a/src/Tests/Moryx.Tests/StateMachines/StateMachineTests.cs
+++ b/src/Tests/Moryx.Tests/StateMachines/StateMachineTests.cs
@@ -89,25 +89,17 @@ public class StateMachineTests
     [Test(Description = "Create a StateMachine with a specific initial state key.")]
     public void CreateWithSpecificInitialState()
     {
-        // Assert
+        // Arrange
         var context = new MyContext();
-        StateMachine.ForContext(context).With<MyStateBase>();
-        context.State.AtoB();
+        var bkey = MyStateBase.StateB;
 
         // Act
-        var reloadedContext = new MyContext();
-        var bkey = context.State.Key;
-        StateMachine.ForContext(reloadedContext).With<MyStateBase>(bkey);
+        StateMachine.ForContext(context).With<MyStateBase>(bkey);
 
         // Assert
-        Assert.Throws<InvalidOperationException>(() => reloadedContext.State.Initial());
-
-        // Act
-        context.State.BtoC();
-
-        // Assert
-        Assert.That(context.BtoCTriggered);
-        Assert.That(context.CtoATriggered, Is.False);
+        using var _ = Assert.EnterMultipleScope();
+        Assert.That(context.State.Key == bkey);
+        Assert.Throws<InvalidOperationException>(() => context.State.Initial());
     }
 
     [Test(Description = "Create a StateMachine with an unknown initial state key.")]


### PR DESCRIPTION

### Summary

<!-- 
Summarize the bug and how this PR fixes it. If applicable, map the PR to tickets (e.g., JIRA, GitHub Issues).
-->
The existing implementation can fail if a state is marked with IsInitial and an explicit initial state is used, when the state given by the initial state paramter appears before the state marked as initial via attribute.

Additionally the existing error messages were sometimes misleading.

Change MyAsyncStateBase to demonstrates the problem by swapping the order of the fields. Simplified test case structure for related tests.


### Linked Issues

<!-- 
Link to any related issues using GitHub keywords (e.g., Fixes #123, Closes #456).
-->

### Relevant logs and/or screenshots

<!-- 
Paste any relevant logs. Please use code blocks (```) to format console output, logs, and code.
-->

### Breaking Changes

<!-- 
Does this PR introduce any breaking changes? If yes, describe them.
-->

### Checklist for Submitter

- [x] I have tested these changes locally
- [x] I have updated documentation as needed
- [x] I have added or updated tests as appropriate
- [x] I have used clear and descriptive commit messages

### Review

**Typical tasks**

- [ ] Merge request is well described
- [ ] Critical sections are *documented in code*
- [ ] *Tests* are extended
- [ ] *Documentation* is created / updated
- [ ] Running in test environment
- [ ] Ports to other maintained versions are created

**Clean code**

- [ ] *All* unused references are removed
- [ ] Clean code rules are respected with passion (naming, ...)
- [ ] Avoid *copy and pasted* code snippets