### PR TITLE
Pdfs media are not shown in the Visual instruction

### DIFF
--- a/src/Moryx.VisualInstructions.Web/app/src/app/components/media-contents/media-contents.html
+++ b/src/Moryx.VisualInstructions.Web/app/src/app/components/media-contents/media-contents.html
@@ -8,7 +8,7 @@
   }
   @if (selectedContent()?.type?.includes('application/pdf') ) {
     <ngx-doc-viewer
-      viewer="url"
+      viewer="pdf"
       [url]="selectedContent()?.url ?? ''"
       class="media-content-detail-image"
     ></ngx-doc-viewer>


### PR DESCRIPTION
use the pdf value instead of url in the ngx-doc-viewer to display the pdf content properly as suggested in the library documentation