### PR TITLE
Per-connection SSE channel 

### DIFF
--- a/src/Moryx.ControlSystem.Jobs.Endpoints/JobManagementController.cs
+++ b/src/Moryx.ControlSystem.Jobs.Endpoints/JobManagementController.cs
@@ -1,8 +1,6 @@
 // Copyright (c) 2026 Phoenix Contact GmbH & Co. KG
 // Licensed under the Apache License, Version 2.0
 
-using System.Collections.Concurrent;
-using System.Runtime.CompilerServices;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Microsoft.AspNetCore.Authorization;
@@ -24,7 +22,6 @@ public class JobManagementController : ControllerBase
 {
     private readonly IJobManagement _jobManagement;
 
-    private static readonly ConcurrentDictionary<Guid, Channel<string>> _jobStreamSubscribers = new();
     private static readonly JsonSerializerOptions _serializerOptions = new()
     {
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
@@ -85,12 +82,14 @@ public class JobManagementController : ControllerBase
     [ProducesResponseType(StatusCodes.Status200OK)]
     public async Task ProgressStream(CancellationToken cancellationToken)
     {
-        // Define event handlers using the broadcast helper
-        var progressEventHandler = new EventHandler<Job>((_, job) =>
-            Broadcast(job));
+        var channel = Channel.CreateUnbounded<string>();
 
-        var stateEventHandler = new EventHandler<JobStateChangedEventArgs>((_, e) =>
-            Broadcast(e.Job));
+        // Define event handlers using the broadcast helper
+        EventHandler<Job> progressEventHandler = (_, job) =>
+            Broadcast(job);
+
+        EventHandler<JobStateChangedEventArgs> stateEventHandler = (_, e) =>
+            Broadcast(e.Job);
 
         try
         {
@@ -114,32 +113,15 @@ public class JobManagementController : ControllerBase
 
         return;
 
-        async IAsyncEnumerable<string> Subscribe([EnumeratorCancellation] CancellationToken cancelToken)
+        IAsyncEnumerable<string> Subscribe(CancellationToken cancelToken)
         {
-            var channel = Channel.CreateUnbounded<string>();
-            var id = Guid.NewGuid();
-            _jobStreamSubscribers[id] = channel;
-
-            try
-            {
-                await foreach (var data in channel.Reader.ReadAllAsync(cancelToken))
-                {
-                    yield return data;
-                }
-            }
-            finally
-            {
-                _jobStreamSubscribers.TryRemove(id, out _);
-            }
+            return channel.Reader.ReadAllAsync(cancelToken);
         }
 
-        // Local helper to broadcast job updates to all connected clients
-        static void Broadcast(Job job)
+        // Local helper to push job updates to the client
+        void Broadcast(Job job)
         {
-            foreach (var channel in _jobStreamSubscribers.Values)
-            {
-                channel.Writer.TryWrite(JsonSerializer.Serialize(Converter.ToModel(job), _serializerOptions));
-            }
+            channel.Writer.TryWrite(JsonSerializer.Serialize(Converter.ToModel(job), _serializerOptions));
         }
     }
 }

--- a/src/Moryx.ControlSystem.Processes.Endpoints/ProcessEngineController.cs
+++ b/src/Moryx.ControlSystem.Processes.Endpoints/ProcessEngineController.cs
@@ -1,8 +1,6 @@
 // Copyright (c) 2026 Phoenix Contact GmbH & Co. KG
 // Licensed under the Apache License, Version 2.0
 
-using System.Collections.Concurrent;
-using System.Runtime.CompilerServices;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Threading.Channels;
@@ -33,8 +31,6 @@ public class ProcessEngineController : ControllerBase // TODO: Rename to Process
     private readonly IResourceManagement _resourceManagement;
     private readonly IJobManagement _jobManagement;
 
-    private static readonly ConcurrentDictionary<Guid, Channel<string>> _processStreamSubscribers = new();
-    private static readonly ConcurrentDictionary<Guid, Channel<string>> _activityStreamSubscribers = new();
     private static readonly JsonSerializerOptions _serializerOptions = new()
     {
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
@@ -210,9 +206,11 @@ public class ProcessEngineController : ControllerBase // TODO: Rename to Process
     [ProducesResponseType(typeof(JobProcessModel), StatusCodes.Status200OK)]
     public async Task ProcessUpdatesStream(CancellationToken cancellationToken)
     {
+        var channel = Channel.CreateUnbounded<string>();
+
         // Define event handler using the broadcast helper
-        var eventHandler = new EventHandler<ProcessUpdatedEventArgs>((_, e) =>
-            Broadcast(e));
+        EventHandler<ProcessUpdatedEventArgs> eventHandler = (_, e) =>
+            Broadcast(e);
 
         try
         {
@@ -230,35 +228,17 @@ public class ProcessEngineController : ControllerBase // TODO: Rename to Process
 
         return;
 
-        async IAsyncEnumerable<string> Subscribe([EnumeratorCancellation] CancellationToken cancelToken)
+        IAsyncEnumerable<string> Subscribe(CancellationToken cancelToken)
         {
-            var channel = Channel.CreateUnbounded<string>();
-            var id = Guid.NewGuid();
-            _processStreamSubscribers[id] = channel;
-
-            try
-            {
-                await foreach (var data in channel.Reader.ReadAllAsync(cancelToken))
-                {
-                    yield return data;
-                }
-            }
-            finally
-            {
-                _processStreamSubscribers.TryRemove(id, out _);
-            }
+            return channel.Reader.ReadAllAsync(cancelToken);
         }
 
-        // Local helper to broadcast process updates to all connected clients
+        // Local helper to push process updates to the client
         void Broadcast(ProcessUpdatedEventArgs e)
         {
             var processModel = Converter.ConvertProcess(e.Process, _processControl, _resourceManagement);
             processModel.State = e.Progress;
-
-            foreach (var channel in _processStreamSubscribers.Values)
-            {
-                channel.Writer.TryWrite(JsonSerializer.Serialize(processModel, _serializerOptions));
-            }
+            channel.Writer.TryWrite(JsonSerializer.Serialize(processModel, _serializerOptions));
         }
     }
 
@@ -267,9 +247,11 @@ public class ProcessEngineController : ControllerBase // TODO: Rename to Process
     [ProducesResponseType(typeof(ProcessActivityModel), StatusCodes.Status200OK)]
     public async Task ActivitiesUpdatesStream(CancellationToken cancellationToken)
     {
+        var channel = Channel.CreateUnbounded<string>();
+
         // Define event handler using the broadcast helper
-        var eventHandler = new EventHandler<ActivityUpdatedEventArgs>((_, e) =>
-            Broadcast(e));
+        EventHandler<ActivityUpdatedEventArgs> eventHandler = (_, e) =>
+            Broadcast(e);
 
         try
         {
@@ -291,37 +273,18 @@ public class ProcessEngineController : ControllerBase // TODO: Rename to Process
 
         return;
 
-        async IAsyncEnumerable<string> Subscribe([EnumeratorCancellation] CancellationToken cancelToken)
+        IAsyncEnumerable<string> Subscribe(CancellationToken cancelToken)
         {
-            var channel = Channel.CreateUnbounded<string>();
-            var id = Guid.NewGuid();
-            _activityStreamSubscribers[id] = channel;
-
-            try
-            {
-                await foreach (var data in channel.Reader.ReadAllAsync(cancelToken))
-                {
-                    yield return data;
-                }
-            }
-            finally
-            {
-                _activityStreamSubscribers.TryRemove(id, out _);
-            }
+            return channel.Reader.ReadAllAsync(cancelToken);
         }
 
-        // Local helper to broadcast activity updates to all connected clients
+        // Local helper to push activity updates to the client
         void Broadcast(ActivityUpdatedEventArgs e)
         {
             var activityModel = Converter.ConvertActivity(e.Activity, _processControl, _resourceManagement);
             activityModel.State = e.Progress.ToString();
-
-            foreach (var channel in _activityStreamSubscribers.Values)
-            {
-                channel.Writer.TryWrite(JsonSerializer.Serialize(activityModel, _serializerOptions));
-            }
+            channel.Writer.TryWrite(JsonSerializer.Serialize(activityModel, _serializerOptions));
         }
-
     }
 
     #region Process Holder

--- a/src/Moryx.ControlSystem.Processes.Endpoints/StreamServices/ProcessHolderGroupStream.cs
+++ b/src/Moryx.ControlSystem.Processes.Endpoints/StreamServices/ProcessHolderGroupStream.cs
@@ -1,8 +1,6 @@
 // Copyright (c) 2026 Phoenix Contact GmbH & Co. KG
 // Licensed under the Apache License, Version 2.0
 
-using System.Collections.Concurrent;
-using System.Runtime.CompilerServices;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Threading.Channels;
@@ -17,7 +15,6 @@ namespace Moryx.ControlSystem.Processes.Endpoints.StreamServices;
 /// </summary>
 internal class ProcessHolderGroupStream(IResourceManagement resourceManagement)
 {
-    private static readonly ConcurrentDictionary<Guid, Channel<string>> _subscribers = new();
     private static readonly JsonSerializerOptions _serializerOptions = new()
     {
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
@@ -32,6 +29,8 @@ internal class ProcessHolderGroupStream(IResourceManagement resourceManagement)
     /// <returns></returns>
     public async Task Start(HttpContext context, CancellationToken cancellationToken)
     {
+        var channel = Channel.CreateUnbounded<string>();
+
         // using unsafe because resourceManagement.GetResources<T> is very restricted in the sense
         // that casting at line 55 doesn't work
         var groups = resourceManagement.GetResourcesUnsafe<IProcessHolderGroup>(_ => true);
@@ -86,35 +85,18 @@ internal class ProcessHolderGroupStream(IResourceManagement resourceManagement)
             resourceManagement.ResourceAdded -= resourceAdded;
             resourceManagement.ResourceRemoved -= resourceRemoved;
         }
-    }
 
-    /// <summary>
-    /// Local helper to broadcast process holder group changes to all connected clients
-    /// </summary>
-    private static void Broadcast(ProcessHolderGroupModel groupModel)
-    {
-        foreach (var channel in _subscribers.Values)
+        return;
+
+        IAsyncEnumerable<string> Subscribe(CancellationToken cancelToken)
+        {
+            return channel.Reader.ReadAllAsync(cancelToken);
+        }
+
+        // Local helper to push process holder group changes to the client
+        void Broadcast(ProcessHolderGroupModel groupModel)
         {
             channel.Writer.TryWrite(JsonSerializer.Serialize(groupModel, _serializerOptions));
-        }
-    }
-
-    private static async IAsyncEnumerable<string> Subscribe([EnumeratorCancellation] CancellationToken cancellationToken)
-    {
-        var channel = Channel.CreateUnbounded<string>();
-        var id = Guid.NewGuid();
-        _subscribers[id] = channel;
-
-        try
-        {
-            await foreach (var data in channel.Reader.ReadAllAsync(cancellationToken))
-            {
-                yield return data;
-            }
-        }
-        finally
-        {
-            _subscribers.TryRemove(id, out _);
         }
     }
 }

--- a/src/Moryx.FactoryMonitor.Endpoints/FactoryMonitorController.cs
+++ b/src/Moryx.FactoryMonitor.Endpoints/FactoryMonitorController.cs
@@ -1,10 +1,8 @@
 // Copyright (c) 2026 Phoenix Contact GmbH & Co. KG
 // Licensed under the Apache License, Version 2.0
 
-using System.Collections.Concurrent;
 using System.Globalization;
 using System.Net.ServerSentEvents;
-using System.Runtime.CompilerServices;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Threading.Channels;
@@ -43,7 +41,6 @@ public class FactoryMonitorController : ControllerBase
     private readonly IOrderManagement _orderManager;
     private readonly CellSerialization _serialization;
 
-    private static readonly ConcurrentDictionary<Guid, Channel<(string EventType, string Data)>> _factoryStreamSubscribers = new();
     private static readonly JsonSerializerOptions _serializerOptions = new()
     {
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
@@ -245,23 +242,25 @@ public class FactoryMonitorController : ControllerBase
         }
         var converter = new Converter.Converter(_serialization, _logger);
 
+        var channel = Channel.CreateUnbounded<SseItem<string>>();
+
         // Define event handlers using helper methods
-        var resourceEventHandler = new ElapsedEventHandler((_, _) =>
-            FactoryMonitorHelper.ResourceUpdated(_resourceManager, l => MapCellsTo(l), converter, Broadcast));
+        ElapsedEventHandler resourceEventHandler = (_, _) =>
+            FactoryMonitorHelper.ResourceUpdated(_resourceManager, l => MapCellsTo(l), converter, Broadcast);
 
-        var capabilitiesEventHandler = new EventHandler<ICapabilities>((sender, _) =>
-            FactoryMonitorHelper.PublishCellUpdate((sender as ICell)?.GetCellStateChangedModel(), Broadcast));
+        EventHandler<ICapabilities> capabilitiesEventHandler = (sender, _) =>
+            FactoryMonitorHelper.PublishCellUpdate((sender as ICell)?.GetCellStateChangedModel(), Broadcast);
 
-        var orderStartedEventHandler = new EventHandler<OperationStartedEventArgs>((_, eventArgs) =>
-            FactoryMonitorHelper.OrderStarted(eventArgs, TryGetOrders(), Broadcast));
+        EventHandler<OperationStartedEventArgs> orderStartedEventHandler = (_, eventArgs) =>
+            FactoryMonitorHelper.OrderStarted(eventArgs, TryGetOrders(), Broadcast);
 
-        var orderEventHandler = new EventHandler<OperationChangedEventArgs>((sender, eventArgs) =>
-            FactoryMonitorHelper.OrderUpdated(eventArgs, Broadcast));
+        EventHandler<OperationChangedEventArgs> orderEventHandler = (_, eventArgs) =>
+            FactoryMonitorHelper.OrderUpdated(eventArgs, Broadcast);
 
         // ToDo: This breaks if new cells were added and process activities
-        var activityEventHandler = new EventHandler<ActivityUpdatedEventArgs>((sender, eventArgs) =>
+        EventHandler<ActivityUpdatedEventArgs> activityEventHandler = (_, eventArgs) =>
             FactoryMonitorHelper.ActivityUpdated(eventArgs, [.. _locationToCellMappings.Values],
-                TryGetOrders(), Broadcast));
+                TryGetOrders(), Broadcast);
 
         // Setup timer
         _resourceChangedTimer = new();
@@ -307,32 +306,15 @@ public class FactoryMonitorController : ControllerBase
 
         return;
 
-        async IAsyncEnumerable<SseItem<string>> Subscribe([EnumeratorCancellation] CancellationToken cancelToken)
+        IAsyncEnumerable<SseItem<string>> Subscribe(CancellationToken cancelToken)
         {
-            var channel = Channel.CreateUnbounded<(string EventType, string Data)>();
-            var id = Guid.NewGuid();
-            _factoryStreamSubscribers[id] = channel;
-
-            try
-            {
-                await foreach (var (eventType, data) in channel.Reader.ReadAllAsync(cancelToken))
-                {
-                    yield return new SseItem<string>(data, eventType);
-                }
-            }
-            finally
-            {
-                _factoryStreamSubscribers.TryRemove(id, out _);
-            }
+            return channel.Reader.ReadAllAsync(cancelToken);
         }
 
-        // Local helper to broadcast events to all connected clients
-        static void Broadcast(string eventType, object data)
+        // Local helper to push factory events to the client
+        void Broadcast(string eventType, object data)
         {
-            foreach (var channel in _factoryStreamSubscribers.Values)
-            {
-                channel.Writer.TryWrite((eventType, JsonSerializer.Serialize(data, _serializerOptions)));
-            }
+            channel.Writer.TryWrite(new SseItem<string>(JsonSerializer.Serialize(data, _serializerOptions), eventType));
         }
     }
 

--- a/src/Moryx.Orders.Endpoints/OrderManagementController.cs
+++ b/src/Moryx.Orders.Endpoints/OrderManagementController.cs
@@ -1,7 +1,6 @@
 // Copyright (c) 2026 Phoenix Contact GmbH & Co. KG
 // Licensed under the Apache License, Version 2.0
 
-using System.Collections.Concurrent;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -10,7 +9,6 @@ using Moryx.Orders.Endpoints.Properties;
 using Moryx.Users;
 using System.Net;
 using System.Net.ServerSentEvents;
-using System.Runtime.CompilerServices;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Threading.Channels;
@@ -30,7 +28,6 @@ public class OrderManagementController : ControllerBase
     private readonly IOrderManagement _orderManagement;
     private readonly IUserManagement _userManagement;
 
-    private static readonly ConcurrentDictionary<Guid, Channel<(string, string)>> _operationStreamSubscribers = new();
     private static readonly JsonSerializerOptions _serializerOptions = new()
     {
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
@@ -61,43 +58,45 @@ public class OrderManagementController : ControllerBase
     [ProducesResponseType(typeof(OperationChangedModel), StatusCodes.Status200OK)]
     public async Task OperationStream(CancellationToken cancellationToken)
     {
-        // Define event handlers using the broadcast helper
-        var updateEventHandler = new EventHandler<OperationChangedEventArgs>((_, e) =>
-            Broadcast(nameof(OperationTypes.Update), Converter.ToModel(e.Operation)));
+        var channel = Channel.CreateUnbounded<SseItem<string>>();
 
-        var adviceEventHandler = new EventHandler<OperationAdviceEventArgs>((_, e) =>
+        // Define event handlers using the broadcast helper
+        EventHandler<OperationChangedEventArgs> updateEventHandler = (_, e) =>
+            Broadcast(nameof(OperationTypes.Update), Converter.ToModel(e.Operation));
+
+        EventHandler<OperationAdviceEventArgs> adviceEventHandler = (_, e) =>
             Broadcast(nameof(OperationTypes.Advice), new OperationAdvicedModel
             {
                 OperationModel = Converter.ToModel(e.Operation),
                 Advice = Converter.ToModel(e.Advice)
-            }));
+            });
 
-        var reportEventHandler = new EventHandler<OperationReportEventArgs>((_, e) =>
+        EventHandler<OperationReportEventArgs> reportEventHandler = (_, e) =>
             Broadcast(nameof(OperationTypes.Report), new OperationReportedModel
             {
                 OperationModel = Converter.ToModel(e.Operation),
                 Report = Converter.ToModel(e.Report)
-            }));
+            });
 
-        var interruptedEventHandler = new EventHandler<OperationChangedEventArgs>((_, e) =>
-            Broadcast(nameof(OperationTypes.Interrupted), Converter.ToModel(e.Operation)));
+        EventHandler<OperationChangedEventArgs> interruptedEventHandler = (_, e) =>
+            Broadcast(nameof(OperationTypes.Interrupted), Converter.ToModel(e.Operation));
 
-        var completedEventHandler = new EventHandler<OperationReportEventArgs>((_, e) =>
+        EventHandler<OperationReportEventArgs> completedEventHandler = (_, e) =>
             Broadcast(nameof(OperationTypes.Completed), new OperationReportedModel
             {
                 OperationModel = Converter.ToModel(e.Operation),
                 Report = Converter.ToModel(e.Report)
-            }));
+            });
 
-        var startedEventHandler = new EventHandler<OperationStartedEventArgs>((_, e) =>
+        EventHandler<OperationStartedEventArgs> startedEventHandler = (_, e) =>
             Broadcast(nameof(OperationTypes.Start), new OperationStartedModel
             {
                 OperationModel = Converter.ToModel(e.Operation),
                 UserId = e.User.Identifier
-            }));
+            });
 
-        var changedEventHandler = new EventHandler<OperationChangedEventArgs>((_, e) =>
-            Broadcast(nameof(OperationTypes.Progress), Converter.ToModel(e.Operation)));
+        EventHandler<OperationChangedEventArgs> changedEventHandler = (_, e) =>
+            Broadcast(nameof(OperationTypes.Progress), Converter.ToModel(e.Operation));
 
         try
         {
@@ -131,32 +130,15 @@ public class OrderManagementController : ControllerBase
 
         return;
 
-        async IAsyncEnumerable<SseItem<string>> Subscribe([EnumeratorCancellation] CancellationToken cancelToken)
+        IAsyncEnumerable<SseItem<string>> Subscribe(CancellationToken cancelToken)
         {
-            var channel = Channel.CreateUnbounded<(string, string)>();
-            var id = Guid.NewGuid();
-            _operationStreamSubscribers[id] = channel;
-
-            try
-            {
-                await foreach (var evt in channel.Reader.ReadAllAsync(cancelToken))
-                {
-                    yield return new SseItem<string>(evt.Item2, eventType: evt.Item1);
-                }
-            }
-            finally
-            {
-                _operationStreamSubscribers.TryRemove(id, out _);
-            }
+            return channel.Reader.ReadAllAsync(cancelToken);
         }
 
-        // Local helper to broadcast events to all connected clients
-        static void Broadcast(string eventType, object data)
+        // Local helper to push operation events to the client
+        void Broadcast(string eventType, object data)
         {
-            foreach (var channel in _operationStreamSubscribers.Values)
-            {
-                channel.Writer.TryWrite((eventType, JsonSerializer.Serialize(data, _serializerOptions)));
-            }
+            channel.Writer.TryWrite(new SseItem<string>(JsonSerializer.Serialize(data, _serializerOptions), eventType));
         }
     }
 
@@ -490,5 +472,4 @@ public class OrderManagementController : ControllerBase
         return Ok();
     }
     #endregion
-
 }


### PR DESCRIPTION
Applied the per-connection channel pattern from #1362 to the remaining SSE controllers. Removed the static Dictionary for subscribers. introduced named record struct types for typed SSE events.