### PR TITLE
Fixed proxy generation for resources without interfaces

### DIFF
--- a/src/Moryx.Resources.Management/Resources/Proxies/ResourceProxyBuilder.cs
+++ b/src/Moryx.Resources.Management/Resources/Proxies/ResourceProxyBuilder.cs
@@ -26,9 +26,13 @@ internal class ResourceProxyBuilder
         options.AddMixinInstance(mixin);
         options.BaseTypeForInterfaceProxy = typeof(ResourceProxyBase);
 
-        // Separate primary and additional interfaces
-        var primaryInterface = interfaces[0];
-        var additionalInterfaces = interfaces.Skip(1).ToArray();
+        // Use the most specific IResource-derived interface as primary, fall back to IResource itself.
+        // Most specific means no other candidate in the list derives from it.
+        // This ensures the generated proxy type name reflects the most specific interface (e.g. "IAssemblyCellProxy" instead of "IResourceProxy_3").
+        var resourceInterfaces = interfaces.Where(i => typeof(IResource).IsAssignableFrom(i) && i != typeof(IResource)).ToList();
+        var primaryInterface = resourceInterfaces.FirstOrDefault(candidate => !resourceInterfaces.Any(other => other != candidate && candidate.IsAssignableFrom(other)))
+                               ?? typeof(IResource);
+        var additionalInterfaces = interfaces.Where(i => i != primaryInterface).ToArray();
 
         // Create interceptor with deferred proxy reference
         var interceptor = new ResourceInterceptor(mixin, typeController);

--- a/src/Moryx.Resources.Management/Resources/ResourceTypeController.cs
+++ b/src/Moryx.Resources.Management/Resources/ResourceTypeController.cs
@@ -225,11 +225,10 @@ internal class ResourceTypeController : IResourceTypeController, IResourceTypeTr
         var additionalPublicInterfaces = node.ResourceType.GetCustomAttributes<ResourceAvailableAsAttribute>()
             .SelectMany(a => a.AvailableAs).Distinct();
 
-        // Add all resources derived from IResource, but not IResource itself
+        // Add all interfaces derived from IResource, including IResource itself
         relevantInterfaces.AddRange(from resourceInterface in interfaces
             where resourceInterface.IsPublic
-                  && ((typeof(IResource).IsAssignableFrom(resourceInterface)
-                       && !resourceInterface.IsAssignableFrom(typeof(IResource)))
+                  && (typeof(IResource).IsAssignableFrom(resourceInterface)
                       || additionalPublicInterfaces.Contains(resourceInterface))
             select resourceInterface);
 

--- a/src/Tests/Moryx.Resources.Management.Tests/Mocks/PlainResource.cs
+++ b/src/Tests/Moryx.Resources.Management.Tests/Mocks/PlainResource.cs
@@ -1,0 +1,13 @@
+// Copyright (c) 2026 Phoenix Contact GmbH & Co. KG
+// Licensed under the Apache License, Version 2.0
+
+using Moryx.AbstractionLayer.Resources;
+
+namespace Moryx.Resources.Management.Tests;
+
+/// <summary>
+/// Resource that only implements IResource (via Resource base class) without any more-derived resource interface.
+/// </summary>
+public class PlainResource : Resource
+{
+}

--- a/src/Tests/Moryx.Resources.Management.Tests/TypeControllerTests.cs
+++ b/src/Tests/Moryx.Resources.Management.Tests/TypeControllerTests.cs
@@ -32,7 +32,8 @@ public class TypeControllerTests
                 typeof(ResourceWithImplicitApi),
                 typeof(ExplicitEventResource),
                 typeof(SharedEventNameResource),
-                typeof(CustomDelegateResource)
+                typeof(CustomDelegateResource),
+                typeof(PlainResource)
             ]);
 
         _typeController = new ResourceTypeController
@@ -425,6 +426,22 @@ public class TypeControllerTests
         // Act & Assert
         var ex = Assert.Throws<NotSupportedException>(() => _typeController.GetProxy(instance));
         Assert.That(ex!.Message, Does.Contain(nameof(ICustomDelegateResource.StatusReport)));
+    }
+
+    [Test(Description = "Resource without any IResource-derived interface can be proxified as IResource")]
+    public void ProxifyResourceWithOnlyIResource()
+    {
+        // Arrange
+        var instance = new PlainResource { Id = 50, Name = "Plain" };
+
+        // Act
+        var proxy = _typeController.GetProxy(instance);
+
+        // Assert
+        Assert.That(proxy, Is.Not.Null);
+        Assert.That(proxy, Is.InstanceOf<IResource>());
+        Assert.That(proxy.Id, Is.EqualTo(50));
+        Assert.That(proxy.Name, Is.EqualTo("Plain"));
     }
 
     [Test(Description = "Proxy returns null for Name and Capabilities without throwing ProxyDetachedException")]


### PR DESCRIPTION
Resources like MqttTopicJson that only implement IResource (no more-derived resource interface) failed to build a proxy because RelevantInterfaces excluded IResource itself, resulting in an empty interface list. Fixed by including IResource in relevant interfaces and selecting the most specific IResource-derived interface as the primary proxy interface in ResourceProxyBuilder, falling back to IResource when no more-derived interface exists.