### PR TITLE
Unified toolbar style in operation recipes view to other views 

### DIFF
--- a/src/Moryx.Orders.Web/app/src/app/components/operation-recipes/operation-recipes.html
+++ b/src/Moryx.Orders.Web/app/src/app/components/operation-recipes/operation-recipes.html
@@ -1,71 +1,50 @@
 @if (isLoading()) {
-  <mat-progress-bar
-    mode="indeterminate"
-  class="operation-recipe-loading"></mat-progress-bar>
+  <mat-progress-bar mode="indeterminate" class="operation-recipe-loading"></mat-progress-bar>
 }
 <mat-sidenav-container class="operation-recipe-container">
-  <mat-sidenav opened mode="side" position="start">
-    <div class="">
-      <mat-toolbar
-        [style.background-image]="'url(' + operationRecipeToolbarImage + ')'"
-        color="primary"
-        class="operation-recipe-toolbar">
-        <mat-toolbar-row>
-          <a mat-icon-button [routerLink]="['/operations']" mat-icon-button aria-label="Go back to operations">
+  <mat-sidenav opened mode="side" position="start" disableClose="true">
+    <mat-toolbar [style.background-image]="'url(' + operationRecipeToolbarImage + ')'" color="primary"
+      class="operation-recipe-toolbar">
+      <mat-toolbar-row>
+        @if (!isEditMode()) {
+          <button type="button" mat-icon-button aria-label="Go back to operations" [routerLink]="['/operations']"
+            [matTooltip]="TranslationConstants.RECIPES.GO_BACK | translate" matTooltipShowDelay="500">
             <mat-icon>arrow_back</mat-icon>
-          </a>
-        </mat-toolbar-row>
-        <mat-toolbar-row class="operation-recipe-toolbar-details">
-          <div>
-            {{ TranslationConstants.RECIPES.RECIPES_OF | translate }}
-          </div>
-          <div>{{ operation().order }} - {{ operation().number }}</div>
-        </mat-toolbar-row>
-      </mat-toolbar>
-      <mat-list>
-        @for (recipe of recipes(); track recipe) {
-          <mat-list-item
-            [class.moryx-selected]="selectedRecipe()?.id === recipe.id"
-            class="operation-recipes-list-item"
-            (click)="onSelect(recipe)">
-            <span>{{ recipe.name }}</span>
-          </mat-list-item>
+          </button>
+          <span class="spacer"></span>
+          @if (selectedRecipe()) {
+            <button type="button" mat-icon-button aria-label="Start editing the selected product type"
+              (click)="onEdit()" [matTooltip]="TranslationConstants.RECIPES.EDIT | translate" matTooltipShowDelay="500">
+              <mat-icon>edit</mat-icon>
+            </button>
+          }
+        } @else {
+          <span class="spacer"></span>
+          <button type="submit" mat-icon-button aria-label="Save the edited resource" (click)="onSave()"
+            [matTooltip]="TranslationConstants.RECIPES.SAVE | translate" matTooltipShowDelay="500">
+            <mat-icon>save</mat-icon>
+          </button>
+          <button type="reset" mat-icon-button aria-label="Cancel Editing" (click)="onCancel()"
+            [matTooltip]="TranslationConstants.RECIPES.CANCEL | translate" matTooltipShowDelay="500">
+            <mat-icon>cancel</mat-icon>
+          </button>
         }
-      </mat-list>
-    </div>
-  </mat-sidenav>
-  <mat-sidenav [opened]="isEditBarOpened()" mode="side" class="toolbar-nav"  position="end">
-    <div class="operation-recipe-details-container">
-      @if (!isEditMode()) {
-        <button
-          mat-icon-button
-          aria-label="Start editing the selected product type"
-          type="button"
-          (click)="onEdit()">
-          <mat-icon>edit</mat-icon>
-        </button>
+      </mat-toolbar-row>
+      <mat-toolbar-row class="operation-recipe-toolbar-details">
+        <div>
+          {{ TranslationConstants.RECIPES.RECIPES_OF | translate }}
+        </div>
+        <div>{{ operation().order }} - {{ operation().number }}</div>
+      </mat-toolbar-row>
+    </mat-toolbar>
+    <mat-list>
+      @for (recipe of recipes(); track recipe) {
+        <mat-list-item [class.moryx-selected]="selectedRecipe()?.id === recipe.id" class="operation-recipes-list-item"
+          (click)="onSelect(recipe)">
+          <span>{{ recipe.name }}</span>
+        </mat-list-item>
       }
-
-      @if (isEditMode()) {
-        <button
-          mat-icon-button
-          aria-label="Cancel Editing"
-          type="reset"
-          (click)="onCancel()">
-          <mat-icon>cancel</mat-icon>
-        </button>
-      }
-
-      @if (isEditMode()) {
-        <button
-          mat-icon-button
-          aria-label="Save the edited resource"
-          type="submit"
-          (click)="onSave()">
-          <mat-icon>save</mat-icon>
-        </button>
-      }
-    </div>
+    </mat-list>
   </mat-sidenav>
   <mat-sidenav-content>
     @if (selectedRecipe()) {
@@ -73,29 +52,24 @@
         <h2>{{ TranslationConstants.RECIPES.GENERAL | translate }}</h2>
         <mat-form-field appearance="outline">
           <mat-label>{{
-            TranslationConstants.RECIPES.NAME | translate
-          }}</mat-label>
-          <input
-            matInput
-            aria-label="Recipe Name"
-            [disabled]="isEditMode() === false"
-            [(ngModel)]="selectedRecipe()!.name" />
+              TranslationConstants.RECIPES.NAME | translate
+            }}
+          </mat-label>
+          <input matInput aria-label="Recipe Name" [disabled]="isEditMode() === false"
+            [(ngModel)]="selectedRecipe()!.name"/>
         </mat-form-field>
         @if (hasWorkplans()) {
           <mat-form-field appearance="outline">
             <mat-label>{{
-              TranslationConstants.RECIPES.WORKPLAN | translate
-            }}</mat-label>
-            <mat-select
-              [(ngModel)]="selectedWorkplan"
-              [disabled]="isEditMode() === false"
-              required>
+                TranslationConstants.RECIPES.WORKPLAN | translate
+              }}
+            </mat-label>
+            <mat-select [(ngModel)]="selectedWorkplan" [disabled]="isEditMode() === false" required>
               @for (workplan of possibleWorkplans(); track workplan) {
-                <mat-option
-                  [value]="workplan">
+                <mat-option [value]="workplan">
                   {{ workplan.name }} -
                   {{ TranslationConstants.RECIPES.VERSION | translate }}: {{
-                  workplan.version
+                    workplan.version
                   }}
                 </mat-option>
               }
@@ -104,14 +78,12 @@
         }
         <mat-form-field appearance="outline">
           <mat-label>{{
-            TranslationConstants.RECIPES.CLASSIFICATION | translate
-          }}</mat-label>
-          <mat-select
-            [(ngModel)]="selectedRecipe()!.classification"
-            [disabled]="isEditMode() === false">
+              TranslationConstants.RECIPES.CLASSIFICATION | translate
+            }}
+          </mat-label>
+          <mat-select [(ngModel)]="selectedRecipe()!.classification" [disabled]="isEditMode() === false">
             @for (classification of recipeClassifications; track classification) {
-              <mat-option
-                [value]="classification">
+              <mat-option [value]="classification">
                 {{ classification }}
               </mat-option>
             }
@@ -119,11 +91,8 @@
         </mat-form-field>
         <h2>{{ TranslationConstants.RECIPES.PROPERTIES | translate }}</h2>
         @if (selectedRecipe()!.properties !== undefined) {
-          <navigable-entry-editor
-            class="product-recipes-details-properties"
-            queryParam="recipeParameter"
-            [entry]="selectedRecipe()!.properties!"
-          [disabled]="isEditMode() === false"></navigable-entry-editor>
+          <navigable-entry-editor class="product-recipes-details-properties" queryParam="recipeParameter"
+            [entry]="selectedRecipe()!.properties!" [disabled]="isEditMode() === false"></navigable-entry-editor>
         }
       </div>
     }

--- a/src/Moryx.Orders.Web/app/src/app/components/operation-recipes/operation-recipes.html
+++ b/src/Moryx.Orders.Web/app/src/app/components/operation-recipes/operation-recipes.html
@@ -20,11 +20,11 @@
           }
         } @else {
           <span class="spacer"></span>
-          <button type="submit" mat-icon-button aria-label="Save the edited resource" (click)="onSave()"
+          <button type="button" mat-icon-button aria-label="Save the edited resource" (click)="onSave()"
             [matTooltip]="TranslationConstants.RECIPES.SAVE | translate" matTooltipShowDelay="500">
             <mat-icon>save</mat-icon>
           </button>
-          <button type="reset" mat-icon-button aria-label="Cancel Editing" (click)="onCancel()"
+          <button type="button" mat-icon-button aria-label="Cancel Editing" (click)="onCancel()"
             [matTooltip]="TranslationConstants.RECIPES.CANCEL | translate" matTooltipShowDelay="500">
             <mat-icon>cancel</mat-icon>
           </button>

--- a/src/Moryx.Orders.Web/app/src/app/components/operation-recipes/operation-recipes.scss
+++ b/src/Moryx.Orders.Web/app/src/app/components/operation-recipes/operation-recipes.scss
@@ -1,6 +1,17 @@
 @use '@angular/material' as mat;
 @use "@moryx/ngx-web-framework/styles/variables" as *;
 
+.mat-toolbar-row{
+  button{
+    color: white;
+    margin: 4px;
+  }
+}
+
+.spacer {
+  flex: 1 1 auto;
+}
+
 .operation-recipe-container {
     height: 100%;
     @include mat.sidenav-overrides((
@@ -50,12 +61,7 @@ mat-list {
     flex-flow: column;
     align-items: flex-start;
 }
+
 .moryx-selected{
     background-color: $primary-light;
-}
-.toolbar-nav{
-    @include mat.sidenav-overrides((
-        container-background-color: var(--mat-sys-surface-container-lowest),
-        container-width: 50px
-      ));
 }

--- a/src/Moryx.Orders.Web/app/src/app/components/operation-recipes/operation-recipes.ts
+++ b/src/Moryx.Orders.Web/app/src/app/components/operation-recipes/operation-recipes.ts
@@ -25,6 +25,7 @@ import { MatFormFieldModule } from "@angular/material/form-field";
 import { MatOptionModule } from "@angular/material/core";
 import { MatInputModule } from "@angular/material/input";
 import { MatSelectModule } from '@angular/material/select';
+import { MatTooltip } from '@angular/material/tooltip';
 
 @Component({
   selector: "app-operation-recipes",
@@ -46,7 +47,8 @@ import { MatSelectModule } from '@angular/material/select';
     MatInputModule,
     MatFormFieldModule,
     ReactiveFormsModule,
-    MatSelectModule
+    MatSelectModule,
+    MatTooltip
   ]
 })
 export class OperationRecipes implements OnInit {
@@ -132,8 +134,17 @@ export class OperationRecipes implements OnInit {
             await this.snackbarService.handleError(e)
         );
     }
-    if (this.selectedRecipe()) {
-      this.selectedRecipe.set(this.recipes().find((r) => r.id === this.selectedRecipe()?.id));
+
+    const selectedRecipe = this.selectedRecipe();
+
+    if (selectedRecipe) {
+      this.selectedRecipe.set(this.recipes().find((r) => r.id === selectedRecipe.id));
+    }
+
+    const updatedSelection = this.selectedRecipe();
+
+    if (!updatedSelection && this.recipes().length > 0) {
+     this.selectedRecipe.set(this.recipes()[0]);
     }
   }
 

--- a/src/Moryx.Orders.Web/app/src/app/translation-constants.ts
+++ b/src/Moryx.Orders.Web/app/src/app/translation-constants.ts
@@ -69,6 +69,10 @@ export class TranslationConstants {
     CLASSIFICATION: 'RECIPES.CLASSIFICATION',
     PROPERTIES: 'RECIPES.PROPERTIES',
     VERSION: 'RECIPES.VERSION',
+    GO_BACK: 'RECIPES.GO_BACK',
+    EDIT: 'RECIPES.EDIT',
+    SAVE: 'RECIPES.SAVE',
+    CANCEL: 'RECIPES.CANCEL'
   };
 
   public static readonly DOCUMENTS = {

--- a/src/Moryx.Orders.Web/app/src/assets/languages/de.json
+++ b/src/Moryx.Orders.Web/app/src/assets/languages/de.json
@@ -59,7 +59,11 @@
     "WORKPLAN": "Arbeitsplan",
     "CLASSIFICATION": "Klassifikation",
     "PROPERTIES": "Eigenschaften",
-    "VERSION": "Version"
+    "VERSION": "Version",
+    "GO_BACK": "Zurück gehen",
+    "EDIT": "Editieren",
+    "SAVE": "Speichern",
+    "CANCEL": "Abbrechen"
   },
   "DOCUMENTS": {
     "DOCUMENTS_OF": "Dokumente von",

--- a/src/Moryx.Orders.Web/app/src/assets/languages/en.json
+++ b/src/Moryx.Orders.Web/app/src/assets/languages/en.json
@@ -59,7 +59,11 @@
     "WORKPLAN": "Workplan",
     "CLASSIFICATION": "Classification",
     "PROPERTIES": "Properties",
-    "VERSION": "Version"
+    "VERSION": "Version",
+    "GO_BACK": "Go back",
+    "EDIT": "Edit",
+    "SAVE": "Save",
+    "CANCEL": "Cancel"
   },
   "DOCUMENTS": {
     "DOCUMENTS_OF": "Documents of",

--- a/src/Moryx.Orders.Web/app/src/assets/languages/it.json
+++ b/src/Moryx.Orders.Web/app/src/assets/languages/it.json
@@ -59,7 +59,11 @@
     "WORKPLAN": "Piano di Lavoro",
     "CLASSIFICATION": "Classificazione",
     "PROPERTIES": "Proprietà",
-    "VERSION": "Versione"
+    "VERSION": "Versione",
+    "GO BACK": "Torna indietro",
+    "EDIT": "Modifica",
+    "SAVE": "Salva",
+    "CANCEL": "Cancella"
   },
   "DOCUMENTS": {
     "DOCUMENTS_OF": "Documenti di",

--- a/src/Moryx.Orders.Web/app/src/assets/languages/it.json
+++ b/src/Moryx.Orders.Web/app/src/assets/languages/it.json
@@ -60,7 +60,7 @@
     "CLASSIFICATION": "Classificazione",
     "PROPERTIES": "Proprietà",
     "VERSION": "Versione",
-    "GO BACK": "Torna indietro",
+    "GO_BACK": "Torna indietro",
     "EDIT": "Modifica",
     "SAVE": "Salva",
     "CANCEL": "Cancella"

--- a/src/Moryx.Orders.Web/app/src/assets/languages/zh.json
+++ b/src/Moryx.Orders.Web/app/src/assets/languages/zh.json
@@ -59,7 +59,11 @@
     "WORKPLAN": "工作计划",
     "CLASSIFICATION": "分类",
     "PROPERTIES": "属性",
-    "VERSION": "版本"
+    "VERSION": "版本",
+    "GO BACK": "返回",
+    "EDIT": "编辑",
+    "SAVE": "保存",
+    "CANCEL": "取消"
   },
   "DOCUMENTS": {
     "DOCUMENTS_OF": "文档 -",

--- a/src/Moryx.Orders.Web/app/src/assets/languages/zh.json
+++ b/src/Moryx.Orders.Web/app/src/assets/languages/zh.json
@@ -60,7 +60,7 @@
     "CLASSIFICATION": "分类",
     "PROPERTIES": "属性",
     "VERSION": "版本",
-    "GO BACK": "返回",
+    "GO_BACK": "返回",
     "EDIT": "编辑",
     "SAVE": "保存",
     "CANCEL": "取消"


### PR DESCRIPTION
The commands in the operation recipes view, which were previosly placed in a separate side bar on the right, were migrated into the top part of the left side bar. This way the layout is unified to other views like Products, Resources, and so on.

<img width="1270" height="623" alt="image" src="https://github.com/user-attachments/assets/ed04be2f-3fbc-4c48-9837-ed6336899ceb" />

The contrast to the background is not part of this issue. Someone needs to provide better background images.