### PR TITLE
Do not inherit `ResourceConstructorAttribute`

### DIFF
--- a/src/Moryx.AbstractionLayer/Resources/Attributes/ResourceConstructorAttribute.cs
+++ b/src/Moryx.AbstractionLayer/Resources/Attributes/ResourceConstructorAttribute.cs
@@ -6,7 +6,7 @@ namespace Moryx.AbstractionLayer.Resources;
 /// <summary>
 /// Attribute to decorate methods that can be used to construct a resource instance
 /// </summary>
-[AttributeUsage(AttributeTargets.Method)]
+[AttributeUsage(AttributeTargets.Method, Inherited = false)]
 public class ResourceConstructorAttribute : Attribute
 {
     /// <summary>

--- a/src/Tests/Moryx.AbstractionLayer.Tests/ResourceConstructorAttributeTests.cs
+++ b/src/Tests/Moryx.AbstractionLayer.Tests/ResourceConstructorAttributeTests.cs
@@ -1,0 +1,24 @@
+// Copyright (c) 2026 Phoenix Contact GmbH & Co. KG
+// Licensed under the Apache License, Version 2.0
+
+using Moryx.AbstractionLayer.Resources;
+using Moryx.AbstractionLayer.Tests.TestData;
+using NUnit.Framework;
+
+namespace Moryx.AbstractionLayer.Tests;
+
+[TestFixture]
+public class ResourceConstructorAttributeTests
+{
+    [Test]
+    public void GetCustomAttribute_OnOverridenResourceConstructorMethod_IsNotInherited()
+    {
+        var method = typeof(SpecificConstructorResource).GetMethod(nameof(SpecificConstructorResource.ConstructGeneralResource));
+        var attribute = method.GetCustomAttributes(typeof(ResourceConstructorAttribute), true);
+
+        Assert.That(attribute, Is.Empty,
+            "ResourceConstructorAttribute must not be derived because a resource constructor can be used in base " +
+            "classes for general resource constructors which however should be hidden in more specific derived " +
+            "classes which in turn could define different resource constructor methods.");
+    }
+}

--- a/src/Tests/Moryx.AbstractionLayer.Tests/TestData/ResourceConstructorTestResources.cs
+++ b/src/Tests/Moryx.AbstractionLayer.Tests/TestData/ResourceConstructorTestResources.cs
@@ -1,0 +1,20 @@
+// Copyright (c) 2026 Phoenix Contact GmbH & Co. KG
+// Licensed under the Apache License, Version 2.0
+
+using Moryx.AbstractionLayer.Resources;
+
+namespace Moryx.AbstractionLayer.Tests.TestData;
+
+internal class GeneralConstructorResource : Resource
+{
+    [ResourceConstructor]
+    public virtual void ConstructGeneralResource() => throw new NotImplementedException();
+}
+
+internal class SpecificConstructorResource : GeneralConstructorResource
+{
+    public override void ConstructGeneralResource() => throw new NotImplementedException();
+
+    [ResourceConstructor]
+    public void ConstructSpecificResource() => throw new NotImplementedException();
+}


### PR DESCRIPTION
### Summary

ResourceConstructorAttribute must not be derived because a resource constructor can be used in base classes for general resource constructors which however should be hidden in more specific derived classes which in turn could define different resource constructor methods.

### Linked Issues

The issue was found while creating the `MaterialContainer` resource definitions in #1368

### Breaking Changes

This is a behaviour change, the question I honestly cannot answer is, whether this was the intentional behaviour or just an overlooked field on the `AttributeUsageAttribute`.

I'd ask @szThunder, @dbeuchler, @aniggemann and @dacky179, could you please tell me wheether there are any known occasions were the `ResourceConstructorAttribute` was used and intentionally inherited to a derived class? If there are, I'll move this as a proposal for MORYX 12.

### Checklist for Submitter

- [x] I have tested these changes locally
- [ ] I have updated documentation as needed
- [x] I have added or updated tests as appropriate
- [x] I have used clear and descriptive commit messages

### Review

**Typical tasks**

- [ ] Merge request is well described
- [ ] Critical sections are *documented in code*
- [ ] *Tests* are extended
- [ ] *Documentation* is created / updated
- [ ] Running in test environment
- [ ] Ports to other maintained versions are created

**Clean code**

- [ ] *All* unused references are removed
- [ ] Clean code rules are respected with passion (naming, ...)
- [ ] Avoid *copy and pasted* code snippets
