### PR TITLE
Fixed storage of ServerModules behaviors

### DIFF
--- a/src/Moryx.Runtime.Kernel/Modules/BehaviourAccess.cs
+++ b/src/Moryx.Runtime.Kernel/Modules/BehaviourAccess.cs
@@ -1,6 +1,7 @@
 // Copyright (c) 2026 Phoenix Contact GmbH & Co. KG
 // Licensed under the Apache License, Version 2.0
 
+using Moryx.Configuration;
 using Moryx.Modules;
 using Moryx.Runtime.Modules;
 
@@ -8,13 +9,13 @@ namespace Moryx.Runtime.Kernel;
 
 internal static class ABehaviourAccess
 {
-    public static ABehaviourAccess<T> Create<T>(ModuleManagerConfig config, IModule module)
+    public static ABehaviourAccess<T> Create<T>(ModuleManagerConfig config, IConfigManager configManager, IModule module)
     {
         if (typeof(T) == typeof(ModuleStartBehaviour))
-            return new StartBehaviorAccess(config, module) as ABehaviourAccess<T>;
+            return new StartBehaviorAccess(config, configManager, module) as ABehaviourAccess<T>;
 
         if (typeof(T) == typeof(FailureBehaviour))
-            return new FailureBehaviourAccess(config, module) as ABehaviourAccess<T>;
+            return new FailureBehaviourAccess(config, configManager, module) as ABehaviourAccess<T>;
 
         return null;
     }
@@ -22,9 +23,16 @@ internal static class ABehaviourAccess
 
 internal abstract class ABehaviourAccess<T> : IBehaviourAccess<T>
 {
-    protected ManagedModuleConfig Module { get; private set; }
-    protected ABehaviourAccess(ModuleManagerConfig config, IModule module)
+    private readonly ModuleManagerConfig _config;
+    private readonly IConfigManager _configManager;
+
+    protected ManagedModuleConfig Module { get; }
+
+    protected ABehaviourAccess(ModuleManagerConfig config, IConfigManager configManager, IModule module)
     {
+        _config = config;
+        _configManager = configManager;
+
         Module = config.GetOrCreate(module.Name);
     }
 
@@ -34,7 +42,11 @@ internal abstract class ABehaviourAccess<T> : IBehaviourAccess<T>
     public T Behaviour
     {
         get { return GetBehavior(); }
-        set { SetBehavior(value); }
+        set
+        {
+            SetBehavior(value);
+            _configManager.SaveConfiguration(_config);
+        }
     }
 
     protected abstract T GetBehavior();
@@ -44,7 +56,7 @@ internal abstract class ABehaviourAccess<T> : IBehaviourAccess<T>
 
 internal class StartBehaviorAccess : ABehaviourAccess<ModuleStartBehaviour>
 {
-    public StartBehaviorAccess(ModuleManagerConfig config, IModule module) : base(config, module)
+    public StartBehaviorAccess(ModuleManagerConfig config, IConfigManager configManager, IModule module) : base(config, configManager, module)
     {
     }
 
@@ -61,7 +73,7 @@ internal class StartBehaviorAccess : ABehaviourAccess<ModuleStartBehaviour>
 
 internal class FailureBehaviourAccess : ABehaviourAccess<FailureBehaviour>
 {
-    public FailureBehaviourAccess(ModuleManagerConfig config, IModule module) : base(config, module)
+    public FailureBehaviourAccess(ModuleManagerConfig config, IConfigManager configManager, IModule module) : base(config, configManager, module)
     {
     }
 

--- a/src/Moryx.Runtime.Kernel/Modules/ModuleManager.cs
+++ b/src/Moryx.Runtime.Kernel/Modules/ModuleManager.cs
@@ -19,6 +19,7 @@ public class ModuleManager : IModuleManager
     private readonly IModuleStarter _moduleStarter;
     private readonly IModuleStopper _moduleStopper;
     private readonly ModuleManagerConfig _config;
+    private readonly IConfigManager _configManager;
 
     #endregion
 
@@ -32,6 +33,7 @@ public class ModuleManager : IModuleManager
         var allModules = modules.ToList();
 
         // Create components
+        _configManager = configManager;
         _config = configManager.GetConfiguration<ModuleManagerConfig>();
 
         // Create dependency manager and build tree of available modules
@@ -133,7 +135,7 @@ public class ModuleManager : IModuleManager
     /// <typeparam name="T">Type of behaviour</typeparam>
     public IBehaviourAccess<T> BehaviourAccess<T>(IServerModule plugin)
     {
-        return ABehaviourAccess.Create<T>(_config, plugin);
+        return ABehaviourAccess.Create<T>(_config, _configManager, plugin);
     }
 
     #endregion

--- a/src/Tests/Moryx.Runtime.Kernel.Tests/ModuleManagerTests.cs
+++ b/src/Tests/Moryx.Runtime.Kernel.Tests/ModuleManagerTests.cs
@@ -22,14 +22,17 @@ public class ModuleManagerTests
 {
     private Mock<IConfigManager> _mockConfigManager;
     private Mock<IModuleLogger> _mockLogger;
+    private ModuleManagerConfig _moduleManagerConfig;
 
     [SetUp]
     public void Setup()
     {
         _mockConfigManager = new Mock<IConfigManager>();
-        var moduleManagerConfig = new ModuleManagerConfig { ManagedModules = [] };
-        _mockConfigManager.Setup(mock => mock.GetConfiguration(typeof(ModuleManagerConfig), typeof(ModuleManagerConfig).FullName, false)).Returns(moduleManagerConfig);
-        _mockConfigManager.Setup(mock => mock.GetConfiguration(typeof(RuntimeConfigManagerTestConfig2), typeof(RuntimeConfigManagerTestConfig2).FullName, false)).Returns(new RuntimeConfigManagerTestConfig2());
+        _moduleManagerConfig = new ModuleManagerConfig { ManagedModules = [] };
+        _mockConfigManager.Setup(mock => mock.GetConfiguration(typeof(ModuleManagerConfig), typeof(ModuleManagerConfig).FullName, false))
+            .Returns(_moduleManagerConfig);
+        _mockConfigManager.Setup(mock => mock.GetConfiguration(typeof(RuntimeConfigManagerTestConfig2), typeof(RuntimeConfigManagerTestConfig2).FullName, false))
+            .Returns(new RuntimeConfigManagerTestConfig2());
 
         _mockLogger = new Mock<IModuleLogger>();
         _mockLogger.Setup(ml => ml.GetChild(It.IsAny<string>(), It.IsAny<Type>())).Returns(_mockLogger.Object);
@@ -305,6 +308,27 @@ public class ModuleManagerTests
 
         // Assert
         Assert.That(module.ActivatedCount, Is.EqualTo(1));
+    }
+
+    [Test, Description("Setting a module behaviour should update the config and persist it")]
+    public void BehaviourChangeSavesConfig()
+    {
+        // Arrange
+        const string moduleName = "TestModule";
+        const ModuleStartBehaviour targetBehaviour = ModuleStartBehaviour.Manual;
+
+        var mockModule = new Mock<IServerModule>();
+        mockModule.Setup(m => m.Name).Returns(moduleName);
+        var moduleManager = CreateObjectUnderTest([mockModule.Object]);
+
+        // Act
+        var startBehaviour = moduleManager.BehaviourAccess<ModuleStartBehaviour>(mockModule.Object);
+        startBehaviour.Behaviour = targetBehaviour;
+
+        // Assert
+        var managedModuleConfig = _moduleManagerConfig.ManagedModules.Single(m => m.ModuleName == moduleName);
+        Assert.That(managedModuleConfig.StartBehaviour, Is.EqualTo(targetBehaviour));
+        _mockConfigManager.Verify(cm => cm.SaveConfiguration(_moduleManagerConfig, It.IsAny<string>(), It.IsAny<bool>()), Times.Once);
     }
 
     private static void WaitForTimeboxed(Func<bool> condition, int maxSeconds = 10)


### PR DESCRIPTION
Saves the config now in BehaviorAccess (before in the HeartOfGold it was a step to save all loaded configs. This was removed in MORYX around 6).

I added https://github.com/PHOENIXCONTACT/MORYX-Framework/issues/1476 to reconsider the whole ServerModule behaviors. In a follow-up PR I will remove the FailureBehavior field on the CommandCenter.

closes #1471