### PR TITLE
fix pdf issue in media & order similar to visual instruction

### DIFF
--- a/src/Moryx.Media.Web/app/src/app/components/variant-overview/variant-overview.html
+++ b/src/Moryx.Media.Web/app/src/app/components/variant-overview/variant-overview.html
@@ -98,7 +98,7 @@
                 <img src="{{ bigPictureUrl() }}" alt="Image could not be loaded" class="variant-image" />
               }
               @if (bigPictureIsPdf()) {
-                <ngx-doc-viewer [url]="pdfUrl()!" viewer="url" class="variant-pdf"></ngx-doc-viewer>
+                <ngx-doc-viewer [url]="pdfUrl()!" viewer="pdf" class="variant-pdf"></ngx-doc-viewer>
               }
             }
           }

--- a/src/Moryx.Orders.Web/app/src/app/components/operation-documents/operation-documents.html
+++ b/src/Moryx.Orders.Web/app/src/app/components/operation-documents/operation-documents.html
@@ -42,7 +42,7 @@
         @if (url() && !isImage()) {
           <ngx-doc-viewer
             class="document-pdf"
-            viewer="url"
+            viewer="pdf"
             [url]="url()!"></ngx-doc-viewer>
         }
       </div>


### PR DESCRIPTION
fix pdf issue in media and order, use the pdf value instead of url in the ngx-doc-viewer