### PR TITLE
Add codecov.yml with informational status checks

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,8 @@
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true


### PR DESCRIPTION
Codecov was introduced today and is blocking pull-requests. This makes it informational for now, can be changed later when our overall test-coverage is improved.