### PR TITLE
Use proper grammar in exceptions

### DIFF
--- a/src/Moryx.AbstractionLayer.Products.Endpoints/ProductConverter.cs
+++ b/src/Moryx.AbstractionLayer.Products.Endpoints/ProductConverter.cs
@@ -142,7 +142,7 @@ internal class ProductConverter
         var partLinkBase = FindGenericBaseDefinition(linkType, typeof(ProductPartLink<>));
         if (partLinkBase == null)
         {
-            throw new InvalidOperationException($"Cannot find product type for {linkType.FullName}");
+            throw new InvalidOperationException($"Cannot find product type for {linkType.FullName}.");
         }
 
         var prodType = partLinkBase.GetGenericArguments()[0];

--- a/src/Moryx.AbstractionLayer.Resources.Mqtt.Endpoints/ResourceRpcEndpoint.cs
+++ b/src/Moryx.AbstractionLayer.Resources.Mqtt.Endpoints/ResourceRpcEndpoint.cs
@@ -102,7 +102,7 @@ public class ResourceRpcEndpoint(ILogger<ResourceRpcEndpoint> logger, IResourceM
             }
             catch (InvalidCastException ex)
             {
-                throw new InvalidCastException($"Could not convert parameter '{methodToInvokeParameters[i].Name}' to type '{methodToInvokeParameters[i].ParameterType.FullName}'", ex);
+                throw new InvalidCastException($"Could not convert parameter '{methodToInvokeParameters[i].Name}' to type '{methodToInvokeParameters[i].ParameterType.FullName}'.", ex);
             }
         }
         return parameters;

--- a/src/Moryx.AbstractionLayer.Resources.Mqtt.Endpoints/Serializations/ResourceToJsonConverter.cs
+++ b/src/Moryx.AbstractionLayer.Resources.Mqtt.Endpoints/Serializations/ResourceToJsonConverter.cs
@@ -43,7 +43,7 @@ internal class ResourceToJsonConverter(IResourceManagement resourceManagement) :
         var synchronizationTypeId = jsonObj[nameof(ResourceSynchronizationAttribute.SynchronizationTypeId)]?.ToString();
         if (synchronizationTypeId is null)
         {
-            throw new InvalidOperationException("Cannot handle unknown resource without SynchronizationTypeId");
+            throw new InvalidOperationException("Cannot handle unknown resource without SynchronizationTypeId.");
         }
 
         var matchingResourceType = resourceManagement.GetResourcesUnsafe<Resource>(x =>
@@ -52,7 +52,7 @@ internal class ResourceToJsonConverter(IResourceManagement resourceManagement) :
             .GetType();
 
         return matchingResourceType is null
-            ? throw new InvalidOperationException($"No resource type found for SynchronizationTypeId {synchronizationTypeId}")
+            ? throw new InvalidOperationException($"No resource type found for SynchronizationTypeId {synchronizationTypeId}.")
             : jsonObj.Deserialize(matchingResourceType, options) as Resource;
     }
 

--- a/src/Moryx.AbstractionLayer.Resources.Mqtt.Endpoints/Serializations/ResourceToJsonConverter.cs
+++ b/src/Moryx.AbstractionLayer.Resources.Mqtt.Endpoints/Serializations/ResourceToJsonConverter.cs
@@ -43,7 +43,7 @@ internal class ResourceToJsonConverter(IResourceManagement resourceManagement) :
         var synchronizationTypeId = jsonObj[nameof(ResourceSynchronizationAttribute.SynchronizationTypeId)]?.ToString();
         if (synchronizationTypeId is null)
         {
-            throw new InvalidOperationException("Cannot handle unknown resource without SynchronizationTypeId.");
+            throw new InvalidOperationException($"Cannot handle unknown resource without {nameof(ResourceSynchronizationAttribute.SynchronizationTypeId)}.");
         }
 
         var matchingResourceType = resourceManagement.GetResourcesUnsafe<Resource>(x =>
@@ -52,7 +52,7 @@ internal class ResourceToJsonConverter(IResourceManagement resourceManagement) :
             .GetType();
 
         return matchingResourceType is null
-            ? throw new InvalidOperationException($"No resource type found for SynchronizationTypeId {synchronizationTypeId}.")
+            ? throw new InvalidOperationException($"No resource type found for {nameof(ResourceSynchronizationAttribute.SynchronizationTypeId)}: {synchronizationTypeId}.")
             : jsonObj.Deserialize(matchingResourceType, options) as Resource;
     }
 

--- a/src/Moryx.AbstractionLayer.TestTools/Resources/ResourceGraphMock.cs
+++ b/src/Moryx.AbstractionLayer.TestTools/Resources/ResourceGraphMock.cs
@@ -73,7 +73,7 @@ public class ResourceGraphMock : IResourceGraph
         var instance = Activator.CreateInstance(_typeMap[type]) as Resource;
         if (instance == null)
         {
-            throw new InvalidOperationException($"Cannot instantiate {type}");
+            throw new InvalidOperationException($"Cannot instantiate {type}.");
         }
 
         SetReferenceCollections(instance);

--- a/src/Moryx.AbstractionLayer/Processes/ProcessBindingResolverFactory.cs
+++ b/src/Moryx.AbstractionLayer/Processes/ProcessBindingResolverFactory.cs
@@ -88,7 +88,7 @@ public class PartLinkShortCut : BindingResolverBase
         // 3. Make sure we do not have a naming conflict
         if (linkResult != null && prodResult != null)
         {
-            throw new InvalidOperationException("Binding value inconclusive on part link and product!");
+            throw new InvalidOperationException("Binding value inconclusive on part link and product.");
         }
 
         return linkResult != null ? partLink : partLink.Product;
@@ -168,6 +168,6 @@ public class ProductResolver : BindingResolverBase
     /// <inheritdoc />
     protected override bool Update(object source, object value)
     {
-        throw new InvalidOperationException("Products cannot be updated!");
+        throw new InvalidOperationException("Products cannot be updated.");
     }
 }

--- a/src/Moryx.AbstractionLayer/Products/ProductIdentity.cs
+++ b/src/Moryx.AbstractionLayer/Products/ProductIdentity.cs
@@ -50,7 +50,7 @@ public partial class ProductIdentity : IIdentity
         var match = IdentityPattern().Match(identityString);
         if (!match.Success || !short.TryParse(match.Groups["revision"].Value,
                 NumberStyles.None, CultureInfo.InvariantCulture, out var revision))
-            throw new FormatException($"identityString should consist of <identity>-<revision> instead of {identityString}");
+            throw new FormatException($"identityString should consist of <identity>-<revision> instead of {identityString}.");
 
         return new ProductIdentity(match.Groups["identifier"].Value, revision);
     }
@@ -88,7 +88,7 @@ public partial class ProductIdentity : IIdentity
     /// <exception cref="InvalidOperationException">Identifiers of some identities must not be overriden</exception>
     public void SetIdentifier(string identifier)
     {
-        throw new InvalidOperationException("Product identifiers must not be overriden!");
+        throw new InvalidOperationException("Product identifiers must not be overriden.");
     }
 
     /// <summary>

--- a/src/Moryx.AbstractionLayer/Products/ProductIdentity.cs
+++ b/src/Moryx.AbstractionLayer/Products/ProductIdentity.cs
@@ -50,7 +50,7 @@ public partial class ProductIdentity : IIdentity
         var match = IdentityPattern().Match(identityString);
         if (!match.Success || !short.TryParse(match.Groups["revision"].Value,
                 NumberStyles.None, CultureInfo.InvariantCulture, out var revision))
-            throw new FormatException($"identityString should consist of <identity>-<revision> instead of {identityString}.");
+            throw new FormatException($"'{identityString}' does not match the expected pattern '{IdentityPattern()}'.");
 
         return new ProductIdentity(match.Groups["identifier"].Value, revision);
     }

--- a/src/Moryx.AbstractionLayer/Products/ProductReference.cs
+++ b/src/Moryx.AbstractionLayer/Products/ProductReference.cs
@@ -30,6 +30,6 @@ public class ProductReference : ProductType
     /// <inheritdoc />
     protected override ProductInstance Instantiate()
     {
-        throw new InvalidOperationException("Reference products can not be instantiated. Please replace with a real product first!");
+        throw new InvalidOperationException("Reference products can not be instantiated. Please replace with a real product first.");
     }
 }

--- a/src/Moryx.AbstractionLayer/Recipes/RecipeBindingResolverFactory.cs
+++ b/src/Moryx.AbstractionLayer/Recipes/RecipeBindingResolverFactory.cs
@@ -64,7 +64,7 @@ public class RecipeBindingResolverFactory : BindingResolverFactory
 
         protected override bool Update(object source, object value)
         {
-            throw new InvalidOperationException("Workplan can not be updated!");
+            throw new InvalidOperationException("Workplan can not be updated.");
         }
     }
 
@@ -86,7 +86,7 @@ public class RecipeBindingResolverFactory : BindingResolverFactory
 
         protected override bool Update(object source, object value)
         {
-            throw new InvalidOperationException("Step can not be updated!");
+            throw new InvalidOperationException("Step can not be updated.");
         }
     }
 }

--- a/src/Moryx.AbstractionLayer/Recipes/RecipeReference.cs
+++ b/src/Moryx.AbstractionLayer/Recipes/RecipeReference.cs
@@ -48,6 +48,6 @@ public class RecipeReference : IRecipe
     /// <inheritdoc />
     public IRecipe Clone()
     {
-        throw new InvalidOperationException($"{nameof(RecipeReference)} cannot be cloned!");
+        throw new InvalidOperationException($"{nameof(RecipeReference)} cannot be cloned.");
     }
 }

--- a/src/Moryx.AbstractionLayer/Workplans/TaskTransition.cs
+++ b/src/Moryx.AbstractionLayer/Workplans/TaskTransition.cs
@@ -104,7 +104,7 @@ public class TaskTransition<TActivity> : TransitionBase, IObservableTransition, 
 
         if (activity is not Activity castedActivity)
         {
-            throw new InvalidCastException($"Activity type must inherit from Activity");
+            throw new InvalidCastException($"Activity type must inherit from Activity.");
         }
 
         // Link objects

--- a/src/Moryx.AbstractionLayer/Workplans/TaskTransition.cs
+++ b/src/Moryx.AbstractionLayer/Workplans/TaskTransition.cs
@@ -104,7 +104,7 @@ public class TaskTransition<TActivity> : TransitionBase, IObservableTransition, 
 
         if (activity is not Activity castedActivity)
         {
-            throw new InvalidCastException($"Activity type must inherit from Activity.");
+            throw new InvalidCastException($"Activity type must inherit from {nameof(Activity)}.");
         }
 
         // Link objects

--- a/src/Moryx.AbstractionLayer/Workplans/WorkplanExtensions.cs
+++ b/src/Moryx.AbstractionLayer/Workplans/WorkplanExtensions.cs
@@ -37,7 +37,7 @@ public static class WorkplanExtensions
             }
 
             if (task.Outputs.Length != outputs.Length)
-                throw new ArgumentException($"Wrong number of outputs for the task {task.Name}");
+                throw new ArgumentException($"Wrong number of outputs for the task {task.Name}.");
 
             workplan.Add(task);
 
@@ -66,7 +66,7 @@ public static class WorkplanExtensions
             }
 
             if (task.Outputs.Length != outputs.Length)
-                throw new ArgumentException($"Wrong number of outputs for the task {task.Name}");
+                throw new ArgumentException($"Wrong number of outputs for the task {task.Name}.");
 
             workplan.Add(task);
 

--- a/src/Moryx.AspNetCore.Mqtt/Components/ManagedMqttClient.cs
+++ b/src/Moryx.AspNetCore.Mqtt/Components/ManagedMqttClient.cs
@@ -84,7 +84,7 @@ internal sealed class ManagedMqttClient : IManagedMqttClient
 
         if (_internalClient.Options == null)
         {
-            throw new InvalidOperationException("call StartAsync before publishing messages");
+            throw new InvalidOperationException("call StartAsync before publishing messages.");
         }
 
         MqttTopicValidator.ThrowIfInvalid(applicationMessage.Topic);

--- a/src/Moryx.AspNetCore.Mqtt/Components/ManagedMqttClient.cs
+++ b/src/Moryx.AspNetCore.Mqtt/Components/ManagedMqttClient.cs
@@ -84,7 +84,7 @@ internal sealed class ManagedMqttClient : IManagedMqttClient
 
         if (_internalClient.Options == null)
         {
-            throw new InvalidOperationException("call StartAsync before publishing messages.");
+            throw new InvalidOperationException($"Call {nameof(StartAsync)} before publishing messages.");
         }
 
         MqttTopicValidator.ThrowIfInvalid(applicationMessage.Topic);
@@ -235,7 +235,7 @@ internal sealed class ManagedMqttClient : IManagedMqttClient
 
         if (_internalClient.Options == null)
         {
-            throw new InvalidOperationException("Client is not started. Call StartAsync first.");
+            throw new InvalidOperationException($"Client is not started. Call {nameof(StartAsync)} first.");
         }
 
         var filterList = topicFilters.ToList();
@@ -282,7 +282,7 @@ internal sealed class ManagedMqttClient : IManagedMqttClient
 
         if (_internalClient.Options == null)
         {
-            throw new InvalidOperationException("Client is not started. Call StartAsync first.");
+            throw new InvalidOperationException($"Client is not started. Call {nameof(StartAsync)} first.");
         }
 
         var topicList = topics.ToList();

--- a/src/Moryx.AspNetCore.Mqtt/Services/MqttEndpointService.cs
+++ b/src/Moryx.AspNetCore.Mqtt/Services/MqttEndpointService.cs
@@ -32,7 +32,7 @@ internal sealed class MqttEndpointService(IManagedMqttClient client, MqttRouteBu
 
     public IManagedMqttClient Client { get; }
         = client
-          ?? throw new ArgumentNullException("No 'IHostedMqttClient' found. Make sure your added 'services.AddMqttClient()' to your program.cs.");
+          ?? throw new ArgumentNullException($"No '{nameof(IManagedMqttClient)}' found. Make sure your added 'services.AddMqttClient()' to your program.cs.");
     #endregion
 
     #region Hosted Service

--- a/src/Moryx.AspNetCore.Mqtt/Services/MqttEndpointService.cs
+++ b/src/Moryx.AspNetCore.Mqtt/Services/MqttEndpointService.cs
@@ -32,7 +32,7 @@ internal sealed class MqttEndpointService(IManagedMqttClient client, MqttRouteBu
 
     public IManagedMqttClient Client { get; }
         = client
-          ?? throw new ArgumentNullException("No 'IHostedMqttClient' found. Make sure your added 'services.AddMqttClient()' to your program.cs");
+          ?? throw new ArgumentNullException("No 'IHostedMqttClient' found. Make sure your added 'services.AddMqttClient()' to your program.cs.");
     #endregion
 
     #region Hosted Service

--- a/src/Moryx.ControlSystem.Assemble/AssembleSetupTrigger.cs
+++ b/src/Moryx.ControlSystem.Assemble/AssembleSetupTrigger.cs
@@ -46,7 +46,7 @@ public class AssembleSetupTrigger : SetupTriggerBase<AssembleSetupTriggerConfig>
             .FirstOrDefault();
 
         if (requiredAssembleCapabilitiesType == null)
-            throw new InvalidConfigException(Config.RequiredCapabilityType, $"{nameof(AssembleSetupTriggerConfig.RequiredCapabilityType)} was not found!");
+            throw new InvalidConfigException(Config.RequiredCapabilityType, $"{nameof(AssembleSetupTriggerConfig.RequiredCapabilityType)} was not found.");
 
         _capabilitiesConstructor = ReflectionTool.ConstructorDelegate<ICapabilities>(requiredAssembleCapabilitiesType); ;
 
@@ -61,7 +61,7 @@ public class AssembleSetupTrigger : SetupTriggerBase<AssembleSetupTriggerConfig>
 
         var targetProperty = requiredAssembleCapabilitiesType.GetProperty(Config.TargetPropertyName);
         if (targetProperty == null)
-            throw new ArgumentException($"{nameof(AssembleSetupTriggerConfig.TargetPropertyName)} is not available in {Config.RequiredCapabilityType}");
+            throw new ArgumentException($"{nameof(AssembleSetupTriggerConfig.TargetPropertyName)} is not available in {Config.RequiredCapabilityType}.");
 
         // Make custom descriptor instance
         _descriptorAccessor = ReflectionTool.PropertyAccessor<ICapabilities>(targetProperty);

--- a/src/Moryx.ControlSystem.Jobs.Endpoints/Models/Converter.cs
+++ b/src/Moryx.ControlSystem.Jobs.Endpoints/Models/Converter.cs
@@ -69,7 +69,7 @@ internal static class Converter
         }
         else
         {
-            throw new ArgumentException("Unsupported job type", nameof(job));
+            throw new ArgumentException("Unsupported job type.", nameof(job));
         }
 
         return model;

--- a/src/Moryx.ControlSystem.ProcessEngine/Facades/JobManagementFacade.cs
+++ b/src/Moryx.ControlSystem.ProcessEngine/Facades/JobManagementFacade.cs
@@ -179,7 +179,7 @@ internal class JobManagementFacade : IJobManagement, IFacadeControl
         if (errors.Count > 0)
         {
             var msg = string.Join("\n", errors);
-            throw new ValidationException("Workplan validation failed. Errors:\n" + msg);
+            throw new ValidationException($"Workplan validation failed. Errors:\n{msg}");
         }
     }
 

--- a/src/Moryx.ControlSystem.ProcessEngine/Facades/JobManagementFacade.cs
+++ b/src/Moryx.ControlSystem.ProcessEngine/Facades/JobManagementFacade.cs
@@ -106,7 +106,7 @@ internal class JobManagementFacade : IJobManagement, IFacadeControl
     {
         ValidateHealthState();
         if (recipe is not ProductionRecipe prodRecipe)
-            throw new ArgumentException($"Process engine only supports {nameof(ProductionRecipe)}", nameof(recipe));
+            throw new ArgumentException($"Process engine only supports {nameof(ProductionRecipe)}.", nameof(recipe));
 
         return new JobEvaluation
         {
@@ -144,7 +144,7 @@ internal class JobManagementFacade : IJobManagement, IFacadeControl
         ValidateHealthState();
         return JobList.Get(jobId)?.Job
                ?? History.Get(jobId)
-               ?? throw new ArgumentException("Job does not refer to managed job", nameof(jobId));
+               ?? throw new ArgumentException("Job does not refer to managed job.", nameof(jobId));
     }
 
     public IReadOnlyList<Job> GetAll()
@@ -170,16 +170,16 @@ internal class JobManagementFacade : IJobManagement, IFacadeControl
         ArgumentNullException.ThrowIfNull(recipe);
 
         if (recipe.Origin == null)
-            throw new ArgumentException("Origin must not be null on recipe", nameof(recipe));
+            throw new ArgumentException("Origin must not be null on recipe.", nameof(recipe));
 
         var productionRecipe = recipe as ProductionRecipe
-                               ?? throw new NotSupportedException("Process engine only supports 'ProductionRecipe'!");
+                               ?? throw new NotSupportedException("Process engine only supports 'ProductionRecipe'.");
 
         var errors = WorkplanValidation.Validate(productionRecipe.Workplan);
         if (errors.Count > 0)
         {
             var msg = string.Join("\n", errors);
-            throw new ValidationException("Workplan validation failed! Errors \n" + msg);
+            throw new ValidationException("Workplan validation failed. Errors:\n" + msg);
         }
     }
 
@@ -192,7 +192,7 @@ internal class JobManagementFacade : IJobManagement, IFacadeControl
 
         ValidateHealthState();
         return JobList.Get(job.Id)
-               ?? throw new ArgumentException("Job does not refer to managed job", nameof(job));
+               ?? throw new ArgumentException("Job does not refer to managed job.", nameof(job));
     }
 
     /// <inheritdoc />

--- a/src/Moryx.ControlSystem.ProcessEngine/Facades/JobManagementFacade.cs
+++ b/src/Moryx.ControlSystem.ProcessEngine/Facades/JobManagementFacade.cs
@@ -173,7 +173,7 @@ internal class JobManagementFacade : IJobManagement, IFacadeControl
             throw new ArgumentException("Origin must not be null on recipe.", nameof(recipe));
 
         var productionRecipe = recipe as ProductionRecipe
-                               ?? throw new NotSupportedException("Process engine only supports 'ProductionRecipe'.");
+                               ?? throw new NotSupportedException($"Process engine only supports '{nameof(ProductionRecipe)}'.");
 
         var errors = WorkplanValidation.Validate(productionRecipe.Workplan);
         if (errors.Count > 0)

--- a/src/Moryx.ControlSystem.ProcessEngine/Jobs/IJobDataFactory.cs
+++ b/src/Moryx.ControlSystem.ProcessEngine/Jobs/IJobDataFactory.cs
@@ -71,7 +71,7 @@ internal class JobDataFactory : IJobDataFactory
     private static void ValidateCreatedJob(IJobData jobData, IWorkplanRecipe recipe)
     {
         if (jobData == null)
-            throw new InvalidOperationException("Cannot find job type for recipe of type: " + recipe.GetType().FullName);
+            throw new InvalidOperationException("Cannot find job type for recipe of type: " + recipe.GetType().FullName + ".");
     }
 
     public void Destroy(IJobData jobData) => InternalFactory.Destroy(jobData);

--- a/src/Moryx.ControlSystem.ProcessEngine/Jobs/IJobDataFactory.cs
+++ b/src/Moryx.ControlSystem.ProcessEngine/Jobs/IJobDataFactory.cs
@@ -71,7 +71,7 @@ internal class JobDataFactory : IJobDataFactory
     private static void ValidateCreatedJob(IJobData jobData, IWorkplanRecipe recipe)
     {
         if (jobData == null)
-            throw new InvalidOperationException("Cannot find job type for recipe of type: " + recipe.GetType().FullName + ".");
+            throw new InvalidOperationException($"Cannot find job type for recipe of type: {recipe.GetType().FullName}.");
     }
 
     public void Destroy(IJobData jobData) => InternalFactory.Destroy(jobData);

--- a/src/Moryx.ControlSystem.ProcessEngine/Jobs/Implementation/JobList.cs
+++ b/src/Moryx.ControlSystem.ProcessEngine/Jobs/Implementation/JobList.cs
@@ -260,7 +260,7 @@ internal class JobList : IJobDataList, IJobList
             JobPositionType.AfterOther => AfterOther(jobDatas, affectedJobs, jobPosition),
             JobPositionType.AroundExisting => Expand(jobDatas, affectedJobs),
             JobPositionType.AppendToRecipe => AppendToRecipe(jobDatas, affectedJobs, jobPosition),
-            _ => throw new ArgumentOutOfRangeException(nameof(jobPosition), "Unsupported job position!")
+            _ => throw new ArgumentOutOfRangeException(nameof(jobPosition), "Unsupported job position.")
         };
 
         // Save modified collection to database BEFORE any other action
@@ -360,7 +360,7 @@ internal class JobList : IJobDataList, IJobList
             currentNode = currentNode.Next;
         }
 
-        throw new KeyNotFoundException($"Found no job with id: {id} in the job list! Maybe it was removed?");
+        throw new KeyNotFoundException($"Found no job with id: {id} in the job list. Maybe it was removed?");
     }
 
     private long? Expand(LinkedList<IJobData> expandedList, List<IJobData> affectedJobs)
@@ -410,7 +410,7 @@ internal class JobList : IJobDataList, IJobList
                     // If we reached the end without finding a match, something is broken
                     var jobString = string.Join(";", expandedList.Select(j => $"{j.Id}-{j.Recipe.Name}"));
                     Logger.Log(LogLevel.Error, "Expanding list failed: {0}", jobString);
-                    throw new InvalidOperationException($"Expand: Existing job {currentNode.Value.Id} does not match job list position!");
+                    throw new InvalidOperationException($"Expand: Existing job {currentNode.Value.Id} does not match job list position.");
                 }
             }
 

--- a/src/Moryx.ControlSystem.ProcessEngine/Jobs/Implementation/JobStorage.cs
+++ b/src/Moryx.ControlSystem.ProcessEngine/Jobs/Implementation/JobStorage.cs
@@ -118,7 +118,7 @@ internal class JobStorage : IJobStorage, IJobHistory, ILoggingComponent
 
         // If there are still jobs left, the database was corrupted
         if (dbJobs.Any())
-            throw new InvalidOperationException("Failed to restore sorted jobs. Database corrupted!");
+            throw new InvalidOperationException("Failed to restore sorted jobs. Database corrupted.");
 
         // return sorted list
         return jobs;
@@ -182,7 +182,7 @@ internal class JobStorage : IJobStorage, IJobHistory, ILoggingComponent
 
         var provider = RecipeProviders.First(p => p.Name == result.RecipeProvider);
         if (provider is not IProductManagement)
-            throw new InvalidOperationException("Only jobs based on product recipes can be reloaded");
+            throw new InvalidOperationException("Only jobs based on product recipes can be reloaded.");
 
         result.DelayedRecipe = provider.LoadRecipeAsync(result.RecipeId).GetAwaiter().GetResult();
         return result;

--- a/src/Moryx.ControlSystem.ProcessEngine/Processes/Implementation/ProcessArchive.cs
+++ b/src/Moryx.ControlSystem.ProcessEngine/Processes/Implementation/ProcessArchive.cs
@@ -225,7 +225,7 @@ internal class ProcessArchive : IProcessArchive
             if (_jobData.TryGetTarget(out var job))
                 return job;
 
-            throw new ObjectDisposedException("Target of the chunk has been disposed!");
+            throw new ObjectDisposedException("Target of the chunk has been disposed.");
         }
 
         /// <summary>

--- a/src/Moryx.ControlSystem.ProcessEngine/Processes/ProcessStorage.cs
+++ b/src/Moryx.ControlSystem.ProcessEngine/Processes/ProcessStorage.cs
@@ -423,7 +423,7 @@ internal class ProcessStorage : IProcessStorage, ILoggingComponent
             return nonNullDateTime;
         if (nonNullDateTime.Kind == DateTimeKind.Local)
             return TimeZoneInfo.ConvertTimeToUtc(nonNullDateTime, TimeZoneInfo.Local);
-        throw new ArgumentException($"Provided {nameof(DateTime)} is neither UTC nor Local Time");
+        throw new ArgumentException($"Provided {nameof(DateTime)} is neither UTC nor Local Time.");
     }
 
     private class TracingWrapper : IPersistentObject

--- a/src/Moryx.ControlSystem/Cells/ActivityStart.cs
+++ b/src/Moryx.ControlSystem/Cells/ActivityStart.cs
@@ -30,7 +30,7 @@ public class ActivityStart : Session
     public ActivityCompleted CreateResult()
     {
         if (Activity.Result == null)
-            throw new InvalidOperationException("Can not create completed message for activity without result");
+            throw new InvalidOperationException("Can not create completed message for activity without result.");
 
         return new ActivityCompleted(Activity, this);
     }

--- a/src/Moryx.ControlSystem/Processes/IProcessExtensions.cs
+++ b/src/Moryx.ControlSystem/Processes/IProcessExtensions.cs
@@ -36,10 +36,10 @@ public static class IProcessExtensions
             where TInstance : ProductInstance
         {
             if (process is not ProductionProcess productionProcess)
-                throw new InvalidOperationException($"Cannot modify an {nameof(ProductInstance)} on a process of type {process.GetType()}");
+                throw new InvalidOperationException($"Cannot modify an {nameof(ProductInstance)} on a process of type {process.GetType()}.");
             if (productionProcess.ProductInstance is not TInstance instance)
                 throw new InvalidCastException($"Cannot cast {nameof(ProductionProcess.ProductInstance)} of type " +
-                                               $"{productionProcess?.ProductInstance?.GetType()} to {typeof(TInstance)}");
+                                               $"{productionProcess?.ProductInstance?.GetType()} to {typeof(TInstance)}.");
             setter.Invoke(instance);
             return instance;
         }

--- a/src/Moryx.ControlSystem/Processes/ProcessHolderExtensions.cs
+++ b/src/Moryx.ControlSystem/Processes/ProcessHolderExtensions.cs
@@ -272,7 +272,7 @@ public static class ProcessHolderExtensions
                 throw new InvalidOperationException($"Tried to update the {nameof(Session)} on an " +
                                                     $"{nameof(IProcessHolderPosition)} with a different session. Make sure to " +
                                                     $"{nameof(IProcessHolderPosition.Reset)} the {nameof(IProcessHolderPosition)} before " +
-                                                    $"assigning a new {nameof(Session)}");
+                                                    $"assigning a new {nameof(Session)}.");
 
             if (position is ProcessHolderPosition explicitPosition)
             {

--- a/src/Moryx.ControlSystem/Processes/ProcessHolderPosition.cs
+++ b/src/Moryx.ControlSystem/Processes/ProcessHolderPosition.cs
@@ -147,7 +147,7 @@ public class ProcessHolderPosition : Resource, IProcessHolderPosition
     {
         if (!(Session is ActivityStart activityStart))
         {
-            throw new InvalidOperationException("Can only complete the activity if the current session is ActivityStart");
+            throw new InvalidOperationException("Can only complete the activity if the current session is ActivityStart.");
         }
 
         Session = activityStart.CreateResult(result);
@@ -159,7 +159,7 @@ public class ProcessHolderPosition : Resource, IProcessHolderPosition
     {
         if (Process != null)
         {
-            throw new InvalidOperationException("Can not mount a position currently holding a process");
+            throw new InvalidOperationException("Can not mount a position currently holding a process.");
         }
 
         Session = mountInformation.Session;

--- a/src/Moryx.ControlSystem/Processes/ProcessHolderPosition.cs
+++ b/src/Moryx.ControlSystem/Processes/ProcessHolderPosition.cs
@@ -147,7 +147,7 @@ public class ProcessHolderPosition : Resource, IProcessHolderPosition
     {
         if (!(Session is ActivityStart activityStart))
         {
-            throw new InvalidOperationException("Can only complete the activity if the current session is ActivityStart.");
+            throw new InvalidOperationException($"Can only complete the activity if the current session is {nameof(ActivityStart)}.");
         }
 
         Session = activityStart.CreateResult(result);

--- a/src/Moryx.ControlSystem/Processes/ProcessMovement.cs
+++ b/src/Moryx.ControlSystem/Processes/ProcessMovement.cs
@@ -103,7 +103,7 @@ public class ProcessMovement : IDisposable
     public void MountOnTarget()
     {
         if (Progress < MovementProgress.InformationRetrieved)
-            throw new InvalidOperationException("Can not mount before initiating the transaction");
+            throw new InvalidOperationException("Can not mount before initiating the transaction.");
 
         _target.Mount(MountInformation);
         Progress = MovementProgress.MountedOnTarget;
@@ -115,7 +115,7 @@ public class ProcessMovement : IDisposable
     public void RemoveOnSource()
     {
         if (Progress < MovementProgress.MountedOnTarget)
-            throw new InvalidOperationException("Can not remove before mounting on target");
+            throw new InvalidOperationException("Can not remove before mounting on target.");
 
         _source.Unmount();
         Progress = MovementProgress.RemovedFromSource;
@@ -127,7 +127,7 @@ public class ProcessMovement : IDisposable
     public void Confirm()
     {
         if (Progress < MovementProgress.MountedOnTarget)
-            throw new InvalidOperationException("Can not confirm before everything was completed");
+            throw new InvalidOperationException("Can not confirm before everything was completed.");
 
         Progress = MovementProgress.Completed;
     }

--- a/src/Moryx.ControlSystem/Processes/ProcessReplacement.cs
+++ b/src/Moryx.ControlSystem/Processes/ProcessReplacement.cs
@@ -27,7 +27,7 @@ public abstract class ProcessReplacement : Process
     public override long Id
     {
         get => _processId;
-        set => throw new NotSupportedException("Changing replacement id is not supported!");
+        set => throw new NotSupportedException("Changing replacement id is not supported.");
     }
 
     /// <inheritdoc />

--- a/src/Moryx.ControlSystem/VisualInstructions/VisualInstructorExtensions.cs
+++ b/src/Moryx.ControlSystem/VisualInstructions/VisualInstructorExtensions.cs
@@ -110,11 +110,11 @@ public static class VisualInstructorExtensions
         {
             var activity = activityStart.Activity;
             var attr = activity.GetType().GetCustomAttribute<ActivityResultsAttribute>() ??
-                       throw new ArgumentException($"Activity is not decorated with the {nameof(ActivityResultsAttribute)}");
+                       throw new ArgumentException($"Activity is not decorated with the {nameof(ActivityResultsAttribute)}.");
 
             if (!attr.ResultEnum.IsEnum)
             {
-                throw new ArgumentException("Result type is not an enum!");
+                throw new ArgumentException("Result type is not an enum.");
             }
 
             return instructor.Execute(new ActiveInstruction

--- a/src/Moryx.Drivers.Mqtt/MqttTopic.cs
+++ b/src/Moryx.Drivers.Mqtt/MqttTopic.cs
@@ -351,7 +351,7 @@ public abstract class MqttTopic<TMessage> : MqttTopic, IMessageChannel
         {
             Logger.Log(LogLevel.Error, "Message {0} has the wrong Type. It is {1} instead of {2}",
                 payload, payload.GetType(), typeof(TMessage));
-            throw new ArgumentException("Message " + payload + " has the wrong Type. It is " + payload.GetType() + " instead of " + typeof(TMessage) + ".");
+            throw new ArgumentException($"Message {payload} has the wrong Type. It is {payload.GetType()} instead of {typeof(TMessage)}.");
         }
 
         await MqttDriver.SendInternalAsync(this, payload, cancellationToken);
@@ -366,13 +366,12 @@ public abstract class MqttTopic<TMessage> : MqttTopic, IMessageChannel
             topic = identifierMessage.Identifier;
             if (topic.Contains('{'))
             {
-                throw new ArgumentException("Topic " + topic + " of a IdentifierMessage contains placeholders.");
+                throw new ArgumentException($"Topic {topic} of a IdentifierMessage contains placeholders.");
             }
 
             if (!Matches(topic))
             {
-                throw new ArgumentException("Topic " + topic + " of the IdentifierMessage" +
-                                            " does not match the topic defined in the Resource.");
+                throw new ArgumentException($"Topic {topic} of the IdentifierMessage does not match the topic defined in the Resource.");
             }
         }
         else
@@ -382,7 +381,7 @@ public abstract class MqttTopic<TMessage> : MqttTopic, IMessageChannel
         }
         if (topic.Contains('#') || topic.Contains('+'))
         {
-            throw new ArgumentException("Topic to be published on contains wildcards: " + topic + ".");
+            throw new ArgumentException($"Topic to be published on contains wildcards: {topic}.");
         }
 
         if (topic.Contains('{'))

--- a/src/Moryx.Drivers.Mqtt/MqttTopic.cs
+++ b/src/Moryx.Drivers.Mqtt/MqttTopic.cs
@@ -62,7 +62,7 @@ public abstract class MqttTopic : Resource, IMessageChannel
                     // $ to match end of string
                     pattern += "$";
                     RegexTopic = new Regex(pattern);
-                    
+
                     var subscribeTopic = value.Replace(".", "__");
                     subscribeTopic = new Regex(@"\{\w+\|#\}").Replace(subscribeTopic, "#");
                     SubscribedTopic = new Regex(@"({\w*})").Replace(subscribeTopic, "+");
@@ -351,7 +351,7 @@ public abstract class MqttTopic<TMessage> : MqttTopic, IMessageChannel
         {
             Logger.Log(LogLevel.Error, "Message {0} has the wrong Type. It is {1} instead of {2}",
                 payload, payload.GetType(), typeof(TMessage));
-            throw new ArgumentException("Message " + payload + " has the wrong Type. It is " + payload.GetType() + " instead of " + typeof(TMessage));
+            throw new ArgumentException("Message " + payload + " has the wrong Type. It is " + payload.GetType() + " instead of " + typeof(TMessage) + ".");
         }
 
         await MqttDriver.SendInternalAsync(this, payload, cancellationToken);
@@ -366,13 +366,13 @@ public abstract class MqttTopic<TMessage> : MqttTopic, IMessageChannel
             topic = identifierMessage.Identifier;
             if (topic.Contains('{'))
             {
-                throw new ArgumentException("Topic " + topic + " of a IdentifierMessage contains placeholders");
+                throw new ArgumentException("Topic " + topic + " of a IdentifierMessage contains placeholders.");
             }
 
             if (!Matches(topic))
             {
                 throw new ArgumentException("Topic " + topic + " of the IdentifierMessage" +
-                                            " does not match the topic defined in the Resource");
+                                            " does not match the topic defined in the Resource.");
             }
         }
         else
@@ -382,7 +382,7 @@ public abstract class MqttTopic<TMessage> : MqttTopic, IMessageChannel
         }
         if (topic.Contains('#') || topic.Contains('+'))
         {
-            throw new ArgumentException("Topic to be published on contains wildcards: " + topic);
+            throw new ArgumentException("Topic to be published on contains wildcards: " + topic + ".");
         }
 
         if (topic.Contains('{'))

--- a/src/Moryx.Drivers.Mqtt/States/DriverMqttState.cs
+++ b/src/Moryx.Drivers.Mqtt/States/DriverMqttState.cs
@@ -22,7 +22,7 @@ internal abstract class DriverMqttState : SyncDriverState<MqttDriver>
 
     internal virtual Task SendAsync(MqttTopic topic, object message, CancellationToken cancellationToken)
     {
-        throw new InvalidOperationException($"Current state {GetType().Name} can net send message of type {message.GetType().Name}");
+        throw new InvalidOperationException($"Current state {GetType().Name} can net send message of type {message.GetType().Name}.");
     }
 
     internal virtual void TriedConnecting(bool successful)

--- a/src/Moryx.Drivers.Mqtt/Topics/JsonOptionsExtension.cs
+++ b/src/Moryx.Drivers.Mqtt/Topics/JsonOptionsExtension.cs
@@ -33,7 +33,7 @@ public static class JsonOptionsExtension
         {
             JsonEncoderOption.Default => JavaScriptEncoder.Default,
             JsonEncoderOption.UnsafeRelaxedJsonEscaping => JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
-            _ => throw new NotImplementedException($"EncoderOption {encoderOption} is not defined"),
+            _ => throw new NotImplementedException($"EncoderOption {encoderOption} is not defined."),
         };
     }
 

--- a/src/Moryx.Drivers.Mqtt/Topics/MqttTopicPrimitive.cs
+++ b/src/Moryx.Drivers.Mqtt/Topics/MqttTopicPrimitive.cs
@@ -159,7 +159,7 @@ public class MqttTopicPrimitive : MqttTopic<IConvertible>
             TypeCode.UInt32 => "System.UInt32",
             TypeCode.UInt64 => "System.UInt64",
             TypeCode.String => "System.String",
-            _ => throw new NotImplementedException("This MessageType is not implemented"),
+            _ => throw new NotImplementedException("This MessageType is not implemented."),
         };
     }
     #endregion

--- a/src/Moryx.Drivers.Mqtt/Topics/MqttTopicPrimitive.cs
+++ b/src/Moryx.Drivers.Mqtt/Topics/MqttTopicPrimitive.cs
@@ -159,7 +159,7 @@ public class MqttTopicPrimitive : MqttTopic<IConvertible>
             TypeCode.UInt32 => "System.UInt32",
             TypeCode.UInt64 => "System.UInt64",
             TypeCode.String => "System.String",
-            _ => throw new NotImplementedException("This MessageType is not implemented."),
+            _ => throw new NotImplementedException($"The TypeCode '{type}' is not implemented."),
         };
     }
     #endregion

--- a/src/Moryx.Drivers.OpcUa/Factories/ApplicationConfigurationFactory.cs
+++ b/src/Moryx.Drivers.OpcUa/Factories/ApplicationConfigurationFactory.cs
@@ -42,7 +42,7 @@ internal class ApplicationConfigurationFactory
         var haveAppCertificate = await application.CheckApplicationInstanceCertificatesAsync(false, 0, cancellationToken);
         if (!haveAppCertificate)
         {
-            throw new InvalidCertificateException("Application instance certificate invalid!");
+            throw new InvalidCertificateException("Application instance certificate invalid.");
         }
         else
         {

--- a/src/Moryx.FactoryMonitor.Endpoints/FactoryMonitorController.cs
+++ b/src/Moryx.FactoryMonitor.Endpoints/FactoryMonitorController.cs
@@ -476,7 +476,7 @@ public class FactoryMonitorController : ControllerBase
 
         if (resource is not IMachineLocation locationResource)
         {
-            throw new ArgumentException($"This cannot happen, unless there is a bug in the {_resourceManager}", nameof(location));
+            throw new ArgumentException($"This cannot happen, unless there is a bug in the {_resourceManager}.", nameof(location));
         }
 
         // Location is referencing a cell directly

--- a/src/Moryx.Media.Server/ContentManager/ContentManager.cs
+++ b/src/Moryx.Media.Server/ContentManager/ContentManager.cs
@@ -111,7 +111,7 @@ internal class ContentManager : IContentManager
     public async Task<ContentAddingInfo> AddMaster(string fileName, Stream contentStream)
     {
         if (!contentStream.CanSeek)
-            throw new NotSupportedException("Stream needs to be seekable");
+            throw new NotSupportedException("Stream needs to be seekable.");
 
         var hashPath = HashPath.FromStream(contentStream);
 

--- a/src/Moryx.Model/Annotations/DateTimeKindAnnotation.cs
+++ b/src/Moryx.Model/Annotations/DateTimeKindAnnotation.cs
@@ -66,7 +66,7 @@ public static class DateTimeKindAnnotation
                     property.SetValueConverter(UnspecifiedConverter);
                     break;
                 default:
-                    throw new NotSupportedException($"Kind \"{kind}\" unsupported");
+                    throw new NotSupportedException($"Kind \"{kind}\" unsupported.");
             }
         }
     }

--- a/src/Moryx.Model/Configuration/NullModelConfigurator.cs
+++ b/src/Moryx.Model/Configuration/NullModelConfigurator.cs
@@ -24,49 +24,49 @@ public sealed class NullModelConfigurator : IModelConfigurator
     /// <inheritdoc />
     public DbContext CreateContext()
     {
-        throw new NotSupportedException("Not supported by " + nameof(NullModelConfigurator) + ".");
+        throw new NotSupportedException($"Not supported by {nameof(NullModelConfigurator)}.");
     }
 
     /// <inheritdoc />
     public DbContext CreateContext(DatabaseConfig config)
     {
-        throw new NotSupportedException("Not supported by " + nameof(NullModelConfigurator) + ".");
+        throw new NotSupportedException($"Not supported by {nameof(NullModelConfigurator)}.");
     }
 
     /// <inheritdoc />
     public Task<TestConnectionResult> TestConnectionAsync(DatabaseConfig config, CancellationToken cancellationToken = default)
     {
-        throw new NotSupportedException("Not supported by " + nameof(NullModelConfigurator) + ".");
+        throw new NotSupportedException($"Not supported by {nameof(NullModelConfigurator)}.");
     }
 
     /// <inheritdoc />
     public Task<bool> CreateDatabaseAsync(DatabaseConfig config, CancellationToken cancellationToken = default)
     {
-        throw new NotSupportedException("Not supported by " + nameof(NullModelConfigurator) + ".");
+        throw new NotSupportedException($"Not supported by {nameof(NullModelConfigurator)}.");
     }
 
     /// <inheritdoc />
     public Task<IReadOnlyList<string>> AvailableMigrationsAsync(DatabaseConfig config, CancellationToken cancellationToken = default)
     {
-        throw new NotSupportedException("Not supported by " + nameof(NullModelConfigurator) + ".");
+        throw new NotSupportedException($"Not supported by {nameof(NullModelConfigurator)}.");
     }
 
     /// <inheritdoc />
     public Task<IReadOnlyList<string>> AppliedMigrationsAsync(DatabaseConfig config, CancellationToken cancellationToken = default)
     {
-        throw new NotSupportedException("Not supported by " + nameof(NullModelConfigurator) + ".");
+        throw new NotSupportedException($"Not supported by {nameof(NullModelConfigurator)}.");
     }
 
     /// <inheritdoc />
     public Task<DatabaseMigrationSummary> MigrateDatabaseAsync(DatabaseConfig config, CancellationToken cancellationToken = default)
     {
-        throw new NotSupportedException("Not supported by " + nameof(NullModelConfigurator) + ".");
+        throw new NotSupportedException($"Not supported by {nameof(NullModelConfigurator)}.");
     }
 
     /// <inheritdoc />
     public Task DeleteDatabaseAsync(DatabaseConfig config, CancellationToken cancellationToken = default)
     {
-        throw new NotSupportedException("Not supported by " + nameof(NullModelConfigurator) + ".");
+        throw new NotSupportedException($"Not supported by {nameof(NullModelConfigurator)}.");
     }
 
     /// <inheritdoc />

--- a/src/Moryx.Model/Configuration/NullModelConfigurator.cs
+++ b/src/Moryx.Model/Configuration/NullModelConfigurator.cs
@@ -24,49 +24,49 @@ public sealed class NullModelConfigurator : IModelConfigurator
     /// <inheritdoc />
     public DbContext CreateContext()
     {
-        throw new NotSupportedException("Not supported by " + nameof(NullModelConfigurator));
+        throw new NotSupportedException("Not supported by " + nameof(NullModelConfigurator) + ".");
     }
 
     /// <inheritdoc />
     public DbContext CreateContext(DatabaseConfig config)
     {
-        throw new NotSupportedException("Not supported by " + nameof(NullModelConfigurator));
+        throw new NotSupportedException("Not supported by " + nameof(NullModelConfigurator) + ".");
     }
 
     /// <inheritdoc />
     public Task<TestConnectionResult> TestConnectionAsync(DatabaseConfig config, CancellationToken cancellationToken = default)
     {
-        throw new NotSupportedException("Not supported by " + nameof(NullModelConfigurator));
+        throw new NotSupportedException("Not supported by " + nameof(NullModelConfigurator) + ".");
     }
 
     /// <inheritdoc />
     public Task<bool> CreateDatabaseAsync(DatabaseConfig config, CancellationToken cancellationToken = default)
     {
-        throw new NotSupportedException("Not supported by " + nameof(NullModelConfigurator));
+        throw new NotSupportedException("Not supported by " + nameof(NullModelConfigurator) + ".");
     }
 
     /// <inheritdoc />
     public Task<IReadOnlyList<string>> AvailableMigrationsAsync(DatabaseConfig config, CancellationToken cancellationToken = default)
     {
-        throw new NotSupportedException("Not supported by " + nameof(NullModelConfigurator));
+        throw new NotSupportedException("Not supported by " + nameof(NullModelConfigurator) + ".");
     }
 
     /// <inheritdoc />
     public Task<IReadOnlyList<string>> AppliedMigrationsAsync(DatabaseConfig config, CancellationToken cancellationToken = default)
     {
-        throw new NotSupportedException("Not supported by " + nameof(NullModelConfigurator));
+        throw new NotSupportedException("Not supported by " + nameof(NullModelConfigurator) + ".");
     }
 
     /// <inheritdoc />
     public Task<DatabaseMigrationSummary> MigrateDatabaseAsync(DatabaseConfig config, CancellationToken cancellationToken = default)
     {
-        throw new NotSupportedException("Not supported by " + nameof(NullModelConfigurator));
+        throw new NotSupportedException("Not supported by " + nameof(NullModelConfigurator) + ".");
     }
 
     /// <inheritdoc />
     public Task DeleteDatabaseAsync(DatabaseConfig config, CancellationToken cancellationToken = default)
     {
-        throw new NotSupportedException("Not supported by " + nameof(NullModelConfigurator));
+        throw new NotSupportedException("Not supported by " + nameof(NullModelConfigurator) + ".");
     }
 
     /// <inheritdoc />

--- a/src/Moryx.Model/DbContextManager.cs
+++ b/src/Moryx.Model/DbContextManager.cs
@@ -98,7 +98,7 @@ public class DbContextManager : IDbContextManager
             }
 
             if (configuratorType == null || specificDbContextType == null)
-                throw new InvalidOperationException($"No valid configurator found for DbContext '{possibleModel.DbContext.FullName}'");
+                throw new InvalidOperationException($"No valid configurator found for DbContext '{possibleModel.DbContext.FullName}'.");
 
             var configType = configuratorType.BaseType.GenericTypeArguments.First();
 
@@ -189,7 +189,7 @@ public class DbContextManager : IDbContextManager
     {
         var configuredContext = _configuredModels.FirstOrDefault(m => m.BaseDbContextType == contextType);
         if (configuredContext == null)
-            throw new InvalidOperationException($"Context {contextType.FullName} not configured!");
+            throw new InvalidOperationException($"Context {contextType.FullName} not configured.");
 
         var setupExecutorType = typeof(ModelSetupExecutor<>).MakeGenericType(configuredContext.BaseDbContextType);
         return (IModelSetupExecutor)Activator.CreateInstance(setupExecutorType, this);
@@ -204,7 +204,7 @@ public class DbContextManager : IDbContextManager
     {
         var wrapper = _configuredModels.FirstOrDefault(k => k.BaseDbContextType == typeof(TContext));
         if (wrapper == null)
-            throw new InvalidOperationException("Unknown model");
+            throw new InvalidOperationException("Unknown model.");
 
         var configurator = wrapper.Configurator;
 

--- a/src/Moryx.Model/DesignTimeDbContextFactory.cs
+++ b/src/Moryx.Model/DesignTimeDbContextFactory.cs
@@ -39,8 +39,8 @@ public abstract class DesignTimeDbContextFactory<TContext> : IDesignTimeDbContex
 
         if (string.IsNullOrEmpty(connectionString))
         {
-            throw new InvalidOperationException("The connection string was not set " +
-                                                "in the 'EFCORETOOLSDB' environment variable nor by arguments -- --connection \"connectionString\".");
+            throw new InvalidOperationException("The connection string was not set in the 'EFCORETOOLSDB' environment variable " +
+                                                "nor by arguments -- --connection \"connectionString\".");
         }
 
         return connectionString;

--- a/src/Moryx.Model/DesignTimeDbContextFactory.cs
+++ b/src/Moryx.Model/DesignTimeDbContextFactory.cs
@@ -40,7 +40,7 @@ public abstract class DesignTimeDbContextFactory<TContext> : IDesignTimeDbContex
         if (string.IsNullOrEmpty(connectionString))
         {
             throw new InvalidOperationException("The connection string was not set " +
-                                                "in the 'EFCORETOOLSDB' environment variable nor by arguments -- --connection \"connectionString\"");
+                                                "in the 'EFCORETOOLSDB' environment variable nor by arguments -- --connection \"connectionString\".");
         }
 
         return connectionString;

--- a/src/Moryx.Model/Repositories/Proxy/RepositoryProxyBuilder.cs
+++ b/src/Moryx.Model/Repositories/Proxy/RepositoryProxyBuilder.cs
@@ -199,13 +199,13 @@ public class RepositoryProxyBuilder
     {
         if (!repoApi.IsInterface)
         {
-            throw new InvalidOperationException($"'{repoApi.Name}' is not an interface");
+            throw new InvalidOperationException($"'{repoApi.Name}' is not an interface.");
         }
 
         var repoInterfaces = repoApi.GetInterfaces();
         if (!repoInterfaces.Any(rI => rI.IsGenericType && rI.GetGenericTypeDefinition() == typeof(IRepository<>)))
         {
-            throw new InvalidOperationException($"'{repoApi.Name}' API does not inherit from IRepository<T>");
+            throw new InvalidOperationException($"'{repoApi.Name}' API does not inherit from IRepository<T>.");
         }
     }
 }

--- a/src/Moryx.Model/Repositories/Proxy/Strategies/CreateMethodStrategy.cs
+++ b/src/Moryx.Model/Repositories/Proxy/Strategies/CreateMethodStrategy.cs
@@ -55,8 +55,7 @@ internal class CreateMethodStrategy : MethodProxyStrategyBase
                 if (requiredType.IsAssignableFrom(propertyType))
                     throw new InvalidOperationException("Create entities with collection is currently not supported.");
                 else
-                    throw new InvalidOperationException("Method parameter is type of IEnumerable<T> " +
-                                                        "but the target property is not of type ICollection<T>.");
+                    throw new InvalidOperationException("Method parameter is type of IEnumerable<T> but the target property is not of type ICollection<T>.");
             }
             else
             {

--- a/src/Moryx.Model/Repositories/Proxy/Strategies/CreateMethodStrategy.cs
+++ b/src/Moryx.Model/Repositories/Proxy/Strategies/CreateMethodStrategy.cs
@@ -53,10 +53,10 @@ internal class CreateMethodStrategy : MethodProxyStrategyBase
                 // Check if Property is ICollection<NavigationEntity>
                 var requiredType = typeof(ICollection<>).MakeGenericType(genericArg);
                 if (requiredType.IsAssignableFrom(propertyType))
-                    throw new InvalidOperationException("Create entities with collection is currently not supported!");
+                    throw new InvalidOperationException("Create entities with collection is currently not supported.");
                 else
                     throw new InvalidOperationException("Method parameter is type of IEnumerable<T> " +
-                                                        "but the target property is not of type ICollection<T>");
+                                                        "but the target property is not of type ICollection<T>.");
             }
             else
             {

--- a/src/Moryx.Notifications.Publisher/Processors/NotificationProcessorBase.cs
+++ b/src/Moryx.Notifications.Publisher/Processors/NotificationProcessorBase.cs
@@ -318,7 +318,7 @@ public abstract class NotificationProcessorBase<TNotification, TNotificationType
             return dateTime;
         if (dateTime.Kind == DateTimeKind.Local)
             return TimeZoneInfo.ConvertTimeToUtc(dateTime, TimeZoneInfo.Local);
-        throw new ArgumentException($"Provided {nameof(DateTime)} is neither UTC nor Local Time");
+        throw new ArgumentException($"Provided {nameof(DateTime)} is neither UTC nor Local Time.");
     }
 
     /// <summary>

--- a/src/Moryx.Notifications/Adapter/NotificationAdapter.cs
+++ b/src/Moryx.Notifications/Adapter/NotificationAdapter.cs
@@ -59,7 +59,7 @@ public class NotificationAdapter : INotificationAdapter, INotificationSourceAdap
     public void Publish(INotificationSender sender, Notification notification, object tag)
     {
         if (string.IsNullOrEmpty(sender.Identifier))
-            throw new InvalidOperationException("The identifier of the sender must be set");
+            throw new InvalidOperationException("The identifier of the sender must be set.");
 
         if (notification == null)
             throw new ArgumentNullException(nameof(notification), "Notification must be set");
@@ -71,7 +71,7 @@ public class NotificationAdapter : INotificationAdapter, INotificationSourceAdap
                 .Any(n => n.Notification == notification);
 
             if (isPending)
-                throw new InvalidOperationException("Notification cannot be published twice!");
+                throw new InvalidOperationException("Notification cannot be published twice.");
             notification.Created = DateTime.Now;
             notification.Sender = sender.Identifier;
 
@@ -85,7 +85,7 @@ public class NotificationAdapter : INotificationAdapter, INotificationSourceAdap
     public void Acknowledge(INotificationSender sender, Notification notification)
     {
         if (string.IsNullOrEmpty(sender.Identifier))
-            throw new InvalidOperationException("The identifier of the sender must be set");
+            throw new InvalidOperationException("The identifier of the sender must be set.");
 
         if (notification == null)
             throw new ArgumentNullException(nameof(notification), "Notification must be set");
@@ -105,7 +105,7 @@ public class NotificationAdapter : INotificationAdapter, INotificationSourceAdap
 
                 if (published is null)
                     throw new InvalidOperationException("Notification was not managed by the adapter. " +
-                                                        "The sender was not registered on the adapter");
+                                                        "The sender was not registered on the adapter.");
 
                 _pendingPubs.Remove(published);
             }

--- a/src/Moryx.Orders.Management/Facade/OrderManagementFacade.cs
+++ b/src/Moryx.Orders.Management/Facade/OrderManagementFacade.cs
@@ -171,7 +171,7 @@ internal class OrderManagementFacade : IOrderManagement, IFacadeControl
             }
             catch
             {
-                throw new ArgumentException("Operation source must be serializable", nameof(source));
+                throw new ArgumentException("Operation source must be serializable.", nameof(source));
             }
         }
 
@@ -253,7 +253,7 @@ internal class OrderManagementFacade : IOrderManagement, IFacadeControl
     {
         var operationData = OperationDataPool.Get(operation);
         if (operationData == null)
-            throw new ArgumentException($"Operation with identifier {operation.Identifier} not found");
+            throw new ArgumentException($"Operation with identifier {operation.Identifier} not found.");
 
         return operationData.UpdateAsync(update, cancellationToken);
     }
@@ -262,7 +262,7 @@ internal class OrderManagementFacade : IOrderManagement, IFacadeControl
     {
         var operationData = OperationDataPool.Get(operation);
         if (operationData == null)
-            throw new ArgumentException($"Operation with identifier {operation.Identifier} not found");
+            throw new ArgumentException($"Operation with identifier {operation.Identifier} not found.");
 
         return operationData;
     }

--- a/src/Moryx.Orders.Management/Implementation/Assignment/OperationAssignment.cs
+++ b/src/Moryx.Orders.Management/Implementation/Assignment/OperationAssignment.cs
@@ -145,7 +145,7 @@ internal class OperationAssignment : IOperationAssignment
             if (result)
                 continue;
 
-            throw new InvalidOperationException($"{restoreStep.GetType().Name} was failed.");
+            throw new InvalidOperationException($"{restoreStep.GetType().Name} has failed.");
         }
     }
 }

--- a/src/Moryx.Orders.Management/Implementation/Assignment/OperationAssignment.cs
+++ b/src/Moryx.Orders.Management/Implementation/Assignment/OperationAssignment.cs
@@ -145,7 +145,7 @@ internal class OperationAssignment : IOperationAssignment
             if (result)
                 continue;
 
-            throw new InvalidOperationException(restoreStep.GetType().Name + " was failed");
+            throw new InvalidOperationException(restoreStep.GetType().Name + " was failed.");
         }
     }
 }

--- a/src/Moryx.Orders.Management/Implementation/Assignment/OperationAssignment.cs
+++ b/src/Moryx.Orders.Management/Implementation/Assignment/OperationAssignment.cs
@@ -145,7 +145,7 @@ internal class OperationAssignment : IOperationAssignment
             if (result)
                 continue;
 
-            throw new InvalidOperationException(restoreStep.GetType().Name + " was failed.");
+            throw new InvalidOperationException($"{restoreStep.GetType().Name} was failed.");
         }
     }
 }

--- a/src/Moryx.Orders.Management/Implementation/OperationData/OperationData.cs
+++ b/src/Moryx.Orders.Management/Implementation/OperationData/OperationData.cs
@@ -200,7 +200,7 @@ internal class OperationData : IOperationData, IAsyncStateContext, ILoggingCompo
         {
             if (update.OperationSource.Type != Operation.Source.Type)
             {
-                throw new InvalidOperationException("Type of the operation source cannot be changed");
+                throw new InvalidOperationException("Type of the operation source cannot be changed.");
             }
 
             Operation.Source = update.OperationSource;
@@ -538,12 +538,12 @@ internal class OperationData : IOperationData, IAsyncStateContext, ILoggingCompo
 
         if (orderAdvice is { Amount: <= 0 })
         {
-            ThrowError("Amount less then or equals zero cannot be adviced!");
+            ThrowError("Amount less then or equals zero cannot be adviced.");
         }
 
         if (pickPartAdvice != null && !Operation.Parts.Contains(pickPartAdvice.Part))
         {
-            ThrowError("The part to advice is not part of the operation!");
+            ThrowError("The part to advice is not part of the operation.");
         }
 
         if (orderAdvice == null && pickPartAdvice == null)

--- a/src/Moryx.Orders.Management/Implementation/OperationStorage.cs
+++ b/src/Moryx.Orders.Management/Implementation/OperationStorage.cs
@@ -264,7 +264,7 @@ internal static class OperationStorage
             case DateTimeKind.Unspecified:
                 return dateTime;
             default:
-                throw new ArgumentOutOfRangeException($"Provided {nameof(DateTime)} for {member} is neither UTC nor Local Time");
+                throw new ArgumentOutOfRangeException($"Provided {nameof(DateTime)} for {member} is neither UTC nor Local Time.");
         }
     }
 }

--- a/src/Moryx.Orders.Management/ModuleController/ModuleController.cs
+++ b/src/Moryx.Orders.Management/ModuleController/ModuleController.cs
@@ -103,7 +103,7 @@ public class ModuleController : ServerModuleBase<ModuleConfig>,
     protected override async Task OnStartAsync(CancellationToken cancellationToken)
     {
         if (Config.Users.UserRequired && UserManagement is NullUserManagement)
-            throw new InvalidOperationException("UserRequired configured but there is no UserManagement module available");
+            throw new InvalidOperationException("UserRequired configured but there is no UserManagement module available.");
 
         await Container.Resolve<ComponentOrchestration>().StartAsync(cancellationToken);
 

--- a/src/Moryx.ProcessData.Endpoints/Services/ConfigurationService.cs
+++ b/src/Moryx.ProcessData.Endpoints/Services/ConfigurationService.cs
@@ -52,7 +52,7 @@ internal class ConfigurationService : IConfigurationService
                 ? typeof(Notification)
                 : measurandName.Contains("Process")
                     ? typeof(Process)
-                    : throw new ArgumentException("Measurand type not available");
+                    : throw new ArgumentException("Measurand type not available.");
 
     private List<MeasurementBinding> GetBindingsForMeasurandName(string name)
         => _moduleManager.AllModules

--- a/src/Moryx.Products.Management/Facades/ProductManagementFacade.cs
+++ b/src/Moryx.Products.Management/Facades/ProductManagementFacade.cs
@@ -177,7 +177,7 @@ internal class ProductManagementFacade : FacadeBase, IProductManagement
         ValidateHealthState();
         var wp = await Workplans.LoadWorkplanAsync(workplanId, cancellationToken);
         if (wp == null)
-            throw new KeyNotFoundException($"No workplan with id '{workplanId}' found!");
+            throw new KeyNotFoundException($"No workplan with id '{workplanId}' found.");
         return wp;
     }
 
@@ -286,7 +286,7 @@ internal class ProductManagementFacade : FacadeBase, IProductManagement
     private static void ValidateRecipe(IProductRecipe recipe)
     {
         if (recipe == null)
-            throw new ArgumentException("Recipe could not be found");
+            throw new ArgumentException("Recipe could not be found.");
     }
 
     private void ReplaceOrigin<TRecipe>(TRecipe recipe)

--- a/src/Moryx.Products.Management/Implementation/Storage/ProductExpressionHelpers.cs
+++ b/src/Moryx.Products.Management/Implementation/Storage/ProductExpressionHelpers.cs
@@ -24,7 +24,7 @@ internal static class ProductExpressionHelpers
                 return prop.GetValue(container);
         }
 
-        throw new NotSupportedException("Expression type not supported yet");
+        throw new NotSupportedException("Expression type not supported yet.");
     }
 
     public static bool IsTypeQuery<TInstance>(Expression<Func<TInstance, bool>> selector, out MemberInfo typeMember, out object memberValue)

--- a/src/Moryx.Products.Management/Implementation/Storage/ProductStorage.cs
+++ b/src/Moryx.Products.Management/Implementation/Storage/ProductStorage.cs
@@ -602,7 +602,7 @@ internal class ProductStorage : IProductStorage, IConfiguredTypesProvider
         }
 
         var strategy = _typeInformation[modifiedProductType.ProductTypeName()].Strategy
-                       ?? throw new InvalidOperationException($"Cannot save product of type {modifiedProductType.GetType().FullName}. No {nameof(IProductTypeStrategy)} is configured for this type in the {nameof(ModuleConfig)}");
+                       ?? throw new InvalidOperationException($"Cannot save product of type {modifiedProductType.GetType().FullName}. No {nameof(IProductTypeStrategy)} is configured for this type in the {nameof(ModuleConfig)}.");
 
         //TODO use uow directly instead of repo if that is possible
         // Get or create entity

--- a/src/Moryx.Products.Management/Plugins/GenericStrategies/GenericEntityMapper.cs
+++ b/src/Moryx.Products.Management/Plugins/GenericStrategies/GenericEntityMapper.cs
@@ -130,7 +130,7 @@ internal class GenericEntityMapper<TBase, TReference> : IGenericMapper
                 }
                 break;
         }
-        throw new NotSupportedException("Expression type not supported yet");
+        throw new NotSupportedException("Expression type not supported yet.");
     }
 
     private Expression<Func<IGenericColumns, bool>> Convert(string memberName, ExpressionType type, object value)

--- a/src/Moryx.Products.Management/Plugins/GenericStrategies/PropertyMapper.cs
+++ b/src/Moryx.Products.Management/Plugins/GenericStrategies/PropertyMapper.cs
@@ -49,14 +49,14 @@ public abstract class ColumnMapper<TColumn> : IPropertyMapper
         // Create accessor for the column property
         Column = typeof(IGenericColumns).GetProperty(config.Column);
         if (Column == null || Column.PropertyType != typeof(TColumn))
-            throw new ArgumentException($"Column not found or type mismatch {config.PropertyName}");
+            throw new ArgumentException($"Column not found or type mismatch {config.PropertyName}.");
 
         ColumnAccessor = ReflectionTool.PropertyAccessor<IGenericColumns, TColumn>(Column);
 
         // Retrieve and validate properties
         Property = TargetType.GetProperty(config.PropertyName);
         if (Property == null)
-            throw new ArgumentException($"Target type {TargetType.Name} does not have a property {config.PropertyName}");
+            throw new ArgumentException($"Target type {TargetType.Name} does not have a property {config.PropertyName}.");
 
         // Create delegates for the object property as well
         ObjectAccessor = CreatePropertyAccessor(Property);

--- a/src/Moryx.Resources.Management/Facades/ResourceManagementFacade.cs
+++ b/src/Moryx.Resources.Management/Facades/ResourceManagementFacade.cs
@@ -143,7 +143,7 @@ internal class ResourceManagementFacade : FacadeBase, IResourceManagement
 
         var resource = ResourceGraph.Get(id);
         if (resource == null)
-            throw new KeyNotFoundException($"No resource with Id {id} found!");
+            throw new KeyNotFoundException($"No resource with Id {id} found.");
 
         var result = await modifier(resource);
         if (result)

--- a/src/Moryx.Resources.Management/Resources/ResourceLinker.cs
+++ b/src/Moryx.Resources.Management/Resources/ResourceLinker.cs
@@ -173,7 +173,7 @@ internal class ResourceLinker : IResourceLinker
         // Validate if object assigned to the property is a resource
         if (value != null && referencedResource == null)
         {
-            throw new ArgumentException($"Value of property {referenceProperty.Name} on resource {resource.Id}:{resource.GetType().Name} must be a Resource");
+            throw new ArgumentException($"Value of property {referenceProperty.Name} on resource {resource.Id}:{resource.GetType().Name} must be a Resource.");
         }
 
         var referenceAtt = referenceProperty.GetCustomAttribute<ResourceReferenceAttribute>();
@@ -181,7 +181,7 @@ internal class ResourceLinker : IResourceLinker
         // Validate if required property is set
         if (referencedResource == null && referenceAtt.IsRequired)
         {
-            throw new ValidationException($"Property {referenceProperty.Name} is flagged 'Required' and was null!");
+            throw new ValidationException($"Property {referenceProperty.Name} is flagged 'Required' and was null.");
         }
 
         // Check if there is a relation that represents this reference
@@ -252,7 +252,7 @@ internal class ResourceLinker : IResourceLinker
         // Check required attribute against empty collections
         if (referencedResources.Count == 0 && referenceAtt.IsRequired)
         {
-            throw new ValidationException($"Property {referenceProperty.Name} is flagged 'Required' and was empty!");
+            throw new ValidationException($"Property {referenceProperty.Name} is flagged 'Required' and was empty.");
         }
 
         // First delete references that are not used by ANY property of the same configuration

--- a/src/Moryx.Resources.Management/Resources/ResourceLinker.cs
+++ b/src/Moryx.Resources.Management/Resources/ResourceLinker.cs
@@ -173,7 +173,7 @@ internal class ResourceLinker : IResourceLinker
         // Validate if object assigned to the property is a resource
         if (value != null && referencedResource == null)
         {
-            throw new ArgumentException($"Value of property {referenceProperty.Name} on resource {resource.Id}:{resource.GetType().Name} must be a Resource.");
+            throw new ArgumentException($"Value of property {referenceProperty.Name} on resource {resource.Id}: {resource.GetType().Name} must be a {nameof(Resource)}.");
         }
 
         var referenceAtt = referenceProperty.GetCustomAttribute<ResourceReferenceAttribute>();

--- a/src/Moryx.Resources.Management/Resources/ResourceTypeController.cs
+++ b/src/Moryx.Resources.Management/Resources/ResourceTypeController.cs
@@ -120,7 +120,7 @@ internal class ResourceTypeController : IResourceTypeController, IResourceTypeTr
     public Resource Create(string type)
     {
         if (!_typeCache.TryGetValue(type, out var linker))
-            throw new KeyNotFoundException($"No resource of type {type} found!");
+            throw new KeyNotFoundException($"No resource of type {type} found.");
         if (!linker.Creatable)
             throw new InvalidOperationException($"The resource of type {type} is not creatable.");
 

--- a/src/Moryx.Runtime.Endpoints/Modules/ModulesController.cs
+++ b/src/Moryx.Runtime.Endpoints/Modules/ModulesController.cs
@@ -257,7 +257,7 @@ public class ModulesController : ControllerBase
         }
         catch (Exception e)
         {
-            throw new Exception($"Error while invoking function: {method.DisplayName}", e);
+            throw new Exception($"Error while invoking function: {method.DisplayName}.", e);
         }
     }
 

--- a/src/Moryx.Runtime.Kernel/Configuration/ValueProvider/MicrosoftExtensionsConfigProvider.cs
+++ b/src/Moryx.Runtime.Kernel/Configuration/ValueProvider/MicrosoftExtensionsConfigProvider.cs
@@ -111,7 +111,7 @@ internal class MicrosoftExtensionsConfigProvider : IValueProvider, IContextAware
             }
             else
             {
-                throw new NotSupportedException("Szenario where prop param is not set and the dict does not contain an int is not supported");
+                throw new NotSupportedException("Szenario where prop param is not set and the dict does not contain an int is not supported.");
             }
         }
         else

--- a/src/Moryx.TestTools.IntegrationTest/MoryxTestEnvironment.cs
+++ b/src/Moryx.TestTools.IntegrationTest/MoryxTestEnvironment.cs
@@ -44,7 +44,7 @@ public class MoryxTestEnvironment
         _moduleType = serverModuleType;
 
         if (!serverModuleType.IsAssignableTo(typeof(IServerModule)))
-            throw new ArgumentException("Provided parameter is no server module", nameof(serverModuleType));
+            throw new ArgumentException("Provided parameter is no server module.", nameof(serverModuleType));
 
         var dependencyTypes = serverModuleType.GetProperties()
             .Where(p => p.GetCustomAttribute<RequiredModuleApiAttribute>() is not null)
@@ -54,7 +54,7 @@ public class MoryxTestEnvironment
         foreach (var type in dependencyTypes)
         {
             var mock = dependencyMocks.SingleOrDefault(m => type.IsAssignableFrom(m.Object.GetType())) ??
-                       throw new ArgumentException($"Missing {nameof(Mock)} for dependency of type {type} of facade type {serverModuleType}", nameof(dependencyMocks));
+                       throw new ArgumentException($"Missing {nameof(Mock)} for dependency of type {type} of facade type {serverModuleType}.", nameof(dependencyMocks));
             services.AddSingleton(type, mock.Object);
             services.AddSingleton(typeof(IServerModule), mock.Object);
         }

--- a/src/Moryx.VisualInstructions/EnumInstructionResult.cs
+++ b/src/Moryx.VisualInstructions/EnumInstructionResult.cs
@@ -42,7 +42,7 @@ public static class EnumInstructionResult
         if (response.SelectedResult != null)
             return ResultToEnumValue(resultEnum, response.SelectedResult);
 
-        throw new ArgumentException("No result found on response", nameof(response));
+        throw new ArgumentException("No result found on response.", nameof(response));
     }
 
     /// <summary>
@@ -97,7 +97,7 @@ public static class EnumInstructionResult
             return allValues;
         }
 
-        // Case 3: All values are explicitly hidden => display nothing 
+        // Case 3: All values are explicitly hidden => display nothing
         if (allValues.Count == hiddenValues.Count)
         {
             return displayValues;

--- a/src/Moryx.Workplans.Editing/Implementation/WorkplanEditingSession.cs
+++ b/src/Moryx.Workplans.Editing/Implementation/WorkplanEditingSession.cs
@@ -139,7 +139,7 @@ internal class WorkplanEditingSession : IWorkplanEditingSession
         if (sourceNode is IConnector start)
         {
             if (targetNode is IConnector)
-                throw new InvalidOperationException("Cannot connect start to End or Failed");
+                throw new InvalidOperationException("Cannot connect start to End or Failed.");
 
             if (start == ((IWorkplanStep)targetNode).Inputs[targetIndex])
                 return;

--- a/src/Moryx/Communication/Sockets/Server/TcpListenerConnection.cs
+++ b/src/Moryx/Communication/Sockets/Server/TcpListenerConnection.cs
@@ -96,7 +96,7 @@ public class TcpListenerConnection : IBinaryConnection, IStateContext
         if (IPAddress.TryParse(_config.IpAddress, out var address))
             Address = address;
         else
-            throw new FormatException($"Failed to parse IPAddress: {_config.IpAddress}");
+            throw new FormatException($"Failed to parse IPAddress: {_config.IpAddress}.");
 
         StateMachine.ForContext(this).With<ServerStateBase>();
     }

--- a/src/Moryx/Communication/Sockets/Server/TcpServer.cs
+++ b/src/Moryx/Communication/Sockets/Server/TcpServer.cs
@@ -35,7 +35,7 @@ internal class TcpServer
         var interpreter = listener.Validator.Interpreter;
         if (!PortMap.Register(address, port, interpreter))
         {
-            throw new InvalidOperationException($"Attempted to register protocol header {interpreter} on port {port}, but port was already taken");
+            throw new InvalidOperationException($"Attempted to register protocol header {interpreter} on port {port}, but port was already taken.");
         }
 
         // Get port listeners

--- a/src/Moryx/Container/ContainerLoadComponentsExtension.cs
+++ b/src/Moryx/Container/ContainerLoadComponentsExtension.cs
@@ -126,7 +126,7 @@ public static class ContainerLoadComponentsExtension
             return;
 
         if (!typeof(ISubInitializer).IsAssignableFrom(att.Initializer))
-            throw new InvalidCastException($"SubInitializer {att.Initializer.Name} of component {implementation.Name} does not implement interface ISubInitializer");
+            throw new InvalidCastException($"SubInitializer {att.Initializer.Name} of component {implementation.Name} does not implement interface ISubInitializer.");
 
         container.Register(att.Initializer, [typeof(ISubInitializer), att.Initializer], null, LifeCycle.Singleton);
     }

--- a/src/Moryx/Container/ContainerLoadComponentsExtension.cs
+++ b/src/Moryx/Container/ContainerLoadComponentsExtension.cs
@@ -126,7 +126,7 @@ public static class ContainerLoadComponentsExtension
             return;
 
         if (!typeof(ISubInitializer).IsAssignableFrom(att.Initializer))
-            throw new InvalidCastException($"SubInitializer {att.Initializer.Name} of component {implementation.Name} does not implement interface ISubInitializer.");
+            throw new InvalidCastException($"SubInitializer {att.Initializer.Name} of component {implementation.Name} does not implement interface {nameof(ISubInitializer)}.");
 
         container.Register(att.Initializer, [typeof(ISubInitializer), att.Initializer], null, LifeCycle.Singleton);
     }

--- a/src/Moryx/Serialization/DefaultSerialization.cs
+++ b/src/Moryx/Serialization/DefaultSerialization.cs
@@ -253,7 +253,7 @@ public class DefaultSerialization : ICustomSerialization
                 catch (Exception e)
                 {
                     if (e is FormatException or OverflowException)
-                        throw new ArgumentException($"Invalid value {mappedEntry.Value.Current} for entry {mappedEntry.DisplayName ?? mappedEntry.Identifier}", e);
+                        throw new ArgumentException($"Invalid value {mappedEntry.Value.Current} for entry {mappedEntry.DisplayName ?? mappedEntry.Identifier}.", e);
                     throw;
                 }
         }

--- a/src/Moryx/Serialization/EntryConvert/EntryConvert.cs
+++ b/src/Moryx/Serialization/EntryConvert/EntryConvert.cs
@@ -647,7 +647,7 @@ public static partial class EntryConvert
             }
             else
             {
-                throw new SerializationException($"Unsupported property {property.Name} on {instance.GetType().Name}!");
+                throw new SerializationException($"Unsupported property {property.Name} on {instance.GetType().Name}.");
             }
 
             // Write new value to property
@@ -766,7 +766,7 @@ public static partial class EntryConvert
         }
         else
         {
-            throw new InvalidOperationException($"Unsupported collection type {collectionType}");
+            throw new InvalidOperationException($"Unsupported collection type {collectionType}.");
         }
 
         return strategy;
@@ -800,7 +800,7 @@ public static partial class EntryConvert
             .FirstOrDefault(m => m.Name == methodEntry.Name && (m.IsPublic || m.IsAssembly) && ParametersProvided(m.GetParameters(), methodEntry));
         if (method == null)
         {
-            throw new MissingMethodException($"Method {methodEntry.Name} not found on target {target.GetType().Name}!");
+            throw new MissingMethodException($"Method {methodEntry.Name} not found on target {target.GetType().Name}.");
         }
 
         var arguments = ConvertArguments(method, methodEntry, customSerialization);

--- a/src/Moryx/StateMachines/AsyncStateBase.cs
+++ b/src/Moryx/StateMachines/AsyncStateBase.cs
@@ -92,11 +92,11 @@ public abstract class AsyncStateBase : StateBase
     internal static async Task CreateAsync(Type stateBaseType, IAsyncStateContext context, int? initialKey, CancellationToken cancellationToken)
     {
         if (!typeof(AsyncStateBase).IsAssignableFrom(stateBaseType))
-            throw new InvalidOperationException($"Only states inherited from {nameof(AsyncStateBase)} are supported!");
+            throw new InvalidOperationException($"Only states inherited from {nameof(AsyncStateBase)} are supported.");
 
         var initialState = CreateMapAndGetInitial(stateBaseType, context, initialKey) as AsyncStateBase;
         if (initialState == null)
-            throw new ArgumentException($"Initial state does not inherit from {nameof(AsyncStateBase)}");
+            throw new ArgumentException($"Initial state does not inherit from {nameof(AsyncStateBase)}.");
 
         await context.SetStateAsync(initialState, cancellationToken);
         await initialState.OnEnterAsync(cancellationToken);

--- a/src/Moryx/StateMachines/StateBase.cs
+++ b/src/Moryx/StateMachines/StateBase.cs
@@ -87,18 +87,18 @@ public abstract class StateBase
         // Check the base type
         if (!stateBaseType.IsAbstract)
         {
-            throw new ArgumentException("The state base class must be abstract!");
+            throw new ArgumentException("The state base class must be abstract.");
         }
 
         if (!typeof(StateBase).IsAssignableFrom(stateBaseType))
         {
-            throw new ArgumentException($"'{stateBaseType.Name}' class is not a valid 'StateBase'!");
+            throw new ArgumentException($"'{stateBaseType.Name}' class is not a valid 'StateBase'.");
         }
 
         // Load all fields
         // 1. Get all fields which are static constant with the attribute
         // 2. let attribute and create an anonymous array
-        StateDefinition[] definedStates =
+        var definedStates =
             (from stateField in GetStateFields(stateBaseType)
              let att = stateField.GetCustomAttribute<StateDefinitionAttribute>()
              select new StateDefinition((int)stateField.GetValue(null), att.IsInitial, att.Type)).ToArray();
@@ -110,7 +110,7 @@ public abstract class StateBase
         foreach (var definedState in definedStates)
         {
             var instance = Activator.CreateInstance(definedState.Type, context, stateMap) as StateBase
-                ?? throw new InvalidOperationException($"Could not create instance of State type {definedState.Type.Name}");
+                ?? throw new InvalidOperationException($"Could not create instance of State type {definedState.Type.Name}.");
 
             instance.Key = definedState.Key;
 
@@ -139,7 +139,7 @@ public abstract class StateBase
             // If an initial key is set, we check if it exists
             if (definedStates.All(s => s.Key != initialKey.Value))
             {
-                throw new InvalidOperationException($"There was no state defined with key: {initialKey}");
+                throw new InvalidOperationException($"There was no state defined with key: {initialKey}.");
             }
         }
         else
@@ -148,12 +148,15 @@ public abstract class StateBase
             var initialStates = definedStates.Where(s => s.IsInitial).ToArray();
             if (initialStates.Length == 0)
             {
-                throw new InvalidOperationException($"No state is marked as initial. Set one using the {nameof(StateDefinitionAttribute)} or pass an initial key explicitly");
+                throw new InvalidOperationException($"No state is marked as initial. " +
+                                                    $"Set one using the {nameof(StateDefinitionAttribute)} or pass an initial key explicitly.");
             }
-            else if (initialStates.Length > 1)
+
+            if (initialStates.Length > 1)
             {
                 var initialStateString = string.Join(", ", initialStates.Select(i => i.Type.Name));
-                throw new InvalidOperationException($"Multiple states are marked as initial: '{initialStateString}'. Define exactly one or set an initial state explicitly");
+                throw new InvalidOperationException($"Multiple states are marked as initial: '{initialStateString}'. " +
+                                                    $"Define exactly one or set an initial state explicitly.");
             }
         }
 
@@ -162,14 +165,15 @@ public abstract class StateBase
         if (duplicateStates.Count != 0)
         {
             var typeNames = string.Join(", ", duplicateStates.Select(type => type.Name));
-            throw new InvalidOperationException($"State types are only allowed once: {typeNames}");
+            throw new InvalidOperationException($"State types are only allowed once: {typeNames}.");
         }
+
         // Group by key to find statemachine keys that are used multiple times
         var duplicateKeys = FindDuplicates(definedStates, s => s.Key);
         if (duplicateKeys.Count != 0)
         {
             var stateKeys = string.Join(", ", duplicateKeys);
-            throw new InvalidOperationException($"State keys are only allowed once: {stateKeys}");
+            throw new InvalidOperationException($"State keys are only allowed once: {stateKeys}.");
         }
     }
 
@@ -225,7 +229,7 @@ public abstract class StateBase
     public sealed class StateMap : Dictionary<int, StateBase>;
 
     /// <summary>
-    /// Temporary container for state metadata 
+    /// Temporary container for state metadata
     /// </summary>
     private record StateDefinition(int Key, bool IsInitial, Type Type);
 }

--- a/src/Moryx/StateMachines/StateBase.cs
+++ b/src/Moryx/StateMachines/StateBase.cs
@@ -92,7 +92,7 @@ public abstract class StateBase
 
         if (!typeof(StateBase).IsAssignableFrom(stateBaseType))
         {
-            throw new ArgumentException($"'{stateBaseType.Name}' class is not a valid 'StateBase'.");
+            throw new ArgumentException($"'{stateBaseType.Name}' class is not a valid '{nameof(StateBase)}'.");
         }
 
         // Load all fields

--- a/src/Moryx/StateMachines/SyncStateBase.cs
+++ b/src/Moryx/StateMachines/SyncStateBase.cs
@@ -45,11 +45,11 @@ public abstract class SyncStateBase : StateBase
     internal static void Create(Type stateBaseType, IStateContext context, int? initialKey)
     {
         if (!typeof(SyncStateBase).IsAssignableFrom(stateBaseType))
-            throw new InvalidOperationException($"Only states inherited from {nameof(SyncStateBase)} are supported!");
+            throw new InvalidOperationException($"Only states inherited from {nameof(SyncStateBase)} are supported.");
 
         var initialState = CreateMapAndGetInitial(stateBaseType, context, initialKey) as SyncStateBase;
         if (initialState == null)
-            throw new ArgumentException($"Initial state does not inherit from {nameof(SyncStateBase)}");
+            throw new ArgumentException($"Initial state does not inherit from {nameof(SyncStateBase)}.");
 
         context.SetState(initialState);
         initialState.OnEnter();

--- a/src/Moryx/Threading/ParallelOperations.cs
+++ b/src/Moryx/Threading/ParallelOperations.cs
@@ -144,7 +144,7 @@ public class ParallelOperations : IParallelOperations
     {
         // thread safe increment of timer id
         int id = Interlocked.Increment(ref _lastTimerId);
-            
+
         var timer = new Timer(new NonStackingTimerCallback(state =>
         {
             try
@@ -240,7 +240,7 @@ public class ParallelOperations : IParallelOperations
         lock (_eventDecouplers)
         {
             if (!_eventDecouplers.ContainsKey(target))
-                throw new InvalidOperationException("Can not remove a previously unregistered listener!");
+                throw new InvalidOperationException("Can not remove a previously unregistered listener.");
 
             decoupler = (EventDecoupler<TEventArgs>)_eventDecouplers[target];
             _eventDecouplers.Remove(target);

--- a/src/Moryx/Workplans/Implementation/Engine/PausedState.cs
+++ b/src/Moryx/Workplans/Implementation/Engine/PausedState.cs
@@ -20,7 +20,7 @@ internal class PausedState : EngineState
     internal override void Restore(WorkplanSnapshot snapshot)
     {
         if (snapshot != Context.CurrentSnapshot)
-            throw new InvalidOperationException("Can not restore paused engine with different snapshot. Create a new instance instead!");
+            throw new InvalidOperationException("Can not restore paused engine with different snapshot. Create a new instance instead.");
     }
 
     internal override void Start()

--- a/src/Moryx/Workplans/Implementation/WorkplanExtensions.cs
+++ b/src/Moryx/Workplans/Implementation/WorkplanExtensions.cs
@@ -19,7 +19,7 @@ public static class WorkplanExtensions
         {
             var startConnector = workplan.Connectors.FirstOrDefault(c => c.Classification == NodeClassification.Start);
             if (startConnector == null)
-                throw new ArgumentException("The workplan does not have any start connector");
+                throw new ArgumentException("The workplan does not have any start connector.");
 
             return ExtractPath(workplan, startConnector, startConnector);
         }
@@ -33,7 +33,7 @@ public static class WorkplanExtensions
         {
             var endConnector = workplan.Connectors.FirstOrDefault(c => c.Classification == NodeClassification.End);
             if (endConnector == null)
-                throw new ArgumentException("The workplan does not have any end connector");
+                throw new ArgumentException("The workplan does not have any end connector.");
 
             return ExtractPath(workplan, startConnector, endConnector);
         }
@@ -47,10 +47,10 @@ public static class WorkplanExtensions
         public IReadOnlyList<IWorkplanStep> ExtractPath(IConnector startConnector, IConnector endConnector)
         {
             if (!workplan.Connectors.Contains(startConnector))
-                throw new ArgumentException("The start connector is not part of the workplan");
+                throw new ArgumentException("The start connector is not part of the workplan.");
 
             if (!workplan.Connectors.Contains(endConnector))
-                throw new ArgumentException("The end connector is not part of the workplan");
+                throw new ArgumentException("The end connector is not part of the workplan.");
 
             var path = new List<IWorkplanStep>();
 

--- a/src/Moryx/Workplans/WorkplanSteps/SplitWorkplanStep.cs
+++ b/src/Moryx/Workplans/WorkplanSteps/SplitWorkplanStep.cs
@@ -27,7 +27,7 @@ public class SplitWorkplanStep : WorkplanStepBase
     public SplitWorkplanStep([Display(Name = "Outputs", Description = "Number of parallel paths")] int outputs = 2)
     {
         if (outputs <= 1)
-            throw new ArgumentException("Split must have at least two outputs!");
+            throw new ArgumentException("Split must have at least two outputs.");
 
         Outputs = new IConnector[outputs];
         OutputDescriptions = new OutputDescription[outputs];

--- a/src/Tests/Moryx.Products.Management.Tests/ProductConverterTests.cs
+++ b/src/Tests/Moryx.Products.Management.Tests/ProductConverterTests.cs
@@ -139,7 +139,7 @@ public class ProductConverterTests
     private static bool HasChangedProperties<T>(object A, object B)
     {
         if (A is null || B is null)
-            throw new ArgumentNullException("You need to provide 2 non-null objects");
+            throw new ArgumentNullException("You need to provide 2 non-null objects.");
 
         var type = typeof(T);
         var allProperties = type.GetProperties(BindingFlags.Public | BindingFlags.Instance);

--- a/src/Tests/Moryx.Resources.Management.Tests/Mocks/SimpleResource.cs
+++ b/src/Tests/Moryx.Resources.Management.Tests/Mocks/SimpleResource.cs
@@ -74,7 +74,7 @@ public class SimpleResource : Resource, ISimpleResource, IDuplicateFoo, INonReso
     {
         Capabilities = capabilities;
     }
-    public void ThrowingMethod() => throw new InvalidOperationException("Resource is broken");
+    public void ThrowingMethod() => throw new InvalidOperationException("Resource is broken.");
 
     public void Validate()
     {

--- a/src/Tests/Moryx.Runtime.Tests/Modules/DelayedExceptionModule.cs
+++ b/src/Tests/Moryx.Runtime.Tests/Modules/DelayedExceptionModule.cs
@@ -40,7 +40,7 @@ internal class DelayedExceptionModule : ServerModuleBase<TestConfig>
         Container.Resolve<IParallelOperations>().ExecuteParallel(delegate
         {
             WaitEvent.WaitOne();
-            throw new Exception("Test");
+            throw new Exception("Test.");
         });
         return Task.CompletedTask;
     }

--- a/src/Tests/Moryx.Runtime.Tests/Modules/TestModule.cs
+++ b/src/Tests/Moryx.Runtime.Tests/Modules/TestModule.cs
@@ -43,7 +43,7 @@ internal class TestModule : ServerModuleBase<TestConfig>
             case TestMode.MoryxException:
                 throw new TestException();
             case TestMode.SystemException:
-                throw new Exception("I am done here!");
+                throw new Exception("I am done here.");
         }
 
         return Task.CompletedTask;
@@ -58,7 +58,7 @@ internal class TestModule : ServerModuleBase<TestConfig>
             case TestMode.MoryxException:
                 throw new TestException();
             case TestMode.SystemException:
-                throw new Exception("I am done here!");
+                throw new Exception("I am done here.");
         }
         return Task.CompletedTask;
     }
@@ -71,7 +71,7 @@ internal class TestModule : ServerModuleBase<TestConfig>
             case TestMode.MoryxException:
                 throw new TestException();
             case TestMode.SystemException:
-                throw new Exception("I am done here!");
+                throw new Exception("I am done here.");
         }
         return Task.CompletedTask;
     }

--- a/src/Tests/Moryx.Tests/Serialization/ExceptionDummy.cs
+++ b/src/Tests/Moryx.Tests/Serialization/ExceptionDummy.cs
@@ -9,6 +9,6 @@ public class ExceptionDummy
 {
     public int ThrowsException
     {
-        get { throw new Exception("BAM!"); }
+        get { throw new Exception("BAM."); }
     }
 }

--- a/src/Tests/Moryx.Tests/Threading/EventDecouplerTests.cs
+++ b/src/Tests/Moryx.Tests/Threading/EventDecouplerTests.cs
@@ -126,7 +126,7 @@ public class EventDecouplerTests
 
         public void FaultyListener(object sender, EventArgs e)
         {
-            throw new Exception("Test");
+            throw new Exception("Test.");
         }
     }
 
@@ -161,7 +161,7 @@ public class EventDecouplerTests
 
     public void FaultyListener(object sender, EventArgs e)
     {
-        throw new Exception("Test");
+        throw new Exception("Test.");
     }
 
     #endregion


### PR DESCRIPTION
Regarding the MS-guideline, all exceptions shoud use proper grammar and end with period. Also exclamation marks replaced by period to sound gracefully.

https://learn.microsoft.com/en-us/dotnet/standard/exceptions/best-practices-for-exceptions#use-proper-grammar