### PR TITLE
Fix duplicate module start race-condition

### DIFF
--- a/src/Moryx.Runtime.Kernel/Modules/Components/ModuleLifecycleController.cs
+++ b/src/Moryx.Runtime.Kernel/Modules/Components/ModuleLifecycleController.cs
@@ -14,7 +14,7 @@ internal class ModuleLifecycleController
     private readonly ILogger _logger;
     private readonly ModuleManagerConfig _config;
     private readonly SemaphoreSlim _waitingModulesSemaphore = new(1, 1);
-    private readonly Dictionary<IServerModule, ICollection<IServerModule>> _waitingModules = new();
+    private readonly Dictionary<IServerModule, HashSet<IServerModule>> _waitingModules = new();
 
     public ModuleLifecycleController(IReadOnlyList<IServerModule> availableModules,
         IModuleDependencyManager dependencyManager, ILogger logger, ModuleManagerConfig config)
@@ -142,7 +142,7 @@ internal class ModuleLifecycleController
 
         // Now we start every service waiting on this service to return
         // Extract under semaphore, start outside to avoid re-entrance deadlock
-        ICollection<IServerModule> modulesToStart = null;
+        IServerModule[] modulesToStart = null;
         await _waitingModulesSemaphore.ExecuteAsync(() =>
         {
             if (!_waitingModules.Remove(module, out var candidates))
@@ -155,7 +155,7 @@ internal class ModuleLifecycleController
             // otherwise modules with multiple dependencies can be started multiple times.
             modulesToStart = candidates
                 .Where(m => !_waitingModules.Values.Any(waitingList => waitingList.Contains(m)))
-                .ToList();
+                .ToArray();
         }, cancellationToken);
 
         // To increase boot speed we fork module start if more than one dependent was found
@@ -197,15 +197,12 @@ internal class ModuleLifecycleController
     {
         return _waitingModulesSemaphore.ExecuteAsync(() =>
         {
-            if (_waitingModules.TryGetValue(dependency, out var waitingModules))
+            if (!_waitingModules.TryGetValue(dependency, out var waitingModules))
             {
-                if (!waitingModules.Contains(dependent))
-                    waitingModules.Add(dependent);
+                _waitingModules[dependency] = waitingModules = [];
             }
-            else
-            {
-                _waitingModules[dependency] = new List<IServerModule> { dependent };
-            }
+
+            waitingModules.Add(dependent);
         }, cancellationToken);
     }
 }

--- a/src/Moryx.Runtime.Kernel/Modules/Components/ModuleLifecycleController.cs
+++ b/src/Moryx.Runtime.Kernel/Modules/Components/ModuleLifecycleController.cs
@@ -145,7 +145,17 @@ internal class ModuleLifecycleController
         ICollection<IServerModule> modulesToStart = null;
         await _waitingModulesSemaphore.ExecuteAsync(() =>
         {
-            _waitingModules.Remove(module, out modulesToStart);
+            if (!_waitingModules.Remove(module, out var candidates))
+            {
+                return;
+            }
+
+            // Only start modules that have no remaining unresolved dependencies.
+            // A module still listed as "waiting on another dependency" must not be started yet,
+            // otherwise modules with multiple dependencies can be started multiple times.
+            modulesToStart = candidates
+                .Where(m => !_waitingModules.Values.Any(waitingList => waitingList.Contains(m)))
+                .ToList();
         }, cancellationToken);
 
         // To increase boot speed we fork module start if more than one dependent was found


### PR DESCRIPTION
When a module depends on multiple other modules (e.g. `D` depends on `B` and `C`), each dependency completing removes the waiting module from its own waiting list and calls `StartModule`. If `B`and `C` finish around the same time, both threads pick up `D` and start it. The semaphore only protects dictionary access, not the StartModule call afterwards.

Note there is no Test added because I have NO idea how to test this race-condition. It also occurs not every time depending on the systems-performance. 