### PR TITLE
Removed FailureBehaviour from CommandCenter

### DIFF
--- a/src/Moryx.CommandCenter.Web/app/src/common/components/ModuleHeader.tsx
+++ b/src/Moryx.CommandCenter.Web/app/src/common/components/ModuleHeader.tsx
@@ -8,15 +8,13 @@ import Tabs from "@mui/material/Tabs";
 import * as React from "react";
 import { connect } from "react-redux";
 import { Link } from "react-router";
-import { FailureBehaviour } from "../../modules/models/FailureBehaviour";
 import { ModuleStartBehaviour } from "../../modules/models/ModuleStartBehaviour";
-import { updateFailureBehaviour, updateStartBehaviour } from "../../modules/redux/ModulesActions";
+import { updateStartBehaviour } from "../../modules/redux/ModulesActions";
 import { ActionType } from "../redux/Types";
 
 const mapDispatchToProps = (dispatch: React.Dispatch<ActionType<{}>>): ModuleDispatchPropModel => {
   return {
     onUpdateStartBehaviour: (moduleName: string, startBehaviour: ModuleStartBehaviour) => dispatch(updateStartBehaviour(moduleName, startBehaviour)),
-    onUpdateFailureBehaviour: (moduleName: string, failureBehaviour: FailureBehaviour) => dispatch(updateFailureBehaviour(moduleName, failureBehaviour)),
   };
 };
 
@@ -43,8 +41,6 @@ export class ModuleHeader extends React.Component<ModuleHeaderPropModel & Module
 
 interface ModuleDispatchPropModel {
   onUpdateStartBehaviour?(moduleName: string, startBehaviour: ModuleStartBehaviour): void;
-
-  onUpdateFailureBehaviour?(moduleName: string, failureBehaviour: FailureBehaviour): void;
 }
 
 export default connect<{}, ModuleDispatchPropModel>(null, mapDispatchToProps)(ModuleHeader);

--- a/src/Moryx.CommandCenter.Web/app/src/modules/container/Module.tsx
+++ b/src/Moryx.CommandCenter.Web/app/src/modules/container/Module.tsx
@@ -25,12 +25,11 @@ import ModuleHeader from "../../common/components/ModuleHeader";
 import { ActionType } from "../../common/redux/Types";
 import ModulesRestClient from "../api/ModulesRestClient";
 import { HealthStateBadge } from "../components/HealthStateBadge";
-import { FailureBehaviour } from "../models/FailureBehaviour";
 import { ModuleStartBehaviour } from "../models/ModuleStartBehaviour";
 import NotificationModel from "../models/NotificationModel";
 import ServerModuleModel from "../models/ServerModuleModel";
 import { Serverity } from "../models/Severity";
-import { updateFailureBehaviour, updateStartBehaviour } from "../redux/ModulesActions";
+import { updateStartBehaviour } from "../redux/ModulesActions";
 import { ModuleInfoTile } from "./ModuleInfoTile";
 import { Notifications } from "./Notifications";
 
@@ -47,14 +46,11 @@ interface ModuleStateModel {
 
 interface ModuleDispatchPropModel {
   onUpdateStartBehaviour?(moduleName: string, startBehaviour: ModuleStartBehaviour): void;
-
-  onUpdateFailureBehaviour?(moduleName: string, failureBehaviour: FailureBehaviour): void;
 }
 
 const mapDispatchToProps = (dispatch: React.Dispatch<ActionType<{}>>): ModuleDispatchPropModel => {
   return {
     onUpdateStartBehaviour: (moduleName: string, startBehaviour: ModuleStartBehaviour) => dispatch(updateStartBehaviour(moduleName, startBehaviour)),
-    onUpdateFailureBehaviour: (moduleName: string, failureBehaviour: FailureBehaviour) => dispatch(updateFailureBehaviour(moduleName, failureBehaviour)),
   };
 };
 
@@ -92,11 +88,6 @@ class Module extends React.Component<ModulePropModel & ModuleDispatchPropModel, 
   public onStartBehaviourChange(e: React.ChangeEvent<HTMLInputElement>): void {
     const newValue = e.target.value as ModuleStartBehaviour;
     this.props.RestClient.updateModule({...this.props.Module, startBehaviour: newValue}).then((d) => this.props.onUpdateStartBehaviour(this.props.Module.name, newValue));
-  }
-
-  public onFailureBehaviourChange(e: React.ChangeEvent<HTMLInputElement>): void {
-    const newValue = e.target.value as FailureBehaviour;
-    this.props.RestClient.updateModule({...this.props.Module, failureBehaviour: newValue}).then((d) => this.props.onUpdateFailureBehaviour(this.props.Module.name, newValue));
   }
 
   private static dependenciesList(module: ServerModuleModel): React.ReactNode {
@@ -199,7 +190,7 @@ class Module extends React.Component<ModulePropModel & ModuleDispatchPropModel, 
               </Grid>
             </ModuleInfoTile>
             <ModuleInfoTile
-              title="Start &amp; Failure behaviour"
+              title="Start behaviour"
             >
               <Grid size={12}>
                 <TextField
@@ -213,21 +204,6 @@ class Module extends React.Component<ModulePropModel & ModuleDispatchPropModel, 
                   <MenuItem value={ModuleStartBehaviour.Auto}>Auto</MenuItem>
                   <MenuItem value={ModuleStartBehaviour.Manual}>Manual</MenuItem>
                   <MenuItem value={ModuleStartBehaviour.OnDependency}>On dependency</MenuItem>
-                </TextField>
-              </Grid>
-
-              <Grid size={12}>
-                <TextField
-                  select={true}
-                  label="Failure behaviour"
-                  value={this.props.Module.failureBehaviour}
-                  onChange={(e: React.ChangeEvent<HTMLInputElement>) => this.onFailureBehaviourChange(e)}
-                  size="small"
-                  margin="dense"
-                  fullWidth={true}
-                >
-                  <MenuItem value={FailureBehaviour.Stop}>Stop</MenuItem>
-                  <MenuItem value={FailureBehaviour.StopAndNotify}>Stop and notify</MenuItem>
                 </TextField>
               </Grid>
             </ModuleInfoTile>

--- a/src/Moryx.CommandCenter.Web/app/src/modules/models/FailureBehaviour.ts
+++ b/src/Moryx.CommandCenter.Web/app/src/modules/models/FailureBehaviour.ts
@@ -1,9 +1,0 @@
-/*
- * Copyright (c) 2026 Phoenix Contact GmbH & Co. KG
- * Licensed under the Apache License, Version 2.0
-*/
-
-export enum FailureBehaviour {
-    Stop = "Stop",
-    StopAndNotify = "StopAndNotify",
-}

--- a/src/Moryx.CommandCenter.Web/app/src/modules/models/ServerModuleModel.ts
+++ b/src/Moryx.CommandCenter.Web/app/src/modules/models/ServerModuleModel.ts
@@ -4,7 +4,6 @@
 */
 
 import AssemblyModel from "./AssemblyModel";
-import { FailureBehaviour } from "./FailureBehaviour";
 import { ModuleServerModuleState } from "./ModuleServerModuleState";
 import { ModuleStartBehaviour } from "./ModuleStartBehaviour";
 import NotificationModel from "./NotificationModel";
@@ -13,7 +12,6 @@ export default class ServerModuleModel {
     public name: string;
     public healthState: ModuleServerModuleState;
     public startBehaviour: ModuleStartBehaviour;
-    public failureBehaviour: FailureBehaviour;
     public dependencies: ServerModuleModel[];
     public notifications: NotificationModel[];
     public assembly: AssemblyModel;

--- a/src/Moryx.CommandCenter.Web/app/src/modules/redux/ModulesActions.ts
+++ b/src/Moryx.CommandCenter.Web/app/src/modules/redux/ModulesActions.ts
@@ -4,7 +4,6 @@
 */
 
 import { ActionType } from "../../common/redux/Types";
-import { FailureBehaviour } from "../models/FailureBehaviour";
 import { ModuleServerModuleState } from "../models/ModuleServerModuleState";
 import { ModuleStartBehaviour } from "../models/ModuleStartBehaviour";
 import NotificationModel from "../models/NotificationModel";
@@ -14,7 +13,6 @@ export const UPDATE_MODULES = "UPDATE_MODULES";
 export const UPDATE_HEALTHSTATE = "UPDATE_HEALTHSTATE";
 export const UPDATE_NOTIFICATIONS = "UPDATE_NOTIFICATIONS";
 export const UPDATE_START_BEHAVIOUR = "UPDATE_START_BEHAVIOUR";
-export const UPDATE_FAILURE_BEHAVIOUR = "UPDATE_FAILURE_BEHAVIOUR";
 
 export function updateModules(modules: ServerModuleModel[]): ActionType<ServerModuleModel[]> {
     return { type: UPDATE_MODULES, payload: modules };
@@ -30,8 +28,4 @@ export function updateNotifications(moduleName: string, notifications: Notificat
 
 export function updateStartBehaviour(moduleName: string, startBehaviour: ModuleStartBehaviour): ActionType<{ moduleName: string, startBehaviour: ModuleStartBehaviour }> {
     return { type: UPDATE_START_BEHAVIOUR, payload: { moduleName, startBehaviour } };
-}
-
-export function updateFailureBehaviour(moduleName: string, failureBehaviour: FailureBehaviour): ActionType<{ moduleName: string, failureBehaviour: FailureBehaviour }> {
-    return { type: UPDATE_FAILURE_BEHAVIOUR, payload: { moduleName, failureBehaviour } };
 }

--- a/src/Moryx.CommandCenter.Web/app/src/modules/redux/ModulesState.ts
+++ b/src/Moryx.CommandCenter.Web/app/src/modules/redux/ModulesState.ts
@@ -6,12 +6,11 @@
 import { ActionType } from "../../common/redux/Types";
 import ModulesRestClient from "../api/ModulesRestClient";
 import Config from "../models/Config";
-import { FailureBehaviour } from "../models/FailureBehaviour";
 import { ModuleServerModuleState } from "../models/ModuleServerModuleState";
 import { ModuleStartBehaviour } from "../models/ModuleStartBehaviour";
 import NotificationModel from "../models/NotificationModel";
 import ServerModuleModel from "../models/ServerModuleModel";
-import { UPDATE_FAILURE_BEHAVIOUR, UPDATE_HEALTHSTATE, UPDATE_MODULES, UPDATE_NOTIFICATIONS, UPDATE_START_BEHAVIOUR } from "./ModulesActions";
+import { UPDATE_HEALTHSTATE, UPDATE_MODULES, UPDATE_NOTIFICATIONS, UPDATE_START_BEHAVIOUR } from "./ModulesActions";
 
 export interface ModulesState {
   RestClient: ModulesRestClient;
@@ -53,10 +52,6 @@ export function getModulesReducer(state: ModulesState = initialModulesState, act
     case UPDATE_START_BEHAVIOUR: {
       const { moduleName, startBehaviour } = action.payload as { moduleName: string; startBehaviour: ModuleStartBehaviour };
       return updateModule(state, moduleName, { startBehaviour });
-    }
-    case UPDATE_FAILURE_BEHAVIOUR: {
-      const { moduleName, failureBehaviour } = action.payload as { moduleName: string; failureBehaviour: FailureBehaviour };
-      return updateModule(state, moduleName, { failureBehaviour });
     }
   }
   return state;

--- a/src/Moryx.Runtime/Modules/FailureBehaviour.cs
+++ b/src/Moryx.Runtime/Modules/FailureBehaviour.cs
@@ -3,6 +3,8 @@
 
 namespace Moryx.Runtime.Modules;
 
+// TODO: Remove with next major release, as this is not used anymore
+
 /// <summary>
 /// Enum flags: Notify - Reincarnate
 /// </summary>


### PR DESCRIPTION
Removed unused FailureBehvior from CommandCenter. 

- Mentioned the removal in #1477. 
- Should be reconsidered in https://github.com/PHOENIXCONTACT/MORYX-Framework/issues/1476

This removes not a feature. It is currently unused in the modules and has no effect.